### PR TITLE
Exit plan mode before running entire-external-agent skill

### DIFF
--- a/.claude/skills/entire-external-agent/SKILL.md
+++ b/.claude/skills/entire-external-agent/SKILL.md
@@ -9,6 +9,13 @@ description: >
   "external agent plugin", or wants to run the full pipeline end-to-end.
 ---
 
+## Plan Mode Override
+
+If plan mode is active when this skill is invoked, call ExitPlanMode immediately
+before doing anything else. This skill has its own multi-phase procedure
+(Research → Write-Tests → Implement) that IS the plan. Do not wrap it in a
+separate planning workflow — execute the phases directly.
+
 # External Agent Binary — Full Pipeline
 
 Build a standalone external agent binary that implements the Entire CLI's external agent protocol using E2E-first TDD. Parameters are collected once and reused across all phases.


### PR DESCRIPTION
## Summary
- Adds a "Plan Mode Override" section to the `entire-external-agent` skill
- When plan mode is active, the skill now exits it immediately before proceeding, since the skill's own multi-phase procedure (Research → Write-Tests → Implement) serves as the plan
- Prevents the skill from being unnecessarily wrapped in a separate planning workflow

## Test plan
- [x] Invoke `/entire-external-agent` while in plan mode — verify it exits plan mode and runs directly
- [x] Invoke `/entire-external-agent` outside plan mode — verify no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adjusts skill instructions; no runtime code paths are modified.
> 
> **Overview**
> Adds a **Plan Mode Override** section to the `entire-external-agent` skill instructing it to call `ExitPlanMode` immediately if invoked while plan mode is active.
> 
> Clarifies that the skill’s built-in multi-phase workflow (Research → Write-Tests → Implement) should run directly rather than being wrapped in an additional planning step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d50bdbc88c77fd0620b228b6e9adbec280525130. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->