### PR TITLE
feat: add Mistral Vibe external agent plugin

### DIFF
--- a/agents/entire-agent-mistral-vibe/AGENT.md
+++ b/agents/entire-agent-mistral-vibe/AGENT.md
@@ -1,8 +1,8 @@
 # Mistral Vibe — External Agent Research
 
-## Verdict: PARTIAL
+## Verdict: COMPATIBLE
 
-Mistral Vibe has excellent session management and parseable transcripts, but **no native hook/lifecycle system**. The external agent binary can implement session reading, transcript analysis, and detection, but cannot do real-time lifecycle event tracking via hooks. The Entire CLI will need to poll for session changes rather than receiving push notifications.
+Mistral Vibe has excellent session management, parseable transcripts, and a **full lifecycle hook system** added in the `lifecycle-hooks` branch. The external agent binary can implement all required protocol subcommands including real-time lifecycle event tracking via hooks.
 
 ## Static Checks
 | Check | Result | Notes |
@@ -10,7 +10,7 @@ Mistral Vibe has excellent session management and parseable transcripts, but **n
 | Binary present | PASS | `/Users/alisha/.local/bin/vibe` (Python script via uv) |
 | Help available | PASS | Rich argparse help with all commands |
 | Version info | PASS | `vibe 2.6.2` |
-| Hook keywords | FAIL | No hook, lifecycle, callback, or event keywords in help |
+| Hook keywords | PASS (verified) | `HookManager`, `HooksConfig`, `emit_session_start`, `emit_turn_end` in source |
 | Session keywords | PASS | `--resume`, `--continue`, `session` in help |
 | Config directory | PASS | `~/.vibe/` with `config.toml`, `logs/`, `trusted_folders.toml` |
 | Documentation | PASS | https://docs.mistral.ai/mistral-vibe/introduction |
@@ -24,15 +24,47 @@ Mistral Vibe has excellent session management and parseable transcripts, but **n
 - Requires: `MISTRAL_API_KEY` environment variable
 
 ## Hook Mechanism
-- **Not available.** Mistral Vibe has no native hook/lifecycle system.
-- The internal middleware system (`MiddlewarePipeline` with `before_turn` callbacks) is Python-level only and not configurable via external commands or config files.
-- There is no `.vibe/hooks/` directory, no hook registration config, and no CLI commands for hooks.
-- The agent supports custom "agents" (`.vibe/agents/NAME.toml`) but these are prompt profiles, not lifecycle hooks.
+- Config file: `.vibe/config.toml` (project-level) or `~/.vibe/config.toml` (global)
+- Config format: TOML
+- Hook registration: Array of tables under `[hooks]` section, each with a `command` field
+- Config example:
+  ```toml
+  [[hooks.session_start]]
+  command = "entire hooks mistral-vibe session-start"
+
+  [[hooks.user_prompt_submit]]
+  command = "entire hooks mistral-vibe user-prompt-submit"
+
+  [[hooks.pre_tool_use]]
+  command = "entire hooks mistral-vibe pre-tool-use"
+
+  [[hooks.post_tool_use]]
+  command = "entire hooks mistral-vibe post-tool-use"
+
+  [[hooks.turn_end]]
+  command = "entire hooks mistral-vibe turn-end"
+  ```
+- Hook names and protocol mapping (verified):
+  | Native Hook Name | When It Fires | Protocol Event Type |
+  |-----------------|---------------|---------------------|
+  | `session_start` | First call to `act()` in AgentLoop | 1 = SessionStart |
+  | `user_prompt_submit` | Each prompt submitted to `act()` | 2 = TurnStart |
+  | `pre_tool_use` | Before tool execution | nil (no event emitted) |
+  | `post_tool_use` | After tool execution | nil (captures tool calls) |
+  | `turn_end` | End of `act()` turn, after `_save_messages()` | 3 = TurnEnd |
+- Hook input format (verified): JSON on stdin with these fields:
+  - All events: `hook_event_name`, `cwd`, `session_id`
+  - `user_prompt_submit`: adds `prompt` (string)
+  - `pre_tool_use`: adds `tool_name` (string), `tool_input` (object)
+  - `post_tool_use`: adds `tool_name`, `tool_input`, `tool_outcome` ("success"/"failed"/"cancelled"/"skipped"), `tool_response` (object|null), `tool_error` (string|null)
+- Hook execution: async subprocess via `asyncio.create_subprocess_shell`, non-blocking, 30s timeout, stderr logged
+- Drain: `HookManager.drain()` called at turn end to await all pending hook tasks
+- Note: Vibe does NOT have a dedicated "session_end" or "stop" hook. The `turn_end` hook fires at the end of each turn, not at session teardown.
 
 ## Session Management
 - Session directory: `~/.vibe/logs/session/` (configurable via `session_logging.save_dir` in config)
-- Session ID source: UUID generated at session start (e.g., `a1b2c3d4-e5f6-7890-abcd-ef1234567890`)
-- Session folder naming: `session_YYYYMMDD_HHMMSS_<first-8-chars-of-session-id>`
+- Session ID source: UUID generated at session start (e.g., `0e9f7293-0151-4178-ba58-2c48c5abb8df`) (verified)
+- Session folder naming: `session_YYYYMMDD_HHMMSS_<first-8-chars-of-session-id>` (verified)
 - Session file format: Directory containing:
   - `meta.json` — Session metadata (session_id, start_time, end_time, git info, stats, tools, config)
   - `messages.jsonl` — Full conversation transcript (one JSON object per line)
@@ -42,11 +74,12 @@ Mistral Vibe has excellent session management and parseable transcripts, but **n
 ## Transcript
 - Location: `~/.vibe/logs/session/session_*_<id>/messages.jsonl`
 - Format: JSONL (newline-delimited JSON)
-- Each line is an `LLMMessage` object:
+- Each line is an `LLMMessage` object (verified):
   ```json
-  {"role": "user", "content": "Fix the login bug", "message_id": "uuid"}
-  {"role": "assistant", "content": "I'll fix that.", "tool_calls": [...], "message_id": "uuid"}
-  {"role": "tool", "content": "File written", "tool_call_id": "call_id", "name": "write_file"}
+  {"role": "user", "content": "can you create hello world golang", "message_id": "5bf535d7-cb5c-45f6-8872-3ba26703475a"}
+  {"role": "assistant", "tool_calls": [{"id": "g4WVM7SD2", "index": 0, "function": {"name": "write_file", "arguments": "{...}"}, "type": "function"}], "message_id": "61dec2f6-920a-4c66-9b67-a92dbff14fb5"}
+  {"role": "tool", "content": "path: /path/to/file\nbytes_written: 73\n...", "name": "write_file", "tool_call_id": "g4WVM7SD2"}
+  {"role": "assistant", "content": "Created `hello.go`:\n...", "message_id": "3cac263a-e70d-4cf9-b765-170f4d54a830"}
   ```
 - User prompt field: `.content` where `.role == "user"`
 - Modified files field: Extracted from `.tool_calls[].function.arguments` where tool name is `write_file`, `search_replace`, or `bash`
@@ -54,30 +87,31 @@ Mistral Vibe has excellent session management and parseable transcripts, but **n
 - Tool calls: Stored in assistant messages as `tool_calls` array with `function.name` and `function.arguments`
 
 ## Data Storage Verification
-- Session files contain actual assistant content: YES — full LLM responses stored in messages.jsonl
+- Session files contain actual assistant content: YES — full LLM responses stored in messages.jsonl (verified)
 - Secondary storage location: None needed — messages.jsonl contains complete conversation
 - Cross-reference key: Session ID (first 8 chars) in folder name
-- Hook data flow verified: N/A — no hooks
-- Verification method: Read messages.jsonl directly, grep for known response text
+- Hook data flow verified: YES — stdin JSON payloads confirmed via `/tmp/vibe-hooks/` captures
+- Hook payloads include: session_id, cwd, prompt, tool_name, tool_input, tool_outcome, tool_response, tool_error
+- Verification method: hook-logger.py script in test repo, captures at `/tmp/vibe-hooks/all-events.jsonl`
 
 ## Protocol Mapping
 | Subcommand | Native Concept | Implementation Notes | Feasibility |
 |-----------|---------------|---------------------|-------------|
 | `info` | — | Static metadata, always implementable | Required |
 | `detect` | `~/.vibe/` dir, `vibe` binary | Check for binary in PATH or config dir | Required |
-| `get-session-id` | UUID from HookInput | Extract from hook input JSON (passed by CLI) | Required |
+| `get-session-id` | `session_id` from hook stdin JSON | Extract from hook input JSON `session_id` field | Required |
 | `get-session-dir` | `~/.vibe/logs/session/` | Return session log directory | Required |
-| `resolve-session-file` | `session_*_<id>/messages.jsonl` | Glob for matching session folder | Required |
+| `resolve-session-file` | `session_*_<id>/messages.jsonl` | Glob for matching session folder by first 8 chars of ID | Required |
 | `read-session` | `meta.json` + `messages.jsonl` | Parse session metadata and files | Required |
 | `write-session` | Write to session dir | Create/update session files | Required |
 | `read-transcript` | `messages.jsonl` | Read raw JSONL bytes | Required |
 | `chunk-transcript` | Base64 chunking | Language-generic byte chunking | Required |
 | `reassemble-transcript` | Base64 reassembly | Language-generic byte reassembly | Required |
 | `format-resume-command` | `vibe --resume <id>` | Format resume command string | Required |
-| `parse-hook` | **N/A** | No native hooks — capability disabled | Not feasible |
-| `install-hooks` | **N/A** | No hook config format to write | Not feasible |
-| `uninstall-hooks` | **N/A** | No hooks to remove | Not feasible |
-| `are-hooks-installed` | **N/A** | Always false | Not feasible |
+| `parse-hook` | Hook stdin JSON (verified) | Map `hook_event_name` → protocol event type. `session_start`→1, `user_prompt_submit`→2, `turn_end`→3 | Required (hooks capable) |
+| `install-hooks` | `.vibe/config.toml` `[hooks]` section | Write TOML hook entries pointing to `entire hooks mistral-vibe <event>` | Required (hooks capable) |
+| `uninstall-hooks` | Remove `[hooks]` entries | Remove Entire-owned hook entries from config | Required (hooks capable) |
+| `are-hooks-installed` | Check config for hook commands | Grep config.toml for `entire hooks mistral-vibe` | Required (hooks capable) |
 | `get-transcript-position` | File size of messages.jsonl | `os.Stat().Size()` | Feasible |
 | `extract-modified-files` | Parse JSONL tool calls | Scan for write_file/search_replace/bash tool calls | Feasible |
 | `extract-prompts` | Parse JSONL user messages | Filter `.role == "user"` entries | Feasible |
@@ -86,26 +120,35 @@ Mistral Vibe has excellent session management and parseable transcripts, but **n
 ## Selected Capabilities
 | Capability | Declared | Justification |
 |-----------|----------|---------------|
-| hooks | false | No native hook mechanism — Vibe has no way to register external lifecycle callbacks |
+| hooks | true | Full lifecycle hook system: session_start, user_prompt_submit, pre_tool_use, post_tool_use, turn_end (verified) |
 | transcript_analyzer | true | messages.jsonl is structured JSONL with full tool calls and user messages |
 | transcript_preparer | false | JSONL is already in a directly parseable format |
-| token_calculator | true | Token usage is available in messages.jsonl assistant entries and meta.json stats |
+| token_calculator | true | Token usage is available in meta.json stats |
 | text_generator | false | Would require API key management — out of scope |
-| hook_response_writer | false | No hooks to respond to |
+| hook_response_writer | false | Hooks are fire-and-forget, no response mechanism |
 | subagent_aware_extractor | false | Vibe does not spawn subagents with separate transcripts |
 
 ## Gaps & Limitations
-- **No lifecycle hooks**: The biggest limitation. Without hooks, the Entire CLI cannot receive real-time session start/end/prompt events. Integration is limited to on-demand session reading and transcript analysis.
+- **No session_end hook**: Vibe has `turn_end` but no dedicated session teardown hook. The `turn_end` at the last turn effectively serves as session end.
+- **No stop hook**: Unlike Kiro's `stop` hook, Vibe fires `turn_end`. The external agent maps `turn_end` → TurnEnd (protocol event type 3).
 - **Session discovery requires glob**: Session folders use timestamps in names, so finding a session by ID requires globbing `session_*_<id-prefix>`.
-- **No conversation ID in HookInput**: Since Vibe has no hooks, the session ID must be derived from the session folder name or meta.json.
+- **Hook config is in main config.toml**: Unlike Kiro which has separate hook files, Vibe hooks are in `.vibe/config.toml` `[hooks]` section. The install-hooks subcommand must read/modify TOML.
 - **Python-only**: Vibe is a Python tool — the external agent binary (Go) interacts with it only through filesystem and CLI.
-- **Token usage**: Available per-session in meta.json but not per-message in the JSONL. Token calculation requires reading the metadata file.
+- **Token usage**: Available per-session in meta.json but not per-message in the JSONL.
+- **tool_outcome field**: post_tool_use includes `tool_outcome` ("success"/"failed"/"cancelled"/"skipped") which is not present in all agents — useful for accurate tracking.
 
 ## Captured Payloads
 - Verification script: `agents/entire-agent-mistral-vibe/scripts/verify-mistral-vibe.sh`
-- Capture directory: N/A (no hooks to capture)
-- Verification status: VERIFIED (session storage confirmed via source code analysis)
-- Notable differences from docs: Vibe's internal session format matches source code exactly. No hooks documentation exists because there are no hooks.
+- Hook logger: `/Users/alisha/Projects/test-repos/vibe-hooks-test/.vibe/hook-logger.py`
+- Capture directory: `/tmp/vibe-hooks/`
+- Verification status: VERIFIED (hook payloads captured from real Vibe session)
+- Verified payloads:
+  - `session_start`: `{"hook_event_name":"session_start","cwd":"/Users/alisha/Projects/test-repos/vibe-hooks-test","session_id":"0e9f7293-0151-4178-ba58-2c48c5abb8df"}`
+  - `user_prompt_submit`: adds `"prompt":"hello"`
+  - `pre_tool_use`: adds `"tool_name":"write_file","tool_input":{...}`
+  - `post_tool_use`: adds `"tool_name":"write_file","tool_input":{...},"tool_outcome":"success","tool_response":{...},"tool_error":null`
+  - `turn_end`: same base fields as session_start
+- Notable: `session_start` and `user_prompt_submit` may fire out of order (both fire on first prompt, async)
 
 ## E2E Test Prerequisites
 - Entire CLI binary: `entire` from PATH or `E2E_ENTIRE_BIN` env (found at `/opt/homebrew/bin/entire`)

--- a/agents/entire-agent-mistral-vibe/AGENT.md
+++ b/agents/entire-agent-mistral-vibe/AGENT.md
@@ -1,0 +1,118 @@
+# Mistral Vibe — External Agent Research
+
+## Verdict: PARTIAL
+
+Mistral Vibe has excellent session management and parseable transcripts, but **no native hook/lifecycle system**. The external agent binary can implement session reading, transcript analysis, and detection, but cannot do real-time lifecycle event tracking via hooks. The Entire CLI will need to poll for session changes rather than receiving push notifications.
+
+## Static Checks
+| Check | Result | Notes |
+|-------|--------|-------|
+| Binary present | PASS | `/Users/alisha/.local/bin/vibe` (Python script via uv) |
+| Help available | PASS | Rich argparse help with all commands |
+| Version info | PASS | `vibe 2.6.2` |
+| Hook keywords | FAIL | No hook, lifecycle, callback, or event keywords in help |
+| Session keywords | PASS | `--resume`, `--continue`, `session` in help |
+| Config directory | PASS | `~/.vibe/` with `config.toml`, `logs/`, `trusted_folders.toml` |
+| Documentation | PASS | https://docs.mistral.ai/mistral-vibe/introduction |
+
+## Binary
+- Name: `vibe`
+- Version: 2.6.2
+- Install: `uv tool install mistral-vibe` or `pip install mistral-vibe`
+- Location: `~/.local/bin/vibe` (uv-managed Python script)
+- Package: `mistral-vibe` on PyPI
+- Requires: `MISTRAL_API_KEY` environment variable
+
+## Hook Mechanism
+- **Not available.** Mistral Vibe has no native hook/lifecycle system.
+- The internal middleware system (`MiddlewarePipeline` with `before_turn` callbacks) is Python-level only and not configurable via external commands or config files.
+- There is no `.vibe/hooks/` directory, no hook registration config, and no CLI commands for hooks.
+- The agent supports custom "agents" (`.vibe/agents/NAME.toml`) but these are prompt profiles, not lifecycle hooks.
+
+## Session Management
+- Session directory: `~/.vibe/logs/session/` (configurable via `session_logging.save_dir` in config)
+- Session ID source: UUID generated at session start (e.g., `a1b2c3d4-e5f6-7890-abcd-ef1234567890`)
+- Session folder naming: `session_YYYYMMDD_HHMMSS_<first-8-chars-of-session-id>`
+- Session file format: Directory containing:
+  - `meta.json` — Session metadata (session_id, start_time, end_time, git info, stats, tools, config)
+  - `messages.jsonl` — Full conversation transcript (one JSON object per line)
+- Session prefix: Configurable via `session_logging.session_prefix` (default: `"session"`)
+- Resume command: `vibe --resume <SESSION_ID>` or `vibe -c` (most recent)
+
+## Transcript
+- Location: `~/.vibe/logs/session/session_*_<id>/messages.jsonl`
+- Format: JSONL (newline-delimited JSON)
+- Each line is an `LLMMessage` object:
+  ```json
+  {"role": "user", "content": "Fix the login bug", "message_id": "uuid"}
+  {"role": "assistant", "content": "I'll fix that.", "tool_calls": [...], "message_id": "uuid"}
+  {"role": "tool", "content": "File written", "tool_call_id": "call_id", "name": "write_file"}
+  ```
+- User prompt field: `.content` where `.role == "user"`
+- Modified files field: Extracted from `.tool_calls[].function.arguments` where tool name is `write_file`, `search_replace`, or `bash`
+- Token usage: Available in `meta.json` under `stats.session_prompt_tokens` and `stats.session_completion_tokens`
+- Tool calls: Stored in assistant messages as `tool_calls` array with `function.name` and `function.arguments`
+
+## Data Storage Verification
+- Session files contain actual assistant content: YES — full LLM responses stored in messages.jsonl
+- Secondary storage location: None needed — messages.jsonl contains complete conversation
+- Cross-reference key: Session ID (first 8 chars) in folder name
+- Hook data flow verified: N/A — no hooks
+- Verification method: Read messages.jsonl directly, grep for known response text
+
+## Protocol Mapping
+| Subcommand | Native Concept | Implementation Notes | Feasibility |
+|-----------|---------------|---------------------|-------------|
+| `info` | — | Static metadata, always implementable | Required |
+| `detect` | `~/.vibe/` dir, `vibe` binary | Check for binary in PATH or config dir | Required |
+| `get-session-id` | UUID from HookInput | Extract from hook input JSON (passed by CLI) | Required |
+| `get-session-dir` | `~/.vibe/logs/session/` | Return session log directory | Required |
+| `resolve-session-file` | `session_*_<id>/messages.jsonl` | Glob for matching session folder | Required |
+| `read-session` | `meta.json` + `messages.jsonl` | Parse session metadata and files | Required |
+| `write-session` | Write to session dir | Create/update session files | Required |
+| `read-transcript` | `messages.jsonl` | Read raw JSONL bytes | Required |
+| `chunk-transcript` | Base64 chunking | Language-generic byte chunking | Required |
+| `reassemble-transcript` | Base64 reassembly | Language-generic byte reassembly | Required |
+| `format-resume-command` | `vibe --resume <id>` | Format resume command string | Required |
+| `parse-hook` | **N/A** | No native hooks — capability disabled | Not feasible |
+| `install-hooks` | **N/A** | No hook config format to write | Not feasible |
+| `uninstall-hooks` | **N/A** | No hooks to remove | Not feasible |
+| `are-hooks-installed` | **N/A** | Always false | Not feasible |
+| `get-transcript-position` | File size of messages.jsonl | `os.Stat().Size()` | Feasible |
+| `extract-modified-files` | Parse JSONL tool calls | Scan for write_file/search_replace/bash tool calls | Feasible |
+| `extract-prompts` | Parse JSONL user messages | Filter `.role == "user"` entries | Feasible |
+| `extract-summary` | Last assistant message | Return last assistant content block | Feasible |
+
+## Selected Capabilities
+| Capability | Declared | Justification |
+|-----------|----------|---------------|
+| hooks | false | No native hook mechanism — Vibe has no way to register external lifecycle callbacks |
+| transcript_analyzer | true | messages.jsonl is structured JSONL with full tool calls and user messages |
+| transcript_preparer | false | JSONL is already in a directly parseable format |
+| token_calculator | true | Token usage is available in messages.jsonl assistant entries and meta.json stats |
+| text_generator | false | Would require API key management — out of scope |
+| hook_response_writer | false | No hooks to respond to |
+| subagent_aware_extractor | false | Vibe does not spawn subagents with separate transcripts |
+
+## Gaps & Limitations
+- **No lifecycle hooks**: The biggest limitation. Without hooks, the Entire CLI cannot receive real-time session start/end/prompt events. Integration is limited to on-demand session reading and transcript analysis.
+- **Session discovery requires glob**: Session folders use timestamps in names, so finding a session by ID requires globbing `session_*_<id-prefix>`.
+- **No conversation ID in HookInput**: Since Vibe has no hooks, the session ID must be derived from the session folder name or meta.json.
+- **Python-only**: Vibe is a Python tool — the external agent binary (Go) interacts with it only through filesystem and CLI.
+- **Token usage**: Available per-session in meta.json but not per-message in the JSONL. Token calculation requires reading the metadata file.
+
+## Captured Payloads
+- Verification script: `agents/entire-agent-mistral-vibe/scripts/verify-mistral-vibe.sh`
+- Capture directory: N/A (no hooks to capture)
+- Verification status: VERIFIED (session storage confirmed via source code analysis)
+- Notable differences from docs: Vibe's internal session format matches source code exactly. No hooks documentation exists because there are no hooks.
+
+## E2E Test Prerequisites
+- Entire CLI binary: `entire` from PATH or `E2E_ENTIRE_BIN` env (found at `/opt/homebrew/bin/entire`)
+- Agent CLI binary: `vibe` at `~/.local/bin/vibe`
+- Non-interactive prompt command: `vibe -p "prompt text" --output json --workdir <dir>`
+- Interactive mode: `vibe` (launches Textual TUI) — not suitable for automated E2E tests
+- Expected prompt pattern: N/A (programmatic mode exits after completion, no interactive prompt)
+- Timeout multiplier: 2.0 (API calls to Mistral can be slow)
+- Bootstrap steps: Requires `MISTRAL_API_KEY` environment variable
+- Transient error patterns: `"Rate limits exceeded"`, `"overloaded"`, `"429"`, `"Too Many Requests"`, `"BackendError"`, `"timeout"`

--- a/agents/entire-agent-mistral-vibe/HOOKS-IMPLEMENTATION-SPEC.md
+++ b/agents/entire-agent-mistral-vibe/HOOKS-IMPLEMENTATION-SPEC.md
@@ -1,0 +1,488 @@
+# Mistral Vibe — Lifecycle Hooks Implementation Spec
+
+This document contains everything needed to add lifecycle hooks to Mistral Vibe so it integrates with the Entire CLI external agent protocol.
+
+## Goal
+
+Add a configurable lifecycle hook system to Mistral Vibe that:
+1. Fires shell commands at key lifecycle events (session start, prompt submit, tool use, session end)
+2. Passes structured JSON on stdin to hook commands
+3. Is configured via `.vibe/hooks.toml` (project-level) or `~/.vibe/hooks.toml` (global)
+4. Works with both interactive (TUI) and programmatic (`-p`) modes
+
+## Vibe Source Code Location
+
+The Vibe package is installed at:
+```
+~/.local/share/uv/tools/mistral-vibe/lib/python3.13/site-packages/vibe/
+```
+
+The upstream repo is `mistralai/mistral-vibe` (open source).
+
+## Current Architecture — Where Hooks Fit
+
+### Agent Loop (`vibe/core/agent_loop.py`)
+
+This is the core event loop. Key methods where hooks should fire:
+
+| Lifecycle Event | Where in Code | When It Fires |
+|----------------|---------------|---------------|
+| **session_start** | `AgentLoop.__init__()` or first call to `act()` | Session begins |
+| **user_prompt_submit** | `AgentLoop.act(prompt)` entry point | User submits a prompt |
+| **pre_tool_use** | Before `_execute_tool_call()` runs a tool | About to execute a tool |
+| **post_tool_use** | After `_execute_tool_call()` returns | Tool execution complete |
+| **stop** | End of `act()` generator / session teardown | Agent done responding |
+
+### Key Classes
+
+- **`AgentLoop`** (`vibe/core/agent_loop.py`) — Main loop, lines ~150+. Has `act(prompt)` async generator that yields events. This is where most hooks fire.
+- **`SessionLogger`** (`vibe/core/session/session_logger.py`) — Manages session persistence. Has `session_id`, `session_dir`, `messages_filepath`.
+- **`VibeConfig`** (`vibe/core/config/_settings.py`) — Pydantic settings loaded from TOML. Hook config goes here.
+- **`MiddlewarePipeline`** (`vibe/core/middleware.py`) — Existing before-turn pipeline. Hooks could be implemented as middleware or as a separate system.
+
+### Session Management (already exists)
+
+Sessions are stored at `~/.vibe/logs/session/session_YYYYMMDD_HHMMSS_<id>/`:
+- `meta.json` — Session metadata (session_id, start_time, end_time, git info, stats)
+- `messages.jsonl` — Full conversation (one JSON line per message)
+
+The session ID is a UUID generated in `SessionLogger.__init__()`.
+
+### Config System
+
+Vibe uses TOML config files:
+- Global: `~/.vibe/config.toml`
+- Project: `.vibe/config.toml` (in trusted folders)
+- Loaded via Pydantic Settings in `VibeConfig` class
+
+The harness file manager at `vibe/core/config/harness_files/_harness_manager.py` handles config discovery.
+
+## Hook System Design
+
+### Hook Configuration Format
+
+Add to `.vibe/hooks.toml` (or as a `[hooks]` section in `config.toml`):
+
+```toml
+# .vibe/hooks.toml — project-level hook configuration
+
+[hooks.session_start]
+command = "entire hooks mistral-vibe session-start"
+
+[hooks.user_prompt_submit]
+command = "entire hooks mistral-vibe user-prompt-submit"
+
+[hooks.pre_tool_use]
+command = "entire hooks mistral-vibe pre-tool-use"
+
+[hooks.post_tool_use]
+command = "entire hooks mistral-vibe post-tool-use"
+
+[hooks.stop]
+command = "entire hooks mistral-vibe stop"
+```
+
+Each hook entry has:
+- `command` (required): Shell command to execute
+- Multiple commands per event should be supported (list of tables)
+
+### Hook Payload Format (JSON on stdin)
+
+Every hook command receives a JSON object on stdin. The format must match what the Entire CLI external agent binary expects to parse.
+
+#### session_start
+```json
+{
+  "hook_event_name": "session_start",
+  "cwd": "/path/to/repo",
+  "session_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+}
+```
+
+#### user_prompt_submit
+```json
+{
+  "hook_event_name": "user_prompt_submit",
+  "cwd": "/path/to/repo",
+  "session_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "prompt": "Fix the login bug"
+}
+```
+
+#### pre_tool_use
+```json
+{
+  "hook_event_name": "pre_tool_use",
+  "cwd": "/path/to/repo",
+  "session_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "tool_name": "write_file",
+  "tool_input": {"file_path": "/src/main.py", "content": "..."}
+}
+```
+
+#### post_tool_use
+```json
+{
+  "hook_event_name": "post_tool_use",
+  "cwd": "/path/to/repo",
+  "session_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "tool_name": "write_file",
+  "tool_input": {"file_path": "/src/main.py", "content": "..."},
+  "tool_response": {"result": "File written successfully"}
+}
+```
+
+#### stop
+```json
+{
+  "hook_event_name": "stop",
+  "cwd": "/path/to/repo",
+  "session_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+}
+```
+
+### Hook Execution Requirements
+
+1. **Non-blocking**: Hook commands must be fired asynchronously (subprocess, fire-and-forget). They must NOT block the agent loop or slow down the user experience.
+2. **stdin pipe**: Pass the JSON payload via stdin to the subprocess.
+3. **No stdout capture needed**: Hook commands write their own outputs; Vibe doesn't need to read them.
+4. **stderr logging**: Log any stderr from hook commands to Vibe's log file (`~/.vibe/logs/vibe.log`) for debugging.
+5. **Timeout**: Kill hook subprocesses that haven't exited after 30 seconds.
+6. **Error isolation**: A failing hook must never crash Vibe. Catch all exceptions, log them, continue.
+7. **Environment variables**: Set `ENTIRE_REPO_ROOT` to the git repo root (if in a git repo) for hook commands.
+
+## Implementation Plan
+
+### Step 1: Add Hook Config Model
+
+In `vibe/core/config/_settings.py`, add:
+
+```python
+class HookEntry(BaseModel):
+    command: str
+
+class HooksConfig(BaseModel):
+    session_start: list[HookEntry] = Field(default_factory=list)
+    user_prompt_submit: list[HookEntry] = Field(default_factory=list)
+    pre_tool_use: list[HookEntry] = Field(default_factory=list)
+    post_tool_use: list[HookEntry] = Field(default_factory=list)
+    stop: list[HookEntry] = Field(default_factory=list)
+```
+
+Add `hooks: HooksConfig = Field(default_factory=HooksConfig)` to `VibeConfig`.
+
+### Step 2: Create Hook Manager
+
+Create `vibe/core/hooks.py`:
+
+```python
+"""Lifecycle hook manager for Vibe.
+
+Fires shell commands at key lifecycle events, passing structured JSON on stdin.
+Hook commands run asynchronously and never block the agent loop.
+"""
+import asyncio
+import json
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+HOOK_TIMEOUT_SECONDS = 30
+
+
+class HookManager:
+    def __init__(self, config: "HooksConfig", session_id: str, cwd: str) -> None:
+        self._config = config
+        self._session_id = session_id
+        self._cwd = cwd
+        self._env = self._build_env()
+        self._tasks: list[asyncio.Task] = []
+
+    def _build_env(self) -> dict[str, str]:
+        env = dict(os.environ)
+        # Try to find git repo root
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True, text=True, timeout=5, cwd=self._cwd
+            )
+            if result.returncode == 0:
+                env["ENTIRE_REPO_ROOT"] = result.stdout.strip()
+        except Exception:
+            pass
+        return env
+
+    def _base_payload(self, event_name: str) -> dict[str, Any]:
+        return {
+            "hook_event_name": event_name,
+            "cwd": self._cwd,
+            "session_id": self._session_id,
+        }
+
+    async def _fire(self, event_name: str, extra: dict[str, Any] | None = None) -> None:
+        hooks = getattr(self._config, event_name, [])
+        if not hooks:
+            return
+        payload = self._base_payload(event_name)
+        if extra:
+            payload.update(extra)
+        payload_bytes = json.dumps(payload).encode()
+
+        for hook in hooks:
+            task = asyncio.create_task(self._run_hook(hook.command, payload_bytes))
+            self._tasks.append(task)
+
+    async def _run_hook(self, command: str, payload: bytes) -> None:
+        try:
+            proc = await asyncio.create_subprocess_shell(
+                command,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
+                env=self._env,
+                cwd=self._cwd,
+            )
+            try:
+                _, stderr = await asyncio.wait_for(
+                    proc.communicate(input=payload),
+                    timeout=HOOK_TIMEOUT_SECONDS,
+                )
+                if stderr:
+                    logger.debug("Hook %r stderr: %s", command, stderr.decode(errors="replace"))
+                if proc.returncode != 0:
+                    logger.warning("Hook %r exited with code %d", command, proc.returncode)
+            except asyncio.TimeoutError:
+                proc.kill()
+                logger.warning("Hook %r timed out after %ds, killed", command, HOOK_TIMEOUT_SECONDS)
+        except Exception:
+            logger.exception("Failed to run hook %r", command)
+
+    # --- Public API ---
+
+    async def fire_session_start(self) -> None:
+        await self._fire("session_start")
+
+    async def fire_user_prompt_submit(self, prompt: str) -> None:
+        await self._fire("user_prompt_submit", {"prompt": prompt})
+
+    async def fire_pre_tool_use(self, tool_name: str, tool_input: Any) -> None:
+        await self._fire("pre_tool_use", {"tool_name": tool_name, "tool_input": tool_input})
+
+    async def fire_post_tool_use(self, tool_name: str, tool_input: Any, tool_response: Any) -> None:
+        await self._fire("post_tool_use", {
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+            "tool_response": tool_response,
+        })
+
+    async def fire_stop(self) -> None:
+        await self._fire("stop")
+        # Wait for all pending hooks to complete before session teardown
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+            self._tasks.clear()
+```
+
+### Step 3: Integrate into AgentLoop
+
+In `vibe/core/agent_loop.py`, add hook firing at each lifecycle point:
+
+1. **Constructor / session init**: Create `HookManager` with session config, session ID from `SessionLogger`, and cwd.
+
+2. **`act()` method entry**: Fire `session_start` on first invocation, `user_prompt_submit` on each prompt.
+
+3. **Tool execution**: Fire `pre_tool_use` before and `post_tool_use` after each tool call.
+
+4. **Session end**: Fire `stop` when the agent loop completes or is interrupted.
+
+Key integration points in the existing code:
+
+```python
+# In AgentLoop.__init__() — after SessionLogger is created:
+from vibe.core.hooks import HookManager
+self._hook_manager = HookManager(
+    config=config.hooks,
+    session_id=self.session_logger.session_id,
+    cwd=str(Path.cwd()),
+)
+self._session_started = False
+
+# In AgentLoop.act() — at the top, before processing:
+if not self._session_started:
+    await self._hook_manager.fire_session_start()
+    self._session_started = True
+await self._hook_manager.fire_user_prompt_submit(prompt)
+
+# In tool execution (wherever _execute_tool_call or equivalent runs):
+await self._hook_manager.fire_pre_tool_use(tool_name, tool_input_dict)
+# ... execute tool ...
+await self._hook_manager.fire_post_tool_use(tool_name, tool_input_dict, tool_result_dict)
+
+# At session end (finally block or cleanup):
+await self._hook_manager.fire_stop()
+```
+
+### Step 4: Add Hook Installation CLI Support (Optional)
+
+For the external agent binary to call `install-hooks`, Vibe needs a way to programmatically write hook config. This can be done by writing to `.vibe/hooks.toml` directly from the Go binary — Vibe just needs to read the file on startup.
+
+The external agent binary (`entire-agent-mistral-vibe`) handles `install-hooks` by writing the TOML file.
+
+## Reference: How Kiro Implements Hooks
+
+Kiro's hook system is a useful reference. Key files:
+
+### Hook Types (from `agents/entire-agent-kiro/internal/kiro/types.go`)
+```go
+const (
+    HookNameAgentSpawn       = "agent-spawn"        // → protocol EventType 1 (SessionStart)
+    HookNameUserPromptSubmit = "user-prompt-submit"  // → protocol EventType 2 (TurnStart)
+    HookNamePreToolUse       = "pre-tool-use"        // → nil (no event emitted)
+    HookNamePostToolUse      = "post-tool-use"       // → nil (captures tool calls)
+    HookNameStop             = "stop"                // → protocol EventType 3 (TurnEnd)
+)
+```
+
+### Hook Input Format (what Kiro sends to hooks via stdin)
+```go
+type hookInputRaw struct {
+    HookEventName string          `json:"hook_event_name"`
+    CWD           string          `json:"cwd"`
+    Prompt        string          `json:"prompt,omitempty"`
+    ToolName      string          `json:"tool_name,omitempty"`
+    ToolInput     json.RawMessage `json:"tool_input,omitempty"`
+    ToolResponse  json.RawMessage `json:"tool_response,omitempty"`
+}
+```
+
+### Hook Installation (from `agents/entire-agent-kiro/internal/kiro/hooks.go`)
+
+Kiro writes hooks as JSON config files that the IDE reads:
+- CLI hooks: `.kiro/agents/entire.json` — commands like `entire hooks kiro stop`
+- IDE hooks: `.kiro/hooks/entire-stop.kiro.hook` — trigger type + command
+
+For Vibe, the equivalent is writing `.vibe/hooks.toml` with commands like:
+```toml
+[[hooks.stop]]
+command = "entire hooks mistral-vibe stop"
+```
+
+### Hook Parsing (from `agents/entire-agent-kiro/internal/kiro/hooks.go`)
+
+The `ParseHook()` method maps native hook events to protocol event types:
+- `agent-spawn` → EventType 1 (SessionStart) — generates session ID
+- `user-prompt-submit` → EventType 2 (TurnStart) — includes user prompt
+- `pre-tool-use` → nil (skipped)
+- `post-tool-use` → nil (but captures tool calls for transcript enrichment)
+- `stop` → EventType 3 (TurnEnd) — captures transcript, includes session_ref
+
+## Entire CLI External Agent Protocol — Event Types
+
+The protocol event types that hooks map to:
+
+| Value | Name | Description |
+|-------|------|-------------|
+| 1 | SessionStart | Agent session has begun |
+| 2 | TurnStart | User submitted a prompt |
+| 3 | TurnEnd | Agent finished responding |
+| 4 | Compaction | Context window compression |
+| 5 | SessionEnd | Session terminated |
+| 6 | SubagentStart | Subagent spawned |
+| 7 | SubagentEnd | Subagent completed |
+
+### Protocol Event JSON (what the external agent binary returns)
+```json
+{
+  "type": 3,
+  "session_id": "abc123",
+  "session_ref": "/path/to/messages.jsonl",
+  "prompt": "Fix the login bug",
+  "timestamp": "2026-01-13T12:00:00Z"
+}
+```
+
+## Vibe Source Files to Modify
+
+| File | Change |
+|------|--------|
+| `vibe/core/config/_settings.py` | Add `HookEntry`, `HooksConfig` models; add `hooks` field to `VibeConfig` |
+| `vibe/core/hooks.py` | **NEW** — `HookManager` class |
+| `vibe/core/agent_loop.py` | Create `HookManager`, fire hooks at lifecycle points |
+| `vibe/core/programmatic.py` | Ensure hooks fire in programmatic mode too |
+| `vibe/cli/textual_ui/app.py` | Ensure hooks fire in interactive TUI mode |
+
+## Testing the Integration
+
+### Manual test:
+```bash
+# Create a test hook that dumps payloads
+mkdir -p /tmp/vibe-hooks
+cat > /tmp/test-hook.sh << 'SH'
+#!/bin/bash
+cat > "/tmp/vibe-hooks/$(date +%s)-${1:-unknown}.json"
+SH
+chmod +x /tmp/test-hook.sh
+
+# Configure hooks in project
+mkdir -p .vibe
+cat > .vibe/hooks.toml << 'TOML'
+[[hooks.session_start]]
+command = "/tmp/test-hook.sh session_start"
+
+[[hooks.user_prompt_submit]]
+command = "/tmp/test-hook.sh user_prompt_submit"
+
+[[hooks.stop]]
+command = "/tmp/test-hook.sh stop"
+TOML
+
+# Run vibe
+vibe -p "What is 2+2?"
+
+# Check captured payloads
+ls /tmp/vibe-hooks/
+cat /tmp/vibe-hooks/*.json | python3 -m json.tool
+```
+
+### Integration test with Entire CLI:
+```bash
+# After hooks are implemented in Vibe and the external agent binary is built:
+entire enable mistral-vibe
+vibe -p "Create a file called hello.txt with hello world"
+git add -A && git commit -m "test"
+entire rewind list  # Should show a checkpoint
+```
+
+## Payload Field Reference
+
+These are all the fields that should be available in hook payloads. The external agent binary (`entire-agent-mistral-vibe`) will parse these to construct protocol events.
+
+| Field | Type | Present In | Description |
+|-------|------|-----------|-------------|
+| `hook_event_name` | string | All | Event type identifier |
+| `cwd` | string | All | Working directory |
+| `session_id` | string | All | Vibe session UUID |
+| `prompt` | string | user_prompt_submit | User's prompt text |
+| `tool_name` | string | pre/post_tool_use | Tool being called (e.g., `write_file`, `bash`, `grep`) |
+| `tool_input` | object | pre/post_tool_use | Raw tool input arguments |
+| `tool_response` | object | post_tool_use | Tool execution result |
+
+## Session File Locations (for the external agent binary)
+
+The external agent binary needs to know where Vibe stores sessions:
+
+| Data | Path Pattern |
+|------|-------------|
+| Session log root | `~/.vibe/logs/session/` |
+| Session folder | `session_YYYYMMDD_HHMMSS_<id[:8]>/` |
+| Session metadata | `<session_folder>/meta.json` |
+| Session transcript | `<session_folder>/messages.jsonl` |
+| Config (global) | `~/.vibe/config.toml` |
+| Config (project) | `.vibe/config.toml` |
+| Hook config | `.vibe/hooks.toml` (proposed) |
+
+The session_id in the folder name is the first 8 characters of the full UUID. To find a session by full ID, glob for `session_*_<id[:8]}`.

--- a/agents/entire-agent-mistral-vibe/Makefile
+++ b/agents/entire-agent-mistral-vibe/Makefile
@@ -1,0 +1,12 @@
+BINARY := entire-agent-mistral-vibe
+
+.PHONY: build test clean
+
+build:
+	GOCACHE=/tmp/go-build-cache go build -o $(BINARY) ./cmd/entire-agent-mistral-vibe
+
+test:
+	GOCACHE=/tmp/go-build-cache go test ./...
+
+clean:
+	rm -f $(BINARY)

--- a/agents/entire-agent-mistral-vibe/cmd/entire-agent-mistral-vibe/main.go
+++ b/agents/entire-agent-mistral-vibe/cmd/entire-agent-mistral-vibe/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/entireio/external-agents/agents/entire-agent-mistral-vibe/internal/protocol"
+	"github.com/entireio/external-agents/agents/entire-agent-mistral-vibe/internal/vibe"
+)
+
+func main() {
+	agent := vibe.New()
+
+	if len(os.Args) < 2 {
+		fatalf("usage: entire-agent-mistral-vibe <subcommand> [args]")
+	}
+
+	var err error
+
+	switch os.Args[1] {
+	case "info":
+		err = protocol.WriteJSON(os.Stdout, agent.Info())
+	case "detect":
+		err = protocol.WriteJSON(os.Stdout, agent.Detect())
+	case "get-session-id":
+		err = protocol.HandleGetSessionID(os.Stdin, os.Stdout, agent)
+	case "get-session-dir":
+		err = protocol.HandleGetSessionDir(os.Args[2:], os.Stdout, agent)
+	case "resolve-session-file":
+		err = protocol.HandleResolveSessionFile(os.Args[2:], os.Stdout, agent)
+	case "read-session":
+		err = protocol.HandleReadSession(os.Stdin, os.Stdout, agent)
+	case "write-session":
+		err = protocol.HandleWriteSession(os.Stdin, agent)
+	case "read-transcript":
+		err = protocol.HandleReadTranscript(os.Args[2:], os.Stdout, agent)
+	case "chunk-transcript":
+		err = protocol.HandleChunkTranscript(os.Args[2:], os.Stdin, os.Stdout, agent)
+	case "reassemble-transcript":
+		err = protocol.HandleReassembleTranscript(os.Stdin, os.Stdout, agent)
+	case "format-resume-command":
+		err = protocol.HandleFormatResumeCommand(os.Args[2:], os.Stdout, agent)
+	case "parse-hook":
+		err = protocol.HandleParseHook(os.Args[2:], os.Stdin, os.Stdout, agent)
+	case "install-hooks":
+		err = protocol.HandleInstallHooks(os.Args[2:], os.Stdout, agent)
+	case "uninstall-hooks":
+		err = agent.UninstallHooks()
+	case "are-hooks-installed":
+		err = protocol.WriteJSON(os.Stdout, protocol.AreHooksInstalledResponse{
+			Installed: agent.AreHooksInstalled(),
+		})
+	case "get-transcript-position":
+		err = protocol.HandleGetTranscriptPosition(os.Args[2:], os.Stdout, agent)
+	case "extract-modified-files":
+		err = protocol.HandleExtractModifiedFiles(os.Args[2:], os.Stdout, agent)
+	case "extract-prompts":
+		err = protocol.HandleExtractPrompts(os.Args[2:], os.Stdout, agent)
+	case "extract-summary":
+		err = protocol.HandleExtractSummary(os.Args[2:], os.Stdout, agent)
+	default:
+		fatalf("unknown subcommand: %s", os.Args[1])
+	}
+
+	if err != nil {
+		fatalf("%v", err)
+	}
+}
+
+func fatalf(format string, args ...any) {
+	_, _ = fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/agents/entire-agent-mistral-vibe/go.mod
+++ b/agents/entire-agent-mistral-vibe/go.mod
@@ -1,0 +1,3 @@
+module github.com/entireio/external-agents/agents/entire-agent-mistral-vibe
+
+go 1.26.0

--- a/agents/entire-agent-mistral-vibe/internal/protocol/protocol.go
+++ b/agents/entire-agent-mistral-vibe/internal/protocol/protocol.go
@@ -1,0 +1,313 @@
+package protocol
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type sessionDirResolver interface {
+	GetSessionDir(repoPath string) (string, error)
+}
+
+type sessionFileResolver interface {
+	ResolveSessionFile(sessionDir, sessionID string) string
+}
+
+type sessionIDProvider interface {
+	GetSessionID(*HookInputJSON) string
+}
+
+type sessionReader interface {
+	ReadSession(*HookInputJSON) (AgentSessionJSON, error)
+}
+
+type sessionWriter interface {
+	WriteSession(AgentSessionJSON) error
+}
+
+type transcriptReader interface {
+	ReadTranscript(sessionRef string) ([]byte, error)
+}
+
+type transcriptChunker interface {
+	ChunkTranscript(content []byte, maxSize int) ([][]byte, error)
+	ReassembleTranscript(chunks [][]byte) ([]byte, error)
+}
+
+type resumeFormatter interface {
+	FormatResumeCommand(sessionID string) string
+}
+
+type hookParser interface {
+	ParseHook(hookName string, input []byte) (*EventJSON, error)
+	InstallHooks(localDev bool, force bool) (int, error)
+	UninstallHooks() error
+	AreHooksInstalled() bool
+}
+
+type transcriptAnalyzer interface {
+	GetTranscriptPosition(path string) (int, error)
+	ExtractModifiedFiles(path string, offset int) ([]string, int, error)
+	ExtractPrompts(sessionRef string, offset int) ([]string, error)
+	ExtractSummary(sessionRef string) (string, bool, error)
+}
+
+func WriteJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(v)
+}
+
+func ReadJSON[T any](r io.Reader) (*T, error) {
+	var value T
+	if err := json.NewDecoder(r).Decode(&value); err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
+func RepoRoot() string {
+	if root := os.Getenv("ENTIRE_REPO_ROOT"); root != "" {
+		return root
+	}
+	root, _ := os.Getwd()
+	return root
+}
+
+func HandleGetSessionID(stdin io.Reader, stdout io.Writer, provider sessionIDProvider) error {
+	input, err := ReadJSON[HookInputJSON](stdin)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionIDResponse{SessionID: provider.GetSessionID(input)})
+}
+
+func HandleGetSessionDir(args []string, stdout io.Writer, resolver sessionDirResolver) error {
+	fs := flag.NewFlagSet("get-session-dir", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	repoPath := fs.String("repo-path", "", "repo path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	sessionDir, err := resolver.GetSessionDir(*repoPath)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionDirResponse{SessionDir: sessionDir})
+}
+
+func HandleResolveSessionFile(args []string, stdout io.Writer, resolver sessionFileResolver) error {
+	fs := flag.NewFlagSet("resolve-session-file", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionDir := fs.String("session-dir", "", "session dir")
+	sessionID := fs.String("session-id", "", "session id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionFileResponse{SessionFile: resolver.ResolveSessionFile(*sessionDir, *sessionID)})
+}
+
+func HandleReadSession(stdin io.Reader, stdout io.Writer, reader sessionReader) error {
+	input, err := ReadJSON[HookInputJSON](stdin)
+	if err != nil {
+		return err
+	}
+	session, err := reader.ReadSession(input)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, session)
+}
+
+func HandleWriteSession(stdin io.Reader, writer sessionWriter) error {
+	session, err := ReadJSON[AgentSessionJSON](stdin)
+	if err != nil {
+		return err
+	}
+	return writer.WriteSession(*session)
+}
+
+func HandleReadTranscript(args []string, stdout io.Writer, reader transcriptReader) error {
+	fs := flag.NewFlagSet("read-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	data, err := reader.ReadTranscript(*sessionRef)
+	if err != nil {
+		return err
+	}
+	_, err = stdout.Write(data)
+	return err
+}
+
+func HandleChunkTranscript(args []string, stdin io.Reader, stdout io.Writer, chunker transcriptChunker) error {
+	fs := flag.NewFlagSet("chunk-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	maxSize := fs.Int("max-size", 0, "max size")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	content, err := io.ReadAll(stdin)
+	if err != nil {
+		return err
+	}
+	chunks, err := chunker.ChunkTranscript(content, *maxSize)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ChunkResponse{Chunks: chunks})
+}
+
+func HandleReassembleTranscript(stdin io.Reader, stdout io.Writer, chunker transcriptChunker) error {
+	input, err := ReadJSON[ChunkResponse](stdin)
+	if err != nil {
+		return err
+	}
+	data, err := chunker.ReassembleTranscript(input.Chunks)
+	if err != nil {
+		return err
+	}
+	_, err = stdout.Write(data)
+	return err
+}
+
+func HandleFormatResumeCommand(args []string, stdout io.Writer, formatter resumeFormatter) error {
+	fs := flag.NewFlagSet("format-resume-command", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionID := fs.String("session-id", "", "session id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ResumeCommandResponse{Command: formatter.FormatResumeCommand(*sessionID)})
+}
+
+// readStdinWithTimeout reads from r but returns empty data if nothing arrives
+// within the timeout. This prevents blocking when an IDE keeps stdin open
+// without sending data (e.g., for hooks that have no payload).
+func readStdinWithTimeout(r io.Reader, timeout time.Duration) ([]byte, error) {
+	type result struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		data, err := io.ReadAll(r)
+		ch <- result{data, err}
+	}()
+	select {
+	case res := <-ch:
+		return res.data, res.err
+	case <-time.After(timeout):
+		return nil, nil
+	}
+}
+
+func HandleParseHook(args []string, stdin io.Reader, stdout io.Writer, parser hookParser) error {
+	fs := flag.NewFlagSet("parse-hook", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	hook := fs.String("hook", "", "hook name")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	input, err := readStdinWithTimeout(stdin, 100*time.Millisecond)
+	if err != nil {
+		return err
+	}
+	event, err := parser.ParseHook(*hook, input)
+	if err != nil {
+		return err
+	}
+	if event == nil {
+		_, err = io.WriteString(stdout, "null\n")
+		return err
+	}
+	return WriteJSON(stdout, event)
+}
+
+func HandleInstallHooks(args []string, stdout io.Writer, parser hookParser) error {
+	fs := flag.NewFlagSet("install-hooks", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	localDev := fs.Bool("local-dev", false, "local dev")
+	force := fs.Bool("force", false, "force")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	count, err := parser.InstallHooks(*localDev, *force)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, HooksInstalledCountResponse{HooksInstalled: count})
+}
+
+func HandleGetTranscriptPosition(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("get-transcript-position", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	path := fs.String("path", "", "path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	position, err := analyzer.GetTranscriptPosition(*path)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, TranscriptPositionResponse{Position: position})
+}
+
+func HandleExtractModifiedFiles(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-modified-files", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	path := fs.String("path", "", "path")
+	offset := fs.Int("offset", 0, "offset")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	files, currentPosition, err := analyzer.ExtractModifiedFiles(*path, *offset)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractFilesResponse{Files: files, CurrentPosition: currentPosition})
+}
+
+func HandleExtractPrompts(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-prompts", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	offset := fs.Int("offset", 0, "offset")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	prompts, err := analyzer.ExtractPrompts(*sessionRef, *offset)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractPromptsResponse{Prompts: prompts})
+}
+
+func HandleExtractSummary(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-summary", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	summary, hasSummary, err := analyzer.ExtractSummary(*sessionRef)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractSummaryResponse{Summary: summary, HasSummary: hasSummary})
+}
+
+func DefaultSessionDir(repoPath string) string {
+	return filepath.Join(repoPath, ".entire", "tmp")
+}
+
+func ResolveSessionFile(sessionDir, sessionID string) string {
+	return filepath.Join(sessionDir, fmt.Sprintf("%s.json", sessionID))
+}

--- a/agents/entire-agent-mistral-vibe/internal/protocol/types.go
+++ b/agents/entire-agent-mistral-vibe/internal/protocol/types.go
@@ -1,0 +1,118 @@
+package protocol
+
+import "encoding/json"
+
+const ProtocolVersion = 1
+
+type DeclaredCapabilities struct {
+	Hooks                  bool `json:"hooks"`
+	TranscriptAnalyzer     bool `json:"transcript_analyzer"`
+	TranscriptPreparer     bool `json:"transcript_preparer"`
+	TokenCalculator        bool `json:"token_calculator"`
+	TextGenerator          bool `json:"text_generator"`
+	HookResponseWriter     bool `json:"hook_response_writer"`
+	SubagentAwareExtractor bool `json:"subagent_aware_extractor"`
+	UsesTerminal           bool `json:"uses_terminal"`
+}
+
+type InfoResponse struct {
+	ProtocolVersion int                  `json:"protocol_version"`
+	Name            string               `json:"name"`
+	Type            string               `json:"type"`
+	Description     string               `json:"description"`
+	IsPreview       bool                 `json:"is_preview"`
+	ProtectedDirs   []string             `json:"protected_dirs"`
+	HookNames       []string             `json:"hook_names"`
+	Capabilities    DeclaredCapabilities `json:"capabilities"`
+}
+
+type DetectResponse struct {
+	Present bool `json:"present"`
+}
+
+type SessionIDResponse struct {
+	SessionID string `json:"session_id"`
+}
+
+type SessionDirResponse struct {
+	SessionDir string `json:"session_dir"`
+}
+
+type SessionFileResponse struct {
+	SessionFile string `json:"session_file"`
+}
+
+type ChunkResponse struct {
+	Chunks [][]byte `json:"chunks"`
+}
+
+type ResumeCommandResponse struct {
+	Command string `json:"command"`
+}
+
+type HooksInstalledCountResponse struct {
+	HooksInstalled int `json:"hooks_installed"`
+}
+
+type AreHooksInstalledResponse struct {
+	Installed bool `json:"installed"`
+}
+
+type TranscriptPositionResponse struct {
+	Position int `json:"position"`
+}
+
+type ExtractFilesResponse struct {
+	Files           []string `json:"files"`
+	CurrentPosition int      `json:"current_position"`
+}
+
+type ExtractPromptsResponse struct {
+	Prompts []string `json:"prompts"`
+}
+
+type ExtractSummaryResponse struct {
+	Summary    string `json:"summary"`
+	HasSummary bool   `json:"has_summary"`
+}
+
+type AgentSessionJSON struct {
+	SessionID     string   `json:"session_id"`
+	AgentName     string   `json:"agent_name"`
+	RepoPath      string   `json:"repo_path"`
+	SessionRef    string   `json:"session_ref"`
+	StartTime     string   `json:"start_time"`
+	NativeData    []byte   `json:"native_data"`
+	ModifiedFiles []string `json:"modified_files"`
+	NewFiles      []string `json:"new_files"`
+	DeletedFiles  []string `json:"deleted_files"`
+}
+
+type HookInputJSON struct {
+	HookType   string                 `json:"hook_type"`
+	SessionID  string                 `json:"session_id"`
+	SessionRef string                 `json:"session_ref"`
+	Timestamp  string                 `json:"timestamp"`
+	UserPrompt string                 `json:"user_prompt,omitempty"`
+	ToolName   string                 `json:"tool_name,omitempty"`
+	ToolUseID  string                 `json:"tool_use_id,omitempty"`
+	ToolInput  json.RawMessage        `json:"tool_input,omitempty"`
+	RawData    map[string]interface{} `json:"raw_data,omitempty"`
+}
+
+type EventJSON struct {
+	Type              int               `json:"type"`
+	SessionID         string            `json:"session_id"`
+	PreviousSessionID string            `json:"previous_session_id,omitempty"`
+	SessionRef        string            `json:"session_ref,omitempty"`
+	Prompt            string            `json:"prompt,omitempty"`
+	Model             string            `json:"model,omitempty"`
+	Timestamp         string            `json:"timestamp,omitempty"`
+	ToolUseID         string            `json:"tool_use_id,omitempty"`
+	SubagentID        string            `json:"subagent_id,omitempty"`
+	ToolInput         json.RawMessage   `json:"tool_input,omitempty"`
+	SubagentType      string            `json:"subagent_type,omitempty"`
+	TaskDescription   string            `json:"task_description,omitempty"`
+	ResponseMessage   string            `json:"response_message,omitempty"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+}

--- a/agents/entire-agent-mistral-vibe/internal/vibe/agent.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/agent.go
@@ -77,20 +77,14 @@ func (a *Agent) ReadSession(input *protocol.HookInputJSON) (protocol.AgentSessio
 	if err != nil {
 		return protocol.AgentSessionJSON{}, err
 	}
-	sessionRef := ""
+	sessionRef := a.ResolveSessionFile(sessionDir, sessionID)
 	if input != nil && input.SessionRef != "" {
 		sessionRef = input.SessionRef
-	} else {
-		sessionRef = a.ResolveSessionFile(sessionDir, sessionID)
 	}
 
-	var nativeData []byte
-	if sessionRef != "" {
-		data, readErr := os.ReadFile(sessionRef)
-		if readErr != nil && !os.IsNotExist(readErr) {
-			return protocol.AgentSessionJSON{}, fmt.Errorf("failed to read session file: %w", readErr)
-		}
-		nativeData = data
+	nativeData, err := os.ReadFile(sessionRef)
+	if err != nil && !os.IsNotExist(err) {
+		return protocol.AgentSessionJSON{}, fmt.Errorf("failed to read session file: %w", err)
 	}
 
 	return protocol.AgentSessionJSON{

--- a/agents/entire-agent-mistral-vibe/internal/vibe/agent.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/agent.go
@@ -1,0 +1,155 @@
+package vibe
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/entireio/external-agents/agents/entire-agent-mistral-vibe/internal/protocol"
+)
+
+// Agent implements the Entire CLI external agent protocol for Mistral Vibe.
+type Agent struct{}
+
+// New returns a new Vibe agent instance.
+func New() *Agent {
+	return &Agent{}
+}
+
+// Info returns the agent info response with capabilities and hook names.
+func (a *Agent) Info() protocol.InfoResponse {
+	return protocol.InfoResponse{
+		ProtocolVersion: protocol.ProtocolVersion,
+		Name:            "mistral-vibe",
+		Type:            "Mistral Vibe",
+		Description:     "Mistral Vibe - External agent plugin for Entire CLI",
+		IsPreview:       true,
+		ProtectedDirs:   []string{".vibe"},
+		HookNames: []string{
+			HookNameSessionStart,
+			HookNameUserPromptSubmit,
+			HookNamePreToolUse,
+			HookNamePostToolUse,
+			HookNameTurnEnd,
+		},
+		Capabilities: protocol.DeclaredCapabilities{
+			Hooks:              true,
+			TranscriptAnalyzer: true,
+			TokenCalculator:    true,
+		},
+	}
+}
+
+// Detect checks whether a .vibe/ directory exists in the repo root.
+func (a *Agent) Detect() protocol.DetectResponse {
+	repoRoot := protocol.RepoRoot()
+	_, err := os.Stat(filepath.Join(repoRoot, ".vibe"))
+	return protocol.DetectResponse{Present: err == nil}
+}
+
+// GetSessionID extracts the session ID from the hook input JSON. If the input
+// contains a session_id it is returned directly; otherwise a placeholder is used.
+func (a *Agent) GetSessionID(input *protocol.HookInputJSON) string {
+	if input != nil && input.SessionID != "" {
+		return input.SessionID
+	}
+	return "stub-session-000"
+}
+
+// GetSessionDir returns the session directory for the given repo path.
+func (a *Agent) GetSessionDir(repoPath string) (string, error) {
+	return protocol.DefaultSessionDir(repoPath), nil
+}
+
+// ResolveSessionFile returns the full path to a session file.
+func (a *Agent) ResolveSessionFile(sessionDir, sessionID string) string {
+	return protocol.ResolveSessionFile(sessionDir, sessionID)
+}
+
+// ReadSession reads a session from disk or returns a new session shell.
+func (a *Agent) ReadSession(input *protocol.HookInputJSON) (protocol.AgentSessionJSON, error) {
+	sessionID := a.GetSessionID(input)
+	repoRoot := protocol.RepoRoot()
+	sessionDir, err := a.GetSessionDir(repoRoot)
+	if err != nil {
+		return protocol.AgentSessionJSON{}, err
+	}
+	sessionRef := ""
+	if input != nil && input.SessionRef != "" {
+		sessionRef = input.SessionRef
+	} else {
+		sessionRef = a.ResolveSessionFile(sessionDir, sessionID)
+	}
+
+	var nativeData []byte
+	if sessionRef != "" {
+		data, readErr := os.ReadFile(sessionRef)
+		if readErr != nil && !os.IsNotExist(readErr) {
+			return protocol.AgentSessionJSON{}, fmt.Errorf("failed to read session file: %w", readErr)
+		}
+		nativeData = data
+	}
+
+	return protocol.AgentSessionJSON{
+		SessionID:     sessionID,
+		AgentName:     "mistral-vibe",
+		RepoPath:      repoRoot,
+		SessionRef:    sessionRef,
+		StartTime:     time.Now().UTC().Format(time.RFC3339),
+		NativeData:    nativeData,
+		ModifiedFiles: []string{},
+		NewFiles:      []string{},
+		DeletedFiles:  []string{},
+	}, nil
+}
+
+// WriteSession writes the session JSON to the session file on disk.
+func (a *Agent) WriteSession(session protocol.AgentSessionJSON) error {
+	if session.SessionRef == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(session.SessionRef), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(session.SessionRef, session.NativeData, 0o600)
+}
+
+// ReadTranscript reads raw transcript bytes from the given session ref path.
+func (a *Agent) ReadTranscript(sessionRef string) ([]byte, error) {
+	return os.ReadFile(sessionRef)
+}
+
+// ChunkTranscript splits content into byte chunks of at most maxSize bytes.
+func (a *Agent) ChunkTranscript(content []byte, maxSize int) ([][]byte, error) {
+	if maxSize <= 0 {
+		return nil, errors.New("max-size must be greater than zero")
+	}
+	if len(content) == 0 {
+		return [][]byte{[]byte{}}, nil
+	}
+
+	var chunks [][]byte
+	for start := 0; start < len(content); start += maxSize {
+		end := start + maxSize
+		if end > len(content) {
+			end = len(content)
+		}
+		chunk := make([]byte, end-start)
+		copy(chunk, content[start:end])
+		chunks = append(chunks, chunk)
+	}
+	return chunks, nil
+}
+
+// ReassembleTranscript joins previously-chunked transcript pieces back together.
+func (a *Agent) ReassembleTranscript(chunks [][]byte) ([]byte, error) {
+	return bytes.Join(chunks, nil), nil
+}
+
+// FormatResumeCommand returns the CLI command to resume a Vibe session.
+func (a *Agent) FormatResumeCommand(sessionID string) string {
+	return fmt.Sprintf("vibe --resume %s", sessionID)
+}

--- a/agents/entire-agent-mistral-vibe/internal/vibe/agent_test.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/agent_test.go
@@ -1,0 +1,208 @@
+package vibe
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/external-agents/agents/entire-agent-mistral-vibe/internal/protocol"
+)
+
+func TestInfo(t *testing.T) {
+	agent := New()
+	info := agent.Info()
+
+	if info.ProtocolVersion != 1 {
+		t.Errorf("protocol_version = %d, want 1", info.ProtocolVersion)
+	}
+	if info.Name != "mistral-vibe" {
+		t.Errorf("name = %q, want %q", info.Name, "mistral-vibe")
+	}
+	if info.Type != "Mistral Vibe" {
+		t.Errorf("type = %q, want %q", info.Type, "Mistral Vibe")
+	}
+	if !info.Capabilities.Hooks {
+		t.Error("hooks capability should be true")
+	}
+	if !info.Capabilities.TranscriptAnalyzer {
+		t.Error("transcript_analyzer capability should be true")
+	}
+	if !info.Capabilities.TokenCalculator {
+		t.Error("token_calculator capability should be true")
+	}
+	if len(info.HookNames) != 5 {
+		t.Errorf("hook_names count = %d, want 5", len(info.HookNames))
+	}
+	if len(info.ProtectedDirs) != 1 || info.ProtectedDirs[0] != ".vibe" {
+		t.Errorf("protected_dirs = %v, want [.vibe]", info.ProtectedDirs)
+	}
+}
+
+func TestDetect_Present(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, ".vibe"), 0o700)
+	t.Setenv("ENTIRE_REPO_ROOT", dir)
+
+	agent := New()
+	resp := agent.Detect()
+	if !resp.Present {
+		t.Error("detect should return true when .vibe/ exists")
+	}
+}
+
+func TestDetect_Absent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", dir)
+
+	agent := New()
+	resp := agent.Detect()
+	if resp.Present {
+		t.Error("detect should return false when .vibe/ is absent")
+	}
+}
+
+func TestGetSessionID_FromInput(t *testing.T) {
+	agent := New()
+	input := &protocol.HookInputJSON{SessionID: "test-id-123"}
+	got := agent.GetSessionID(input)
+	if got != "test-id-123" {
+		t.Errorf("session_id = %q, want %q", got, "test-id-123")
+	}
+}
+
+func TestGetSessionID_Fallback(t *testing.T) {
+	agent := New()
+	got := agent.GetSessionID(nil)
+	if got == "" {
+		t.Error("session_id should not be empty for nil input")
+	}
+}
+
+func TestGetSessionDir(t *testing.T) {
+	agent := New()
+	dir, err := agent.GetSessionDir("/tmp/repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "/tmp/repo/.entire/tmp"
+	if dir != want {
+		t.Errorf("session_dir = %q, want %q", dir, want)
+	}
+}
+
+func TestResolveSessionFile(t *testing.T) {
+	agent := New()
+	got := agent.ResolveSessionFile("/tmp/sessions", "abc-123")
+	want := "/tmp/sessions/abc-123.json"
+	if got != want {
+		t.Errorf("session_file = %q, want %q", got, want)
+	}
+}
+
+func TestFormatResumeCommand(t *testing.T) {
+	agent := New()
+	got := agent.FormatResumeCommand("session-xyz")
+	want := "vibe --resume session-xyz"
+	if got != want {
+		t.Errorf("command = %q, want %q", got, want)
+	}
+}
+
+func TestChunkTranscript(t *testing.T) {
+	agent := New()
+
+	t.Run("basic_chunking", func(t *testing.T) {
+		content := []byte("abcdefghijklmnopqrst") // 20 bytes
+		chunks, err := agent.ChunkTranscript(content, 8)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(chunks) != 3 {
+			t.Errorf("chunks = %d, want 3", len(chunks))
+		}
+	})
+
+	t.Run("exact_size", func(t *testing.T) {
+		content := []byte("abcdefghij") // 10 bytes
+		chunks, err := agent.ChunkTranscript(content, 10)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(chunks) != 1 {
+			t.Errorf("chunks = %d, want 1", len(chunks))
+		}
+	})
+
+	t.Run("empty_content", func(t *testing.T) {
+		chunks, err := agent.ChunkTranscript([]byte{}, 10)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(chunks) != 1 {
+			t.Errorf("chunks = %d, want 1 (empty chunk)", len(chunks))
+		}
+	})
+
+	t.Run("invalid_max_size", func(t *testing.T) {
+		_, err := agent.ChunkTranscript([]byte("test"), 0)
+		if err == nil {
+			t.Error("expected error for max-size 0")
+		}
+	})
+}
+
+func TestReassembleTranscript(t *testing.T) {
+	agent := New()
+	chunks := [][]byte{[]byte("hello"), []byte(" "), []byte("world")}
+	got, err := agent.ReassembleTranscript(chunks)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != "hello world" {
+		t.Errorf("reassembled = %q, want %q", got, "hello world")
+	}
+}
+
+func TestChunkReassembleRoundTrip(t *testing.T) {
+	agent := New()
+	original := []byte("The quick brown fox jumps over the lazy dog")
+	chunks, err := agent.ChunkTranscript(original, 10)
+	if err != nil {
+		t.Fatalf("chunk error: %v", err)
+	}
+	reassembled, err := agent.ReassembleTranscript(chunks)
+	if err != nil {
+		t.Fatalf("reassemble error: %v", err)
+	}
+	if string(reassembled) != string(original) {
+		t.Errorf("round-trip failed: got %q, want %q", reassembled, original)
+	}
+}
+
+func TestWriteAndReadSession(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", dir)
+	os.MkdirAll(filepath.Join(dir, ".entire", "tmp"), 0o700)
+
+	agent := New()
+	sessionRef := filepath.Join(dir, ".entire", "tmp", "test-session.json")
+
+	err := agent.WriteSession(protocol.AgentSessionJSON{
+		SessionID:  "test-session",
+		AgentName:  "mistral-vibe",
+		RepoPath:   dir,
+		SessionRef: sessionRef,
+		NativeData: []byte(`{"test":"data"}`),
+	})
+	if err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+
+	data, err := os.ReadFile(sessionRef)
+	if err != nil {
+		t.Fatalf("read file error: %v", err)
+	}
+	if string(data) != `{"test":"data"}` {
+		t.Errorf("written data = %q, want %q", data, `{"test":"data"}`)
+	}
+}

--- a/agents/entire-agent-mistral-vibe/internal/vibe/hooks.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/hooks.go
@@ -51,10 +51,14 @@ func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, e
 		}, nil
 
 	case HookNameTurnEnd:
+		sessionRef := findVibeSessionRef(sessionID)
+		if sessionRef == "" {
+			sessionRef = a.ensurePlaceholderTranscript(sessionID)
+		}
 		return &protocol.EventJSON{
 			Type:       3, // TurnEnd
 			SessionID:  sessionID,
-			SessionRef: findVibeSessionRef(sessionID),
+			SessionRef: sessionRef,
 			Timestamp:  time.Now().UTC().Format(time.RFC3339),
 		}, nil
 
@@ -233,6 +237,25 @@ func (a *Agent) AreHooksInstalled() bool {
 	}
 
 	return strings.Contains(string(data), hookMarker)
+}
+
+// ensurePlaceholderTranscript creates a minimal transcript file in .entire/tmp/
+// so the entire CLI has a valid SessionRef for session persistence. This is
+// the fallback when Vibe's native session logs cannot be found.
+func (a *Agent) ensurePlaceholderTranscript(sessionID string) string {
+	repoRoot := protocol.RepoRoot()
+	sessionDir, err := a.GetSessionDir(repoRoot)
+	if err != nil {
+		return ""
+	}
+	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+		return ""
+	}
+	ref := a.ResolveSessionFile(sessionDir, sessionID)
+	if err := os.WriteFile(ref, []byte("{}"), 0o600); err != nil {
+		return ""
+	}
+	return ref
 }
 
 // findVibeSessionRef finds the messages.jsonl file for a Vibe session by

--- a/agents/entire-agent-mistral-vibe/internal/vibe/hooks.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/hooks.go
@@ -58,16 +58,8 @@ func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, e
 		if sessionID == "" {
 			sessionID = fmt.Sprintf("vibe-%d", time.Now().UnixNano())
 		}
-		// Construct session_ref from the Vibe session log directory.
-		sessionRef := ""
-		if sessionID != "" {
-			home, err := os.UserHomeDir()
-			if err == nil {
-				sessionRef = filepath.Join(home, ".vibe", "logs", "session",
-					fmt.Sprintf("session_%s", sessionID[:min(8, len(sessionID))]),
-					"messages.jsonl")
-			}
-		}
+		// Find the session transcript in Vibe's log directory.
+		sessionRef := findVibeSessionRef(sessionID)
 		return &protocol.EventJSON{
 			Type:       3, // TurnEnd
 			SessionID:  sessionID,
@@ -131,7 +123,75 @@ func (a *Agent) InstallHooks(localDev bool, force bool) (int, error) {
 		return 0, fmt.Errorf("failed to write config.toml: %w", err)
 	}
 
+	// Trust the repo directory so Vibe reads the project-level config.
+	if err := trustDirectory(repoRoot); err != nil {
+		// Non-fatal: hooks are installed even if trust fails.
+		_, _ = fmt.Fprintf(os.Stderr, "warning: failed to trust directory: %v\n", err)
+	}
+
 	return len(hookEntries), nil
+}
+
+// trustDirectory adds the given path to Vibe's trusted folders list
+// (~/.vibe/trusted_folders.toml) so that project-level .vibe/config.toml
+// is read by Vibe when running in that directory.
+func trustDirectory(dir string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	trustFile := filepath.Join(home, ".vibe", "trusted_folders.toml")
+
+	// Resolve symlinks to match Vibe's normalization.
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		resolved = dir
+	}
+	absDir, err := filepath.Abs(resolved)
+	if err != nil {
+		absDir = resolved
+	}
+
+	// Read existing trusted folders file.
+	data, err := os.ReadFile(trustFile)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	content := string(data)
+
+	// Check if already trusted (simple string check).
+	if strings.Contains(content, absDir) {
+		return nil
+	}
+
+	// Append to trusted list. We use a simple approach: read existing
+	// trusted entries, add ours, and rewrite.
+	var trusted []string
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "\"") || strings.HasPrefix(line, "'") {
+			// Extract path from TOML string (strip quotes and trailing comma).
+			path := strings.Trim(line, "\"', \t")
+			if path != "" {
+				trusted = append(trusted, path)
+			}
+		}
+	}
+	trusted = append(trusted, absDir)
+
+	// Write back in TOML format.
+	var sb strings.Builder
+	sb.WriteString("trusted = [\n")
+	for _, t := range trusted {
+		sb.WriteString(fmt.Sprintf("    %q,\n", t))
+	}
+	sb.WriteString("]\nuntrusted = []\n")
+
+	if err := os.MkdirAll(filepath.Dir(trustFile), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(trustFile, []byte(sb.String()), 0o600)
 }
 
 // UninstallHooks removes the Entire CLI hook entries from .vibe/config.toml.
@@ -183,6 +243,39 @@ func (a *Agent) AreHooksInstalled() bool {
 	}
 
 	return strings.Contains(string(data), hookMarker)
+}
+
+// findVibeSessionRef finds the messages.jsonl file for a Vibe session by
+// globbing the session log directory for matching session folders.
+func findVibeSessionRef(sessionID string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	prefix := sessionID
+	if len(prefix) > 8 {
+		prefix = prefix[:8]
+	}
+	logDir := filepath.Join(home, ".vibe", "logs", "session")
+	pattern := filepath.Join(logDir, fmt.Sprintf("session_*_%s", prefix))
+	matches, err := filepath.Glob(pattern)
+	if err != nil || len(matches) == 0 {
+		return ""
+	}
+	// Use the most recently modified match.
+	best := matches[0]
+	var bestMtime int64
+	for _, m := range matches {
+		info, err := os.Stat(m)
+		if err != nil {
+			continue
+		}
+		if info.ModTime().UnixNano() > bestMtime {
+			bestMtime = info.ModTime().UnixNano()
+			best = m
+		}
+	}
+	return filepath.Join(best, "messages.jsonl")
 }
 
 func min(a, b int) int {

--- a/agents/entire-agent-mistral-vibe/internal/vibe/hooks.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/hooks.go
@@ -37,14 +37,14 @@ func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, e
 	switch hookName {
 	case HookNameSessionStart:
 		return &protocol.EventJSON{
-			Type:      1, // SessionStart
+			Type:      EventTypeSessionStart,
 			SessionID: sessionID,
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
 		}, nil
 
 	case HookNameUserPromptSubmit:
 		return &protocol.EventJSON{
-			Type:      2, // TurnStart
+			Type:      EventTypeTurnStart,
 			SessionID: sessionID,
 			Prompt:    payload.Prompt,
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
@@ -53,7 +53,7 @@ func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, e
 	case HookNameTurnEnd:
 		sessionRef := a.cacheTranscriptForTurnEnd(sessionID)
 		return &protocol.EventJSON{
-			Type:       3, // TurnEnd
+			Type:       EventTypeTurnEnd,
 			SessionID:  sessionID,
 			SessionRef: sessionRef,
 			Timestamp:  time.Now().UTC().Format(time.RFC3339),

--- a/agents/entire-agent-mistral-vibe/internal/vibe/hooks.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/hooks.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,6 +19,8 @@ const (
 	prodHookCommandBase   = "entire hooks mistral-vibe "
 	localDevCommandBase   = "go run ./cmd/entire/main.go hooks mistral-vibe "
 	hookMarker            = "entire hooks mistral-vibe"
+	managedHookBlockStart = "# BEGIN ENTIRE MISTRAL VIBE HOOKS"
+	managedHookBlockEnd   = "# END ENTIRE MISTRAL VIBE HOOKS"
 )
 
 // ParseHook parses a Vibe hook JSON payload and maps it to a protocol EventJSON.
@@ -86,30 +90,13 @@ func (a *Agent) InstallHooks(localDev bool, force bool) (int, error) {
 		commandBase = localDevCommandBase
 	}
 
-	hookEntries := []struct {
-		nativeName  string
-		protocolName string
-	}{
-		{VibeNativeSessionStart, HookNameSessionStart},
-		{VibeNativeUserPromptSubmit, HookNameUserPromptSubmit},
-		{VibeNativePreToolUse, HookNamePreToolUse},
-		{VibeNativePostToolUse, HookNamePostToolUse},
-		{VibeNativeTurnEnd, HookNameTurnEnd},
-	}
-
-	var tomlLines []string
-	tomlLines = append(tomlLines, "# Entire CLI hook configuration")
-	tomlLines = append(tomlLines, "# Managed by entire-agent-mistral-vibe")
-	tomlLines = append(tomlLines, "")
-
-	for _, hook := range hookEntries {
-		tomlLines = append(tomlLines, fmt.Sprintf("[[hooks.%s]]", hook.nativeName))
-		tomlLines = append(tomlLines, fmt.Sprintf(`command = "%s%s"`, commandBase, hook.protocolName))
-		tomlLines = append(tomlLines, "")
-	}
-
 	configPath := filepath.Join(configDir, vibeConfigFile)
-	content := strings.Join(tomlLines, "\n")
+	existing, err := os.ReadFile(configPath)
+	if err != nil && !os.IsNotExist(err) {
+		return 0, fmt.Errorf("failed to read config.toml: %w", err)
+	}
+
+	content := mergeHookConfig(string(existing), renderManagedHookBlock(commandBase))
 	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
 		return 0, fmt.Errorf("failed to write config.toml: %w", err)
 	}
@@ -120,7 +107,7 @@ func (a *Agent) InstallHooks(localDev bool, force bool) (int, error) {
 		_, _ = fmt.Fprintf(os.Stderr, "warning: failed to trust directory: %v\n", err)
 	}
 
-	return len(hookEntries), nil
+	return len(managedHookEntries()), nil
 }
 
 // trustDirectory adds the given path to Vibe's trusted folders list
@@ -151,38 +138,39 @@ func trustDirectory(dir string) error {
 
 	content := string(data)
 
-	// Check if already trusted (simple string check).
-	if strings.Contains(content, absDir) {
-		return nil
+	trusted, foundTrusted, err := readTOMLStringArray(content, "trusted")
+	if err != nil {
+		return err
 	}
-
-	// Append to trusted list. We use a simple approach: read existing
-	// trusted entries, add ours, and rewrite.
-	var trusted []string
-	for _, line := range strings.Split(content, "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "\"") || strings.HasPrefix(line, "'") {
-			// Extract path from TOML string (strip quotes and trailing comma).
-			path := strings.Trim(line, "\"', \t")
-			if path != "" {
-				trusted = append(trusted, path)
-			}
+	for _, path := range trusted {
+		if path == absDir {
+			return nil
 		}
+	}
+	if !foundTrusted {
+		trusted = nil
 	}
 	trusted = append(trusted, absDir)
 
-	// Write back in TOML format.
-	var sb strings.Builder
-	sb.WriteString("trusted = [\n")
-	for _, t := range trusted {
-		sb.WriteString(fmt.Sprintf("    %q,\n", t))
+	untrusted, foundUntrusted, err := readTOMLStringArray(content, "untrusted")
+	if err != nil {
+		return err
 	}
-	sb.WriteString("]\nuntrusted = []\n")
+	if !foundUntrusted {
+		untrusted = nil
+	}
+
+	updated := upsertTOMLStringArray(content, "trusted", trusted)
+	updated = upsertTOMLStringArray(updated, "untrusted", untrusted)
+
+	if strings.TrimSpace(updated) == "" {
+		return nil
+	}
 
 	if err := os.MkdirAll(filepath.Dir(trustFile), 0o700); err != nil {
 		return err
 	}
-	return os.WriteFile(trustFile, []byte(sb.String()), 0o600)
+	return os.WriteFile(trustFile, []byte(updated), 0o600)
 }
 
 // UninstallHooks removes the Entire CLI hook entries from .vibe/config.toml.
@@ -198,29 +186,12 @@ func (a *Agent) UninstallHooks() error {
 		return err
 	}
 
-	// Filter out lines containing the hook marker.
-	var filteredLines []string
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.Contains(line, hookMarker) {
-			continue
-		}
-		// Also skip comment lines managed by this agent.
-		if strings.Contains(line, "Managed by entire-agent-mistral-vibe") {
-			continue
-		}
-		if strings.Contains(line, "Entire CLI hook configuration") {
-			continue
-		}
-		filteredLines = append(filteredLines, line)
-	}
-
-	// If only whitespace/empty lines remain, remove the file entirely.
-	remaining := strings.TrimSpace(strings.Join(filteredLines, "\n"))
+	remaining := removeManagedHookConfig(string(data))
 	if remaining == "" || remaining == "[hooks]" {
 		return os.Remove(configPath)
 	}
 
-	return os.WriteFile(configPath, []byte(strings.Join(filteredLines, "\n")), 0o600)
+	return os.WriteFile(configPath, []byte(remaining), 0o600)
 }
 
 // AreHooksInstalled checks whether .vibe/config.toml contains Entire CLI hook entries.
@@ -233,7 +204,8 @@ func (a *Agent) AreHooksInstalled() bool {
 		return false
 	}
 
-	return strings.Contains(string(data), hookMarker)
+	content := string(data)
+	return strings.Contains(content, managedHookBlockStart) || strings.Contains(content, hookMarker)
 }
 
 // cacheTranscriptForTurnEnd copies the Vibe native transcript into
@@ -300,3 +272,173 @@ func findVibeSessionRef(sessionID string) string {
 	return filepath.Join(best, "messages.jsonl")
 }
 
+func managedHookEntries() []struct {
+	nativeName   string
+	protocolName string
+} {
+	return []struct {
+		nativeName   string
+		protocolName string
+	}{
+		{VibeNativeSessionStart, HookNameSessionStart},
+		{VibeNativeUserPromptSubmit, HookNameUserPromptSubmit},
+		{VibeNativePreToolUse, HookNamePreToolUse},
+		{VibeNativePostToolUse, HookNamePostToolUse},
+		{VibeNativeTurnEnd, HookNameTurnEnd},
+	}
+}
+
+func renderManagedHookBlock(commandBase string) string {
+	lines := []string{
+		managedHookBlockStart,
+		"# Entire CLI hook configuration",
+		"# Managed by entire-agent-mistral-vibe",
+	}
+	for _, hook := range managedHookEntries() {
+		lines = append(lines, "")
+		lines = append(lines, fmt.Sprintf("[[hooks.%s]]", hook.nativeName))
+		lines = append(lines, fmt.Sprintf(`command = "%s%s"`, commandBase, hook.protocolName))
+	}
+	lines = append(lines, "", managedHookBlockEnd)
+	return strings.Join(lines, "\n")
+}
+
+func mergeHookConfig(existing string, managedBlock string) string {
+	cleaned := removeManagedHookConfig(existing)
+	if cleaned == "" {
+		return managedBlock + "\n"
+	}
+	return managedBlock + "\n" + cleaned
+}
+
+func removeManagedHookConfig(content string) string {
+	content = removeManagedHookBlock(content)
+	content = removeLegacyManagedHookConfig(content)
+	return strings.TrimLeft(content, "\n")
+}
+
+func removeManagedHookBlock(content string) string {
+	for {
+		start := strings.Index(content, managedHookBlockStart)
+		if start == -1 {
+			return content
+		}
+		end := strings.Index(content[start:], managedHookBlockEnd)
+		if end == -1 {
+			return content
+		}
+		end += start + len(managedHookBlockEnd)
+		if end < len(content) && content[end] == '\n' {
+			end++
+		}
+		content = content[:start] + content[end:]
+	}
+}
+
+func removeLegacyManagedHookConfig(content string) string {
+	lines := strings.Split(content, "\n")
+	var kept []string
+
+	for i := 0; i < len(lines); {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+		if strings.Contains(line, "Managed by entire-agent-mistral-vibe") ||
+			strings.Contains(line, "Entire CLI hook configuration") {
+			i++
+			continue
+		}
+		if strings.HasPrefix(trimmed, "[[hooks.") {
+			j := i + 1
+			managed := false
+			for j < len(lines) {
+				nextTrimmed := strings.TrimSpace(lines[j])
+				if strings.HasPrefix(nextTrimmed, "[[hooks.") {
+					break
+				}
+				if strings.Contains(lines[j], hookMarker) {
+					managed = true
+				}
+				j++
+			}
+			if managed {
+				i = j
+				for i < len(lines) && strings.TrimSpace(lines[i]) == "" {
+					i++
+				}
+				continue
+			}
+			kept = append(kept, lines[i:j]...)
+			i = j
+			continue
+		}
+		kept = append(kept, line)
+		i++
+	}
+
+	result := strings.Join(kept, "\n")
+	if result == "" {
+		return ""
+	}
+	if !strings.HasSuffix(result, "\n") {
+		result += "\n"
+	}
+	return result
+}
+
+func readTOMLStringArray(content string, key string) ([]string, bool, error) {
+	re := regexp.MustCompile(`(?ms)^\s*` + regexp.QuoteMeta(key) + `\s*=\s*\[(.*?)\]`)
+	match := re.FindStringSubmatch(content)
+	if match == nil {
+		return nil, false, nil
+	}
+	itemRE := regexp.MustCompile(`"(?:\\.|[^"])*"|'(?:[^'\\]|\\.)*'`)
+	rawItems := itemRE.FindAllString(match[1], -1)
+	values := make([]string, 0, len(rawItems))
+	for _, raw := range rawItems {
+		parsed, err := parseTOMLStringLiteral(raw)
+		if err != nil {
+			return nil, false, err
+		}
+		values = append(values, parsed)
+	}
+	return values, true, nil
+}
+
+func parseTOMLStringLiteral(raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	if raw[0] == '"' {
+		return strconv.Unquote(raw)
+	}
+	if raw[0] == '\'' && raw[len(raw)-1] == '\'' {
+		return raw[1 : len(raw)-1], nil
+	}
+	return "", fmt.Errorf("unsupported TOML string literal: %s", raw)
+}
+
+func upsertTOMLStringArray(content string, key string, values []string) string {
+	formatted := formatTOMLStringArray(key, values)
+	re := regexp.MustCompile(`(?ms)^\s*` + regexp.QuoteMeta(key) + `\s*=\s*\[(.*?)\]\n?`)
+	if re.MatchString(content) {
+		return re.ReplaceAllString(content, formatted)
+	}
+	if strings.TrimSpace(content) == "" {
+		return formatted
+	}
+	if strings.HasSuffix(content, "\n") {
+		return content + formatted
+	}
+	return content + "\n" + formatted
+}
+
+func formatTOMLStringArray(key string, values []string) string {
+	var b strings.Builder
+	b.WriteString(key)
+	b.WriteString(" = [\n")
+	for _, value := range values {
+		b.WriteString(fmt.Sprintf("    %q,\n", value))
+	}
+	b.WriteString("]\n")
+	return b.String()
+}

--- a/agents/entire-agent-mistral-vibe/internal/vibe/hooks.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/hooks.go
@@ -29,12 +29,13 @@ func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, e
 		}
 	}
 
+	sessionID := payload.SessionID
+	if sessionID == "" {
+		sessionID = fmt.Sprintf("vibe-%d", time.Now().UnixNano())
+	}
+
 	switch hookName {
 	case HookNameSessionStart:
-		sessionID := payload.SessionID
-		if sessionID == "" {
-			sessionID = fmt.Sprintf("vibe-%d", time.Now().UnixNano())
-		}
 		return &protocol.EventJSON{
 			Type:      1, // SessionStart
 			SessionID: sessionID,
@@ -42,10 +43,6 @@ func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, e
 		}, nil
 
 	case HookNameUserPromptSubmit:
-		sessionID := payload.SessionID
-		if sessionID == "" {
-			sessionID = fmt.Sprintf("vibe-%d", time.Now().UnixNano())
-		}
 		return &protocol.EventJSON{
 			Type:      2, // TurnStart
 			SessionID: sessionID,
@@ -54,21 +51,14 @@ func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, e
 		}, nil
 
 	case HookNameTurnEnd:
-		sessionID := payload.SessionID
-		if sessionID == "" {
-			sessionID = fmt.Sprintf("vibe-%d", time.Now().UnixNano())
-		}
-		// Find the session transcript in Vibe's log directory.
-		sessionRef := findVibeSessionRef(sessionID)
 		return &protocol.EventJSON{
 			Type:       3, // TurnEnd
 			SessionID:  sessionID,
-			SessionRef: sessionRef,
+			SessionRef: findVibeSessionRef(sessionID),
 			Timestamp:  time.Now().UTC().Format(time.RFC3339),
 		}, nil
 
 	case HookNamePreToolUse, HookNamePostToolUse:
-		// Pre/post tool use hooks do not produce protocol events.
 		return nil, nil
 
 	default:
@@ -278,9 +268,3 @@ func findVibeSessionRef(sessionID string) string {
 	return filepath.Join(best, "messages.jsonl")
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/agents/entire-agent-mistral-vibe/internal/vibe/hooks.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/hooks.go
@@ -51,10 +51,7 @@ func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, e
 		}, nil
 
 	case HookNameTurnEnd:
-		sessionRef := findVibeSessionRef(sessionID)
-		if sessionRef == "" {
-			sessionRef = a.ensurePlaceholderTranscript(sessionID)
-		}
+		sessionRef := a.cacheTranscriptForTurnEnd(sessionID)
 		return &protocol.EventJSON{
 			Type:       3, // TurnEnd
 			SessionID:  sessionID,
@@ -239,10 +236,10 @@ func (a *Agent) AreHooksInstalled() bool {
 	return strings.Contains(string(data), hookMarker)
 }
 
-// ensurePlaceholderTranscript creates a minimal transcript file in .entire/tmp/
-// so the entire CLI has a valid SessionRef for session persistence. This is
-// the fallback when Vibe's native session logs cannot be found.
-func (a *Agent) ensurePlaceholderTranscript(sessionID string) string {
+// cacheTranscriptForTurnEnd copies the Vibe native transcript into
+// .entire/tmp/{sessionID}.json so the entire CLI has a local session file
+// for persistence. If the native log cannot be found, a placeholder is written.
+func (a *Agent) cacheTranscriptForTurnEnd(sessionID string) string {
 	repoRoot := protocol.RepoRoot()
 	sessionDir, err := a.GetSessionDir(repoRoot)
 	if err != nil {
@@ -251,11 +248,23 @@ func (a *Agent) ensurePlaceholderTranscript(sessionID string) string {
 	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
 		return ""
 	}
-	ref := a.ResolveSessionFile(sessionDir, sessionID)
-	if err := os.WriteFile(ref, []byte("{}"), 0o600); err != nil {
+	cachePath := a.ResolveSessionFile(sessionDir, sessionID)
+
+	// Try to copy from the native Vibe session log.
+	if nativeRef := findVibeSessionRef(sessionID); nativeRef != "" {
+		data, err := os.ReadFile(nativeRef)
+		if err == nil {
+			if err := os.WriteFile(cachePath, data, 0o600); err == nil {
+				return cachePath
+			}
+		}
+	}
+
+	// Fallback: write a placeholder so the session file exists.
+	if err := os.WriteFile(cachePath, []byte("{}"), 0o600); err != nil {
 		return ""
 	}
-	return ref
+	return cachePath
 }
 
 // findVibeSessionRef finds the messages.jsonl file for a Vibe session by

--- a/agents/entire-agent-mistral-vibe/internal/vibe/hooks.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/hooks.go
@@ -1,0 +1,193 @@
+package vibe
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/entireio/external-agents/agents/entire-agent-mistral-vibe/internal/protocol"
+)
+
+const (
+	vibeConfigFile        = "config.toml"
+	vibeConfigDir         = ".vibe"
+	prodHookCommandBase   = "entire hooks mistral-vibe "
+	localDevCommandBase   = "go run ./cmd/entire/main.go hooks mistral-vibe "
+	hookMarker            = "entire hooks mistral-vibe"
+)
+
+// ParseHook parses a Vibe hook JSON payload and maps it to a protocol EventJSON.
+// Returns nil for hooks that do not produce protocol events (pre/post tool use).
+func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, error) {
+	var payload VibeHookPayload
+	if len(input) > 0 {
+		if err := json.Unmarshal(input, &payload); err != nil {
+			return nil, err
+		}
+	}
+
+	switch hookName {
+	case HookNameSessionStart:
+		sessionID := payload.SessionID
+		if sessionID == "" {
+			sessionID = fmt.Sprintf("vibe-%d", time.Now().UnixNano())
+		}
+		return &protocol.EventJSON{
+			Type:      1, // SessionStart
+			SessionID: sessionID,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+		}, nil
+
+	case HookNameUserPromptSubmit:
+		sessionID := payload.SessionID
+		if sessionID == "" {
+			sessionID = fmt.Sprintf("vibe-%d", time.Now().UnixNano())
+		}
+		return &protocol.EventJSON{
+			Type:      2, // TurnStart
+			SessionID: sessionID,
+			Prompt:    payload.Prompt,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+		}, nil
+
+	case HookNameTurnEnd:
+		sessionID := payload.SessionID
+		if sessionID == "" {
+			sessionID = fmt.Sprintf("vibe-%d", time.Now().UnixNano())
+		}
+		// Construct session_ref from the Vibe session log directory.
+		sessionRef := ""
+		if sessionID != "" {
+			home, err := os.UserHomeDir()
+			if err == nil {
+				sessionRef = filepath.Join(home, ".vibe", "logs", "session",
+					fmt.Sprintf("session_%s", sessionID[:min(8, len(sessionID))]),
+					"messages.jsonl")
+			}
+		}
+		return &protocol.EventJSON{
+			Type:       3, // TurnEnd
+			SessionID:  sessionID,
+			SessionRef: sessionRef,
+			Timestamp:  time.Now().UTC().Format(time.RFC3339),
+		}, nil
+
+	case HookNamePreToolUse, HookNamePostToolUse:
+		// Pre/post tool use hooks do not produce protocol events.
+		return nil, nil
+
+	default:
+		return nil, nil
+	}
+}
+
+// InstallHooks writes Vibe hook configuration entries to .vibe/config.toml
+// that point to the Entire CLI hook handler.
+func (a *Agent) InstallHooks(localDev bool, force bool) (int, error) {
+	repoRoot := protocol.RepoRoot()
+
+	if !force && a.AreHooksInstalled() {
+		return 0, nil
+	}
+
+	configDir := filepath.Join(repoRoot, vibeConfigDir)
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		return 0, fmt.Errorf("failed to create .vibe directory: %w", err)
+	}
+
+	commandBase := prodHookCommandBase
+	if localDev {
+		commandBase = localDevCommandBase
+	}
+
+	hookEntries := []struct {
+		nativeName  string
+		protocolName string
+	}{
+		{VibeNativeSessionStart, HookNameSessionStart},
+		{VibeNativeUserPromptSubmit, HookNameUserPromptSubmit},
+		{VibeNativePreToolUse, HookNamePreToolUse},
+		{VibeNativePostToolUse, HookNamePostToolUse},
+		{VibeNativeTurnEnd, HookNameTurnEnd},
+	}
+
+	var tomlLines []string
+	tomlLines = append(tomlLines, "# Entire CLI hook configuration")
+	tomlLines = append(tomlLines, "# Managed by entire-agent-mistral-vibe")
+	tomlLines = append(tomlLines, "")
+
+	for _, hook := range hookEntries {
+		tomlLines = append(tomlLines, fmt.Sprintf("[[hooks.%s]]", hook.nativeName))
+		tomlLines = append(tomlLines, fmt.Sprintf(`command = "%s%s"`, commandBase, hook.protocolName))
+		tomlLines = append(tomlLines, "")
+	}
+
+	configPath := filepath.Join(configDir, vibeConfigFile)
+	content := strings.Join(tomlLines, "\n")
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		return 0, fmt.Errorf("failed to write config.toml: %w", err)
+	}
+
+	return len(hookEntries), nil
+}
+
+// UninstallHooks removes the Entire CLI hook entries from .vibe/config.toml.
+func (a *Agent) UninstallHooks() error {
+	repoRoot := protocol.RepoRoot()
+	configPath := filepath.Join(repoRoot, vibeConfigDir, vibeConfigFile)
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	// Filter out lines containing the hook marker.
+	var filteredLines []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.Contains(line, hookMarker) {
+			continue
+		}
+		// Also skip comment lines managed by this agent.
+		if strings.Contains(line, "Managed by entire-agent-mistral-vibe") {
+			continue
+		}
+		if strings.Contains(line, "Entire CLI hook configuration") {
+			continue
+		}
+		filteredLines = append(filteredLines, line)
+	}
+
+	// If only whitespace/empty lines remain, remove the file entirely.
+	remaining := strings.TrimSpace(strings.Join(filteredLines, "\n"))
+	if remaining == "" || remaining == "[hooks]" {
+		return os.Remove(configPath)
+	}
+
+	return os.WriteFile(configPath, []byte(strings.Join(filteredLines, "\n")), 0o600)
+}
+
+// AreHooksInstalled checks whether .vibe/config.toml contains Entire CLI hook entries.
+func (a *Agent) AreHooksInstalled() bool {
+	repoRoot := protocol.RepoRoot()
+	configPath := filepath.Join(repoRoot, vibeConfigDir, vibeConfigFile)
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return false
+	}
+
+	return strings.Contains(string(data), hookMarker)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/agents/entire-agent-mistral-vibe/internal/vibe/hooks_test.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/hooks_test.go
@@ -1,0 +1,270 @@
+package vibe
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseHook_SessionStart(t *testing.T) {
+	agent := New()
+	payload := VibeHookPayload{
+		HookEventName: "session_start",
+		CWD:           "/tmp/test",
+		SessionID:     "0e9f7293-0151-4178-ba58-2c48c5abb8df",
+	}
+	input, _ := json.Marshal(payload)
+
+	event, err := agent.ParseHook(HookNameSessionStart, input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("event should not be nil")
+	}
+	if event.Type != 1 {
+		t.Errorf("type = %d, want 1", event.Type)
+	}
+	if event.SessionID != "0e9f7293-0151-4178-ba58-2c48c5abb8df" {
+		t.Errorf("session_id = %q, want %q", event.SessionID, "0e9f7293-0151-4178-ba58-2c48c5abb8df")
+	}
+	if event.Timestamp == "" {
+		t.Error("timestamp should be set")
+	}
+}
+
+func TestParseHook_UserPromptSubmit(t *testing.T) {
+	agent := New()
+	payload := VibeHookPayload{
+		HookEventName: "user_prompt_submit",
+		CWD:           "/tmp/test",
+		SessionID:     "test-session",
+		Prompt:        "fix the login bug",
+	}
+	input, _ := json.Marshal(payload)
+
+	event, err := agent.ParseHook(HookNameUserPromptSubmit, input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("event should not be nil")
+	}
+	if event.Type != 2 {
+		t.Errorf("type = %d, want 2", event.Type)
+	}
+	if event.Prompt != "fix the login bug" {
+		t.Errorf("prompt = %q, want %q", event.Prompt, "fix the login bug")
+	}
+}
+
+func TestParseHook_TurnEnd(t *testing.T) {
+	agent := New()
+	payload := VibeHookPayload{
+		HookEventName: "turn_end",
+		CWD:           "/tmp/test",
+		SessionID:     "0e9f7293-0151-4178-ba58-2c48c5abb8df",
+	}
+	input, _ := json.Marshal(payload)
+
+	event, err := agent.ParseHook(HookNameTurnEnd, input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("event should not be nil")
+	}
+	if event.Type != 3 {
+		t.Errorf("type = %d, want 3", event.Type)
+	}
+	if event.SessionID != "0e9f7293-0151-4178-ba58-2c48c5abb8df" {
+		t.Errorf("session_id = %q", event.SessionID)
+	}
+}
+
+func TestParseHook_PreToolUse_ReturnsNil(t *testing.T) {
+	agent := New()
+	payload := VibeHookPayload{
+		HookEventName: "pre_tool_use",
+		CWD:           "/tmp/test",
+		SessionID:     "test",
+		ToolName:      "write_file",
+	}
+	input, _ := json.Marshal(payload)
+
+	event, err := agent.ParseHook(HookNamePreToolUse, input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event != nil {
+		t.Errorf("pre-tool-use should return nil, got type=%d", event.Type)
+	}
+}
+
+func TestParseHook_PostToolUse_ReturnsNil(t *testing.T) {
+	agent := New()
+	payload := VibeHookPayload{
+		HookEventName: "post_tool_use",
+		CWD:           "/tmp/test",
+		SessionID:     "test",
+		ToolName:      "write_file",
+		ToolOutcome:   "success",
+	}
+	input, _ := json.Marshal(payload)
+
+	event, err := agent.ParseHook(HookNamePostToolUse, input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event != nil {
+		t.Errorf("post-tool-use should return nil, got type=%d", event.Type)
+	}
+}
+
+func TestParseHook_EmptyInput(t *testing.T) {
+	agent := New()
+	event, err := agent.ParseHook(HookNameSessionStart, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("session-start with empty input should still return an event")
+	}
+	if event.SessionID == "" {
+		t.Error("session_id should be generated")
+	}
+}
+
+func TestParseHook_UnknownHook(t *testing.T) {
+	agent := New()
+	event, err := agent.ParseHook("unknown-hook", []byte("{}"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event != nil {
+		t.Error("unknown hook should return nil")
+	}
+}
+
+func TestParseHook_MalformedJSON(t *testing.T) {
+	agent := New()
+	_, err := agent.ParseHook(HookNameSessionStart, []byte("not json"))
+	if err == nil {
+		t.Error("expected error for malformed JSON")
+	}
+}
+
+func TestInstallHooks(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", dir)
+
+	agent := New()
+	count, err := agent.InstallHooks(false, false)
+	if err != nil {
+		t.Fatalf("install error: %v", err)
+	}
+	if count != 5 {
+		t.Errorf("hooks_installed = %d, want 5", count)
+	}
+
+	configPath := filepath.Join(dir, ".vibe", "config.toml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	content := string(data)
+
+	for _, hook := range []string{"session_start", "user_prompt_submit", "pre_tool_use", "post_tool_use", "turn_end"} {
+		if !strings.Contains(content, "[[hooks."+hook+"]]") {
+			t.Errorf("config should contain [[hooks.%s]]", hook)
+		}
+	}
+	if !strings.Contains(content, "entire hooks mistral-vibe") {
+		t.Error("config should contain hook command")
+	}
+}
+
+func TestInstallHooks_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", dir)
+
+	agent := New()
+	agent.InstallHooks(false, false)
+
+	count, err := agent.InstallHooks(false, false)
+	if err != nil {
+		t.Fatalf("second install error: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("second install should return 0, got %d", count)
+	}
+}
+
+func TestInstallHooks_LocalDev(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", dir)
+
+	agent := New()
+	agent.InstallHooks(true, true)
+
+	data, err := os.ReadFile(filepath.Join(dir, ".vibe", "config.toml"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !strings.Contains(string(data), "go run") {
+		t.Error("local-dev mode should use 'go run' command")
+	}
+}
+
+func TestUninstallHooks(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", dir)
+
+	agent := New()
+	agent.InstallHooks(false, false)
+
+	if !agent.AreHooksInstalled() {
+		t.Fatal("hooks should be installed")
+	}
+
+	err := agent.UninstallHooks()
+	if err != nil {
+		t.Fatalf("uninstall error: %v", err)
+	}
+
+	if agent.AreHooksInstalled() {
+		t.Error("hooks should not be installed after uninstall")
+	}
+}
+
+func TestAreHooksInstalled_NoConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", dir)
+
+	agent := New()
+	if agent.AreHooksInstalled() {
+		t.Error("should return false when no config exists")
+	}
+}
+
+func TestNativeToProtocolHookMapping(t *testing.T) {
+	expected := map[string]string{
+		"session_start":      "session-start",
+		"user_prompt_submit": "user-prompt-submit",
+		"pre_tool_use":       "pre-tool-use",
+		"post_tool_use":      "post-tool-use",
+		"turn_end":           "turn-end",
+	}
+	for native, protocol := range expected {
+		got, ok := NativeToProtocolHook[native]
+		if !ok {
+			t.Errorf("missing mapping for %q", native)
+			continue
+		}
+		if got != protocol {
+			t.Errorf("NativeToProtocolHook[%q] = %q, want %q", native, got, protocol)
+		}
+	}
+}

--- a/agents/entire-agent-mistral-vibe/internal/vibe/hooks_test.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/hooks_test.go
@@ -24,8 +24,8 @@ func TestParseHook_SessionStart(t *testing.T) {
 	if event == nil {
 		t.Fatal("event should not be nil")
 	}
-	if event.Type != 1 {
-		t.Errorf("type = %d, want 1", event.Type)
+	if event.Type != EventTypeSessionStart {
+		t.Errorf("type = %d, want %d", event.Type, EventTypeSessionStart)
 	}
 	if event.SessionID != "0e9f7293-0151-4178-ba58-2c48c5abb8df" {
 		t.Errorf("session_id = %q, want %q", event.SessionID, "0e9f7293-0151-4178-ba58-2c48c5abb8df")
@@ -52,8 +52,8 @@ func TestParseHook_UserPromptSubmit(t *testing.T) {
 	if event == nil {
 		t.Fatal("event should not be nil")
 	}
-	if event.Type != 2 {
-		t.Errorf("type = %d, want 2", event.Type)
+	if event.Type != EventTypeTurnStart {
+		t.Errorf("type = %d, want %d", event.Type, EventTypeTurnStart)
 	}
 	if event.Prompt != "fix the login bug" {
 		t.Errorf("prompt = %q, want %q", event.Prompt, "fix the login bug")
@@ -79,8 +79,8 @@ func TestParseHook_TurnEnd(t *testing.T) {
 	if event == nil {
 		t.Fatal("event should not be nil")
 	}
-	if event.Type != 3 {
-		t.Errorf("type = %d, want 3", event.Type)
+	if event.Type != EventTypeTurnEnd {
+		t.Errorf("type = %d, want %d", event.Type, EventTypeTurnEnd)
 	}
 	if event.SessionID != "0e9f7293-0151-4178-ba58-2c48c5abb8df" {
 		t.Errorf("session_id = %q", event.SessionID)
@@ -279,22 +279,3 @@ func TestAreHooksInstalled_NoConfig(t *testing.T) {
 	}
 }
 
-func TestNativeToProtocolHookMapping(t *testing.T) {
-	expected := map[string]string{
-		"session_start":      "session-start",
-		"user_prompt_submit": "user-prompt-submit",
-		"pre_tool_use":       "pre-tool-use",
-		"post_tool_use":      "post-tool-use",
-		"turn_end":           "turn-end",
-	}
-	for native, protocol := range expected {
-		got, ok := NativeToProtocolHook[native]
-		if !ok {
-			t.Errorf("missing mapping for %q", native)
-			continue
-		}
-		if got != protocol {
-			t.Errorf("NativeToProtocolHook[%q] = %q, want %q", native, got, protocol)
-		}
-	}
-}

--- a/agents/entire-agent-mistral-vibe/internal/vibe/hooks_test.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/hooks_test.go
@@ -8,6 +8,14 @@ import (
 	"testing"
 )
 
+func setHookTestEnv(t *testing.T, repoRoot string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repoRoot)
+	t.Setenv("HOME", home)
+	return home
+}
+
 func TestParseHook_SessionStart(t *testing.T) {
 	agent := New()
 	payload := VibeHookPayload{
@@ -62,7 +70,7 @@ func TestParseHook_UserPromptSubmit(t *testing.T) {
 
 func TestParseHook_TurnEnd(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("ENTIRE_REPO_ROOT", dir)
+	setHookTestEnv(t, dir)
 
 	agent := New()
 	payload := VibeHookPayload{
@@ -92,7 +100,7 @@ func TestParseHook_TurnEnd(t *testing.T) {
 
 func TestCacheTranscriptForTurnEnd_Placeholder(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("ENTIRE_REPO_ROOT", dir)
+	setHookTestEnv(t, dir)
 
 	agent := New()
 	ref := agent.cacheTranscriptForTurnEnd("test-session-123")
@@ -188,7 +196,7 @@ func TestParseHook_MalformedJSON(t *testing.T) {
 
 func TestInstallHooks(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("ENTIRE_REPO_ROOT", dir)
+	setHookTestEnv(t, dir)
 
 	agent := New()
 	count, err := agent.InstallHooks(false, false)
@@ -218,7 +226,7 @@ func TestInstallHooks(t *testing.T) {
 
 func TestInstallHooks_Idempotent(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("ENTIRE_REPO_ROOT", dir)
+	setHookTestEnv(t, dir)
 
 	agent := New()
 	agent.InstallHooks(false, false)
@@ -234,7 +242,7 @@ func TestInstallHooks_Idempotent(t *testing.T) {
 
 func TestInstallHooks_LocalDev(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("ENTIRE_REPO_ROOT", dir)
+	setHookTestEnv(t, dir)
 
 	agent := New()
 	agent.InstallHooks(true, true)
@@ -250,7 +258,7 @@ func TestInstallHooks_LocalDev(t *testing.T) {
 
 func TestUninstallHooks(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("ENTIRE_REPO_ROOT", dir)
+	setHookTestEnv(t, dir)
 
 	agent := New()
 	agent.InstallHooks(false, false)
@@ -271,7 +279,7 @@ func TestUninstallHooks(t *testing.T) {
 
 func TestAreHooksInstalled_NoConfig(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("ENTIRE_REPO_ROOT", dir)
+	setHookTestEnv(t, dir)
 
 	agent := New()
 	if agent.AreHooksInstalled() {
@@ -279,3 +287,106 @@ func TestAreHooksInstalled_NoConfig(t *testing.T) {
 	}
 }
 
+func TestInstallHooks_PreservesExistingConfigAndTrustFile(t *testing.T) {
+	dir := t.TempDir()
+	home := setHookTestEnv(t, dir)
+
+	configPath := filepath.Join(dir, ".vibe", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	originalConfig := strings.Join([]string{
+		`model = "mistral-large"`,
+		`[ui]`,
+		`theme = "solarized"`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(configPath, []byte(originalConfig), 0o600); err != nil {
+		t.Fatalf("write original config: %v", err)
+	}
+
+	trustPath := filepath.Join(home, ".vibe", "trusted_folders.toml")
+	if err := os.MkdirAll(filepath.Dir(trustPath), 0o700); err != nil {
+		t.Fatalf("mkdir trust dir: %v", err)
+	}
+	originalTrust := "trusted = [\n    \"/already/trusted\",\n]\nuntrusted = [\n    \"/keep/me\",\n]\n"
+	if err := os.WriteFile(trustPath, []byte(originalTrust), 0o600); err != nil {
+		t.Fatalf("write original trust file: %v", err)
+	}
+
+	agent := New()
+	if _, err := agent.InstallHooks(false, false); err != nil {
+		t.Fatalf("InstallHooks() error = %v", err)
+	}
+
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	config := string(configData)
+	if !strings.Contains(config, `model = "mistral-large"`) {
+		t.Fatal("expected existing config to be preserved")
+	}
+	if !strings.Contains(config, `theme = "solarized"`) {
+		t.Fatal("expected existing nested config to be preserved")
+	}
+	if !strings.Contains(config, "entire hooks mistral-vibe session-start") {
+		t.Fatal("expected managed hooks to be installed")
+	}
+
+	trustData, err := os.ReadFile(trustPath)
+	if err != nil {
+		t.Fatalf("read trust file: %v", err)
+	}
+	trust := string(trustData)
+	if !strings.Contains(trust, `"/already/trusted"`) {
+		t.Fatal("expected existing trusted path to be preserved")
+	}
+	if !strings.Contains(trust, `"/keep/me"`) {
+		t.Fatal("expected existing untrusted path to be preserved")
+	}
+	if !strings.Contains(trust, dir) {
+		t.Fatal("expected repo path to be added to trusted paths")
+	}
+}
+
+func TestUninstallHooks_RemovesManagedBlockOnly(t *testing.T) {
+	dir := t.TempDir()
+	setHookTestEnv(t, dir)
+
+	configPath := filepath.Join(dir, ".vibe", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	originalConfig := strings.Join([]string{
+		`model = "mistral-large"`,
+		`[ui]`,
+		`theme = "solarized"`,
+		`[[hooks.custom_hook]]`,
+		`command = "custom-hook"`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(configPath, []byte(originalConfig), 0o600); err != nil {
+		t.Fatalf("write original config: %v", err)
+	}
+
+	agent := New()
+	if _, err := agent.InstallHooks(false, false); err != nil {
+		t.Fatalf("InstallHooks() error = %v", err)
+	}
+	if err := agent.UninstallHooks(); err != nil {
+		t.Fatalf("UninstallHooks() error = %v", err)
+	}
+
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after uninstall: %v", err)
+	}
+	config := string(configData)
+	if config != originalConfig {
+		t.Fatalf("config after uninstall = %q, want %q", config, originalConfig)
+	}
+	if strings.Contains(config, "entire hooks mistral-vibe") {
+		t.Fatal("managed hook commands should be removed")
+	}
+}

--- a/agents/entire-agent-mistral-vibe/internal/vibe/hooks_test.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/hooks_test.go
@@ -90,19 +90,19 @@ func TestParseHook_TurnEnd(t *testing.T) {
 	}
 }
 
-func TestEnsurePlaceholderTranscript(t *testing.T) {
+func TestCacheTranscriptForTurnEnd_Placeholder(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("ENTIRE_REPO_ROOT", dir)
 
 	agent := New()
-	ref := agent.ensurePlaceholderTranscript("test-session-123")
+	ref := agent.cacheTranscriptForTurnEnd("test-session-123")
 	if ref == "" {
-		t.Fatal("placeholder ref should not be empty")
+		t.Fatal("cache ref should not be empty")
 	}
 
 	data, err := os.ReadFile(ref)
 	if err != nil {
-		t.Fatalf("read placeholder: %v", err)
+		t.Fatalf("read cached transcript: %v", err)
 	}
 	if string(data) != "{}" {
 		t.Errorf("placeholder content = %q, want %q", data, "{}")

--- a/agents/entire-agent-mistral-vibe/internal/vibe/hooks_test.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/hooks_test.go
@@ -61,10 +61,13 @@ func TestParseHook_UserPromptSubmit(t *testing.T) {
 }
 
 func TestParseHook_TurnEnd(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", dir)
+
 	agent := New()
 	payload := VibeHookPayload{
 		HookEventName: "turn_end",
-		CWD:           "/tmp/test",
+		CWD:           dir,
 		SessionID:     "0e9f7293-0151-4178-ba58-2c48c5abb8df",
 	}
 	input, _ := json.Marshal(payload)
@@ -81,6 +84,33 @@ func TestParseHook_TurnEnd(t *testing.T) {
 	}
 	if event.SessionID != "0e9f7293-0151-4178-ba58-2c48c5abb8df" {
 		t.Errorf("session_id = %q", event.SessionID)
+	}
+	if event.SessionRef == "" {
+		t.Error("session_ref should not be empty (placeholder should be created)")
+	}
+}
+
+func TestEnsurePlaceholderTranscript(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", dir)
+
+	agent := New()
+	ref := agent.ensurePlaceholderTranscript("test-session-123")
+	if ref == "" {
+		t.Fatal("placeholder ref should not be empty")
+	}
+
+	data, err := os.ReadFile(ref)
+	if err != nil {
+		t.Fatalf("read placeholder: %v", err)
+	}
+	if string(data) != "{}" {
+		t.Errorf("placeholder content = %q, want %q", data, "{}")
+	}
+
+	want := filepath.Join(dir, ".entire", "tmp", "test-session-123.json")
+	if ref != want {
+		t.Errorf("ref = %q, want %q", ref, want)
 	}
 }
 

--- a/agents/entire-agent-mistral-vibe/internal/vibe/transcript.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/transcript.go
@@ -1,0 +1,201 @@
+package vibe
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"strings"
+)
+
+// vibeFileModificationTools lists the Vibe tool names that modify files.
+var vibeFileModificationTools = map[string]struct{}{
+	"write_file":     {},
+	"search_replace": {},
+	"create_file":    {},
+	"edit_file":      {},
+}
+
+// GetTranscriptPosition returns the number of lines (messages) in the JSONL
+// transcript at the given path.
+func (a *Agent) GetTranscriptPosition(path string) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	defer f.Close()
+
+	count := 0
+	scanner := bufio.NewScanner(f)
+	// Increase buffer size for potentially large JSONL lines.
+	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			count++
+		}
+	}
+	return count, scanner.Err()
+}
+
+// ExtractModifiedFiles scans the JSONL transcript for tool calls that modify
+// files (write_file, search_replace, etc.) and returns the list of file paths.
+func (a *Agent) ExtractModifiedFiles(path string, offset int) ([]string, int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, 0, nil
+		}
+		return nil, 0, err
+	}
+	defer f.Close()
+
+	seen := make(map[string]bool)
+	var files []string
+	lineNum := 0
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		lineNum++
+		if lineNum <= offset {
+			continue
+		}
+
+		var msg VibeMessage
+		if err := json.Unmarshal([]byte(line), &msg); err != nil {
+			continue
+		}
+
+		for _, tc := range msg.ToolCalls {
+			if !isVibeFileModificationTool(tc.Function.Name) {
+				continue
+			}
+			filePath := extractVibeFilePath(tc.Function.Arguments)
+			if filePath != "" && !seen[filePath] {
+				seen[filePath] = true
+				files = append(files, filePath)
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, 0, err
+	}
+	return files, lineNum, nil
+}
+
+// ExtractPrompts filters the JSONL transcript for user messages and returns
+// their content strings.
+func (a *Agent) ExtractPrompts(sessionRef string, offset int) ([]string, error) {
+	f, err := os.Open(sessionRef)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var prompts []string
+	lineNum := 0
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		lineNum++
+		if lineNum <= offset {
+			continue
+		}
+
+		var msg VibeMessage
+		if err := json.Unmarshal([]byte(line), &msg); err != nil {
+			continue
+		}
+
+		if msg.Role == "user" && msg.Content != "" {
+			prompts = append(prompts, msg.Content)
+		}
+	}
+
+	return prompts, scanner.Err()
+}
+
+// ExtractSummary returns the content of the last assistant message in the
+// JSONL transcript as a summary.
+func (a *Agent) ExtractSummary(sessionRef string) (string, bool, error) {
+	f, err := os.Open(sessionRef)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	defer f.Close()
+
+	var lastAssistantContent string
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		var msg VibeMessage
+		if err := json.Unmarshal([]byte(line), &msg); err != nil {
+			continue
+		}
+
+		if msg.Role == "assistant" && msg.Content != "" {
+			lastAssistantContent = msg.Content
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", false, err
+	}
+
+	return lastAssistantContent, lastAssistantContent != "", nil
+}
+
+// isVibeFileModificationTool returns true if the tool name modifies files.
+func isVibeFileModificationTool(name string) bool {
+	_, ok := vibeFileModificationTools[name]
+	return ok
+}
+
+// extractVibeFilePath extracts a file path from a tool call's arguments JSON string.
+func extractVibeFilePath(argsStr string) string {
+	if argsStr == "" {
+		return ""
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(argsStr), &fields); err != nil {
+		return ""
+	}
+
+	for _, key := range []string{"path", "file_path", "filename", "file"} {
+		raw, ok := fields[key]
+		if !ok {
+			continue
+		}
+		var path string
+		if err := json.Unmarshal(raw, &path); err == nil && path != "" {
+			return path
+		}
+	}
+	return ""
+}

--- a/agents/entire-agent-mistral-vibe/internal/vibe/transcript.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/transcript.go
@@ -13,6 +13,7 @@ var vibeFileModificationTools = map[string]struct{}{
 	"search_replace": {},
 	"create_file":    {},
 	"edit_file":      {},
+	"bash":           {},
 }
 
 // GetTranscriptPosition returns the number of lines (messages) in the JSONL
@@ -196,6 +197,38 @@ func extractVibeFilePath(argsStr string) string {
 		if err := json.Unmarshal(raw, &path); err == nil && path != "" {
 			return path
 		}
+	}
+	for _, key := range []string{"command", "cmd", "bash_command", "shell_command"} {
+		raw, ok := fields[key]
+		if !ok {
+			continue
+		}
+		var command string
+		if err := json.Unmarshal(raw, &command); err == nil {
+			if path := extractVibeFilePathFromCommand(command); path != "" {
+				return path
+			}
+		}
+	}
+	return ""
+}
+
+func extractVibeFilePathFromCommand(command string) string {
+	if command == "" {
+		return ""
+	}
+
+	tokens := strings.Fields(command)
+	for i, token := range tokens {
+		switch token {
+		case ">", ">>", "1>", "1>>":
+			if i+1 < len(tokens) {
+				return strings.Trim(tokens[i+1], `"'`)
+			}
+		}
+	}
+	if len(tokens) >= 2 && tokens[0] == "touch" {
+		return strings.Trim(tokens[1], `"'`)
 	}
 	return ""
 }

--- a/agents/entire-agent-mistral-vibe/internal/vibe/transcript_test.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/transcript_test.go
@@ -113,6 +113,32 @@ func TestExtractModifiedFiles_MissingFile(t *testing.T) {
 	}
 }
 
+func TestExtractModifiedFiles_BashTool(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bash.jsonl")
+	content := strings.Join([]string{
+		`{"role":"user","content":"make a file"}`,
+		`{"role":"assistant","tool_calls":[{"id":"call-1","index":0,"function":{"name":"bash","arguments":"{\"command\":\"touch bash-created.txt\"}"},"type":"function"}]}`,
+		`{"role":"tool","content":"done","name":"bash","tool_call_id":"call-1"}`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	agent := New()
+	files, pos, err := agent.ExtractModifiedFiles(path, 0)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(files) != 1 || files[0] != "bash-created.txt" {
+		t.Fatalf("files = %v, want [bash-created.txt]", files)
+	}
+	if pos != 3 {
+		t.Fatalf("position = %d, want 3", pos)
+	}
+}
+
 func TestExtractPrompts(t *testing.T) {
 	dir := t.TempDir()
 	path := writeGoldenJSONL(t, dir)
@@ -207,12 +233,14 @@ func TestExtractSummary_MissingFile(t *testing.T) {
 
 func TestExtractVibeFilePath(t *testing.T) {
 	tests := []struct {
-		name     string
-		argsStr  string
-		want     string
+		name    string
+		argsStr string
+		want    string
 	}{
 		{"path_key", `{"path":"hello.go","content":"test"}`, "hello.go"},
 		{"file_path_key", `{"file_path":"/src/main.py"}`, "/src/main.py"},
+		{"bash_command_touch", `{"command":"touch bash-created.txt"}`, "bash-created.txt"},
+		{"bash_command_redirect", `{"command":"echo hello > out.txt"}`, "out.txt"},
 		{"empty_args", ``, ""},
 		{"no_path_keys", `{"content":"test"}`, ""},
 		{"malformed_json", `not json`, ""},
@@ -228,12 +256,12 @@ func TestExtractVibeFilePath(t *testing.T) {
 }
 
 func TestIsVibeFileModificationTool(t *testing.T) {
-	for _, tool := range []string{"write_file", "search_replace", "create_file", "edit_file"} {
+	for _, tool := range []string{"write_file", "search_replace", "create_file", "edit_file", "bash"} {
 		if !isVibeFileModificationTool(tool) {
 			t.Errorf("%q should be a file modification tool", tool)
 		}
 	}
-	for _, tool := range []string{"bash", "grep", "read_file", "web_search"} {
+	for _, tool := range []string{"grep", "read_file", "web_search"} {
 		if isVibeFileModificationTool(tool) {
 			t.Errorf("%q should not be a file modification tool", tool)
 		}

--- a/agents/entire-agent-mistral-vibe/internal/vibe/transcript_test.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/transcript_test.go
@@ -1,0 +1,255 @@
+package vibe
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Golden JSONL data based on real Vibe session captures.
+const goldenJSONL = `{"role":"user","content":"hello","message_id":"0801cd87-2d71-4a2d-8085-a3104102f506"}
+{"role":"assistant","content":"Hello! How can I assist you today?","message_id":"61c28fc6-f14e-4370-886d-5ee3c2f5e87a"}
+{"role":"user","content":"what is 2+2","message_id":"81b13e7a-036e-42a0-a9f4-d314660618a2"}
+{"role":"assistant","content":"4","message_id":"13c64d77-0c40-4014-adc8-dfe58d81cf1c"}
+{"role":"user","content":"can you create hello world golang","message_id":"5bf535d7-cb5c-45f6-8872-3ba26703475a"}
+{"role":"assistant","tool_calls":[{"id":"g4WVM7SD2","index":0,"function":{"name":"write_file","arguments":"{\"path\":\"hello.go\",\"content\":\"package main\\n\\nimport \\\"fmt\\\"\\n\\nfunc main() {\\n\\tfmt.Println(\\\"Hello, World!\\\")\\n}\"}"},"type":"function"}],"message_id":"61dec2f6-920a-4c66-9b67-a92dbff14fb5"}
+{"role":"tool","content":"path: /Users/test/hello.go\nbytes_written: 73","name":"write_file","tool_call_id":"g4WVM7SD2"}
+{"role":"assistant","content":"Created hello.go with Hello World in Go.","message_id":"3cac263a-e70d-4cf9-b765-170f4d54a830"}
+`
+
+func writeGoldenJSONL(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "messages.jsonl")
+	if err := os.WriteFile(path, []byte(goldenJSONL), 0o600); err != nil {
+		t.Fatalf("write golden JSONL: %v", err)
+	}
+	return path
+}
+
+func TestGetTranscriptPosition(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGoldenJSONL(t, dir)
+
+	agent := New()
+	pos, err := agent.GetTranscriptPosition(path)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if pos != 8 {
+		t.Errorf("position = %d, want 8", pos)
+	}
+}
+
+func TestGetTranscriptPosition_MissingFile(t *testing.T) {
+	agent := New()
+	pos, err := agent.GetTranscriptPosition("/nonexistent/path.jsonl")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if pos != 0 {
+		t.Errorf("position for missing file = %d, want 0", pos)
+	}
+}
+
+func TestGetTranscriptPosition_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.jsonl")
+	os.WriteFile(path, []byte(""), 0o600)
+
+	agent := New()
+	pos, err := agent.GetTranscriptPosition(path)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if pos != 0 {
+		t.Errorf("position for empty file = %d, want 0", pos)
+	}
+}
+
+func TestExtractModifiedFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGoldenJSONL(t, dir)
+
+	agent := New()
+	files, pos, err := agent.ExtractModifiedFiles(path, 0)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(files) != 1 {
+		t.Errorf("files count = %d, want 1: %v", len(files), files)
+	}
+	if len(files) > 0 && files[0] != "hello.go" {
+		t.Errorf("files[0] = %q, want %q", files[0], "hello.go")
+	}
+	if pos != 8 {
+		t.Errorf("current_position = %d, want 8", pos)
+	}
+}
+
+func TestExtractModifiedFiles_WithOffset(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGoldenJSONL(t, dir)
+
+	agent := New()
+	// Offset 7 skips past the tool call line
+	files, _, err := agent.ExtractModifiedFiles(path, 7)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(files) != 0 {
+		t.Errorf("files count with offset 7 = %d, want 0: %v", len(files), files)
+	}
+}
+
+func TestExtractModifiedFiles_MissingFile(t *testing.T) {
+	agent := New()
+	files, pos, err := agent.ExtractModifiedFiles("/nonexistent.jsonl", 0)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(files) != 0 || pos != 0 {
+		t.Errorf("files=%v, pos=%d for missing file", files, pos)
+	}
+}
+
+func TestExtractPrompts(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGoldenJSONL(t, dir)
+
+	agent := New()
+	prompts, err := agent.ExtractPrompts(path, 0)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(prompts) != 3 {
+		t.Errorf("prompts count = %d, want 3: %v", len(prompts), prompts)
+	}
+	expected := []string{"hello", "what is 2+2", "can you create hello world golang"}
+	for i, want := range expected {
+		if i < len(prompts) && prompts[i] != want {
+			t.Errorf("prompts[%d] = %q, want %q", i, prompts[i], want)
+		}
+	}
+}
+
+func TestExtractPrompts_WithOffset(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGoldenJSONL(t, dir)
+
+	agent := New()
+	// Offset 4 skips first 4 lines (user, assistant, user, assistant)
+	prompts, err := agent.ExtractPrompts(path, 4)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(prompts) != 1 {
+		t.Errorf("prompts count = %d, want 1: %v", len(prompts), prompts)
+	}
+}
+
+func TestExtractPrompts_MissingFile(t *testing.T) {
+	agent := New()
+	prompts, err := agent.ExtractPrompts("/nonexistent.jsonl", 0)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(prompts) != 0 {
+		t.Errorf("prompts for missing file = %v", prompts)
+	}
+}
+
+func TestExtractSummary(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGoldenJSONL(t, dir)
+
+	agent := New()
+	summary, hasSummary, err := agent.ExtractSummary(path)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !hasSummary {
+		t.Error("has_summary should be true")
+	}
+	if summary != "Created hello.go with Hello World in Go." {
+		t.Errorf("summary = %q, want %q", summary, "Created hello.go with Hello World in Go.")
+	}
+}
+
+func TestExtractSummary_NoAssistantMessages(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "user-only.jsonl")
+	os.WriteFile(path, []byte(`{"role":"user","content":"hello"}`+"\n"), 0o600)
+
+	agent := New()
+	summary, hasSummary, err := agent.ExtractSummary(path)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if hasSummary {
+		t.Error("has_summary should be false for user-only transcript")
+	}
+	if summary != "" {
+		t.Errorf("summary = %q, want empty", summary)
+	}
+}
+
+func TestExtractSummary_MissingFile(t *testing.T) {
+	agent := New()
+	_, hasSummary, err := agent.ExtractSummary("/nonexistent.jsonl")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if hasSummary {
+		t.Error("has_summary should be false for missing file")
+	}
+}
+
+func TestExtractVibeFilePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		argsStr  string
+		want     string
+	}{
+		{"path_key", `{"path":"hello.go","content":"test"}`, "hello.go"},
+		{"file_path_key", `{"file_path":"/src/main.py"}`, "/src/main.py"},
+		{"empty_args", ``, ""},
+		{"no_path_keys", `{"content":"test"}`, ""},
+		{"malformed_json", `not json`, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractVibeFilePath(tc.argsStr)
+			if got != tc.want {
+				t.Errorf("extractVibeFilePath(%q) = %q, want %q", tc.argsStr, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsVibeFileModificationTool(t *testing.T) {
+	for _, tool := range []string{"write_file", "search_replace", "create_file", "edit_file"} {
+		if !isVibeFileModificationTool(tool) {
+			t.Errorf("%q should be a file modification tool", tool)
+		}
+	}
+	for _, tool := range []string{"bash", "grep", "read_file", "web_search"} {
+		if isVibeFileModificationTool(tool) {
+			t.Errorf("%q should not be a file modification tool", tool)
+		}
+	}
+}
+
+func TestReadTranscript(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGoldenJSONL(t, dir)
+
+	agent := New()
+	data, err := agent.ReadTranscript(path)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !strings.Contains(string(data), "hello") {
+		t.Error("transcript should contain 'hello'")
+	}
+}

--- a/agents/entire-agent-mistral-vibe/internal/vibe/types.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/types.go
@@ -1,0 +1,88 @@
+package vibe
+
+import "encoding/json"
+
+// Protocol hook names (kebab-case, used by the Entire CLI protocol).
+const (
+	HookNameSessionStart      = "session-start"
+	HookNameUserPromptSubmit  = "user-prompt-submit"
+	HookNamePreToolUse        = "pre-tool-use"
+	HookNamePostToolUse       = "post-tool-use"
+	HookNameTurnEnd           = "turn-end"
+)
+
+// Vibe native hook names (underscore, used by Vibe internally).
+const (
+	VibeNativeSessionStart     = "session_start"
+	VibeNativeUserPromptSubmit = "user_prompt_submit"
+	VibeNativePreToolUse       = "pre_tool_use"
+	VibeNativePostToolUse      = "post_tool_use"
+	VibeNativeTurnEnd          = "turn_end"
+)
+
+// NativeToProtocolHook maps Vibe's native underscore hook names to the
+// kebab-case protocol hook names used by the Entire CLI.
+var NativeToProtocolHook = map[string]string{
+	VibeNativeSessionStart:     HookNameSessionStart,
+	VibeNativeUserPromptSubmit: HookNameUserPromptSubmit,
+	VibeNativePreToolUse:       HookNamePreToolUse,
+	VibeNativePostToolUse:      HookNamePostToolUse,
+	VibeNativeTurnEnd:          HookNameTurnEnd,
+}
+
+// VibeHookPayload is the JSON payload Vibe sends on stdin for lifecycle hooks.
+type VibeHookPayload struct {
+	HookEventName string          `json:"hook_event_name"`
+	CWD           string          `json:"cwd"`
+	SessionID     string          `json:"session_id"`
+	Prompt        string          `json:"prompt,omitempty"`
+	ToolName      string          `json:"tool_name,omitempty"`
+	ToolInput     json.RawMessage `json:"tool_input,omitempty"`
+	ToolOutcome   string          `json:"tool_outcome,omitempty"`
+	ToolResponse  json.RawMessage `json:"tool_response,omitempty"`
+	ToolError     string          `json:"tool_error,omitempty"`
+}
+
+// VibeMessage represents a single line in the Vibe JSONL transcript.
+type VibeMessage struct {
+	Role       string         `json:"role"`
+	Content    string         `json:"content"`
+	ToolCalls  []VibeToolCall `json:"tool_calls,omitempty"`
+	MessageID  string         `json:"message_id,omitempty"`
+	Name       string         `json:"name,omitempty"`
+	ToolCallID string         `json:"tool_call_id,omitempty"`
+}
+
+// VibeToolCall represents a tool invocation within a Vibe transcript message.
+type VibeToolCall struct {
+	ID       string           `json:"id"`
+	Index    int              `json:"index"`
+	Function VibeToolFunction `json:"function"`
+	Type     string           `json:"type"`
+}
+
+// VibeToolFunction holds the function name and arguments for a tool call.
+type VibeToolFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+// VibeSessionMeta represents the meta.json file in a Vibe session directory.
+type VibeSessionMeta struct {
+	SessionID     string           `json:"session_id"`
+	StartTime     string           `json:"start_time"`
+	EndTime       string           `json:"end_time,omitempty"`
+	Title         string           `json:"title,omitempty"`
+	TotalMessages int              `json:"total_messages"`
+	GitCommit     string           `json:"git_commit,omitempty"`
+	GitBranch     string           `json:"git_branch,omitempty"`
+	Environment   string           `json:"environment,omitempty"`
+	Stats         VibeSessionStats `json:"stats,omitempty"`
+}
+
+// VibeSessionStats holds aggregate statistics for a Vibe session.
+type VibeSessionStats struct {
+	TotalTokens  int `json:"total_tokens,omitempty"`
+	PromptTokens int `json:"prompt_tokens,omitempty"`
+	OutputTokens int `json:"output_tokens,omitempty"`
+}

--- a/agents/entire-agent-mistral-vibe/internal/vibe/types.go
+++ b/agents/entire-agent-mistral-vibe/internal/vibe/types.go
@@ -2,6 +2,13 @@ package vibe
 
 import "encoding/json"
 
+// Event types for the Entire CLI protocol.
+const (
+	EventTypeSessionStart = 1
+	EventTypeTurnStart    = 2
+	EventTypeTurnEnd      = 3
+)
+
 // Protocol hook names (kebab-case, used by the Entire CLI protocol).
 const (
 	HookNameSessionStart      = "session-start"
@@ -19,16 +26,6 @@ const (
 	VibeNativePostToolUse      = "post_tool_use"
 	VibeNativeTurnEnd          = "turn_end"
 )
-
-// NativeToProtocolHook maps Vibe's native underscore hook names to the
-// kebab-case protocol hook names used by the Entire CLI.
-var NativeToProtocolHook = map[string]string{
-	VibeNativeSessionStart:     HookNameSessionStart,
-	VibeNativeUserPromptSubmit: HookNameUserPromptSubmit,
-	VibeNativePreToolUse:       HookNamePreToolUse,
-	VibeNativePostToolUse:      HookNamePostToolUse,
-	VibeNativeTurnEnd:          HookNameTurnEnd,
-}
 
 // VibeHookPayload is the JSON payload Vibe sends on stdin for lifecycle hooks.
 type VibeHookPayload struct {
@@ -67,22 +64,3 @@ type VibeToolFunction struct {
 	Arguments string `json:"arguments"`
 }
 
-// VibeSessionMeta represents the meta.json file in a Vibe session directory.
-type VibeSessionMeta struct {
-	SessionID     string           `json:"session_id"`
-	StartTime     string           `json:"start_time"`
-	EndTime       string           `json:"end_time,omitempty"`
-	Title         string           `json:"title,omitempty"`
-	TotalMessages int              `json:"total_messages"`
-	GitCommit     string           `json:"git_commit,omitempty"`
-	GitBranch     string           `json:"git_branch,omitempty"`
-	Environment   string           `json:"environment,omitempty"`
-	Stats         VibeSessionStats `json:"stats,omitempty"`
-}
-
-// VibeSessionStats holds aggregate statistics for a Vibe session.
-type VibeSessionStats struct {
-	TotalTokens  int `json:"total_tokens,omitempty"`
-	PromptTokens int `json:"prompt_tokens,omitempty"`
-	OutputTokens int `json:"output_tokens,omitempty"`
-}

--- a/agents/entire-agent-mistral-vibe/scripts/verify-mistral-vibe.sh
+++ b/agents/entire-agent-mistral-vibe/scripts/verify-mistral-vibe.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AGENT_NAME="Mistral Vibe"
+AGENT_SLUG="mistral-vibe"
+AGENT_BIN="vibe"
+PROBE_DIR="${PROBE_DIR:-$(pwd)/.probe-${AGENT_SLUG}-$(date +%s)}"
+PASS=0
+WARN=0
+FAIL=0
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC}: $1"; PASS=$((PASS + 1)); }
+warn() { echo -e "${YELLOW}WARN${NC}: $1"; WARN=$((WARN + 1)); }
+fail() { echo -e "${RED}FAIL${NC}: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== ${AGENT_NAME} Verification Script ==="
+echo "Probe directory: ${PROBE_DIR}"
+echo ""
+
+# ── Section 1: Static Checks ──────────────────────────────────────────
+
+echo "── Static Checks ──"
+
+# Binary present
+if command -v "${AGENT_BIN}" &>/dev/null; then
+    VIBE_PATH=$(command -v "${AGENT_BIN}")
+    pass "Binary found at ${VIBE_PATH}"
+else
+    fail "Binary '${AGENT_BIN}' not found in PATH"
+    echo "Install with: uv tool install mistral-vibe"
+    exit 1
+fi
+
+# Version
+if VERSION=$("${AGENT_BIN}" --version 2>&1); then
+    pass "Version: ${VERSION}"
+else
+    warn "Could not get version"
+fi
+
+# Help output
+if "${AGENT_BIN}" --help &>/dev/null; then
+    pass "Help output available"
+else
+    warn "No help output"
+fi
+
+# Config directory
+VIBE_HOME="${VIBE_HOME:-${HOME}/.vibe}"
+if [ -d "${VIBE_HOME}" ]; then
+    pass "Config directory exists at ${VIBE_HOME}"
+else
+    warn "Config directory not found at ${VIBE_HOME}"
+fi
+
+# Session log directory
+SESSION_DIR="${VIBE_HOME}/logs/session"
+if [ -d "${SESSION_DIR}" ]; then
+    SESSION_COUNT=$(find "${SESSION_DIR}" -maxdepth 1 -name "session_*" -type d 2>/dev/null | wc -l | tr -d ' ')
+    pass "Session log directory exists with ${SESSION_COUNT} sessions"
+else
+    warn "Session log directory not found at ${SESSION_DIR} (created on first use)"
+fi
+
+# API key
+if [ -n "${MISTRAL_API_KEY:-}" ]; then
+    pass "MISTRAL_API_KEY is set"
+else
+    fail "MISTRAL_API_KEY is not set — required for programmatic mode"
+fi
+
+# Programmatic mode check
+HELP_OUTPUT=$("${AGENT_BIN}" --help 2>&1)
+if echo "${HELP_OUTPUT}" | grep -q "\-p.*programmatic"; then
+    pass "Programmatic mode (-p) available"
+else
+    warn "Programmatic mode flag not found in help"
+fi
+
+if echo "${HELP_OUTPUT}" | grep -q "\-\-resume"; then
+    pass "Resume flag (--resume) available"
+else
+    warn "Resume flag not found in help"
+fi
+
+if echo "${HELP_OUTPUT}" | grep -q "\-\-output.*json"; then
+    pass "JSON output mode available"
+else
+    warn "JSON output mode not found in help"
+fi
+
+echo ""
+
+# ── Section 2: Session Storage Verification ────────────────────────────
+
+echo "── Session Storage Verification ──"
+
+if [ -d "${SESSION_DIR}" ]; then
+    # Find most recent session
+    LATEST=$(find "${SESSION_DIR}" -maxdepth 1 -name "session_*" -type d 2>/dev/null | sort -r | head -1)
+    if [ -n "${LATEST}" ]; then
+        pass "Latest session: $(basename "${LATEST}")"
+
+        # Check meta.json
+        if [ -f "${LATEST}/meta.json" ]; then
+            pass "meta.json exists"
+            # Extract session_id
+            SESSION_ID=$(python3 -c "import json; print(json.load(open('${LATEST}/meta.json'))['session_id'])" 2>/dev/null || echo "")
+            if [ -n "${SESSION_ID}" ]; then
+                pass "Session ID from meta.json: ${SESSION_ID}"
+            else
+                warn "Could not extract session_id from meta.json"
+            fi
+        else
+            warn "meta.json not found in latest session"
+        fi
+
+        # Check messages.jsonl
+        if [ -f "${LATEST}/messages.jsonl" ]; then
+            LINE_COUNT=$(wc -l < "${LATEST}/messages.jsonl" | tr -d ' ')
+            pass "messages.jsonl exists with ${LINE_COUNT} lines"
+
+            # Verify JSONL format
+            if python3 -c "
+import json
+with open('${LATEST}/messages.jsonl') as f:
+    for line in f:
+        msg = json.loads(line)
+        assert 'role' in msg, 'missing role'
+print('valid')
+" 2>/dev/null; then
+                pass "messages.jsonl has valid JSONL format with role fields"
+            else
+                warn "messages.jsonl format validation failed"
+            fi
+
+            # Check for actual content (not placeholders)
+            if python3 -c "
+import json
+with open('${LATEST}/messages.jsonl') as f:
+    for line in f:
+        msg = json.loads(line)
+        if msg.get('role') == 'assistant' and msg.get('content'):
+            if len(msg['content']) > 20:
+                print('has_content')
+                exit(0)
+print('no_content')
+exit(1)
+" 2>/dev/null; then
+                pass "Assistant messages contain actual content (not placeholders)"
+            else
+                warn "No substantial assistant content found"
+            fi
+        else
+            warn "messages.jsonl not found in latest session"
+        fi
+    else
+        warn "No sessions found in ${SESSION_DIR}"
+    fi
+else
+    warn "Session directory not yet created — run vibe once to generate sessions"
+fi
+
+echo ""
+
+# ── Section 3: Programmatic Mode Test ──────────────────────────────────
+
+echo "── Programmatic Mode Test ──"
+
+if [ "${1:-}" = "--run-cmd" ] && [ -n "${2:-}" ]; then
+    echo "Running programmatic mode with custom command..."
+    mkdir -p "${PROBE_DIR}/captures"
+
+    PROMPT="${2}"
+    WORKDIR="${3:-$(pwd)}"
+
+    echo "Prompt: ${PROMPT}"
+    echo "Workdir: ${WORKDIR}"
+
+    # Create timestamp marker
+    touch "${PROBE_DIR}/before-marker"
+
+    # Run vibe in programmatic mode
+    if OUTPUT=$("${AGENT_BIN}" -p "${PROMPT}" --output json --workdir "${WORKDIR}" 2>"${PROBE_DIR}/captures/stderr.txt"); then
+        echo "${OUTPUT}" > "${PROBE_DIR}/captures/programmatic-output.json"
+        pass "Programmatic mode completed successfully"
+
+        # Check output format
+        if python3 -c "import json; json.loads(open('${PROBE_DIR}/captures/programmatic-output.json').read())" 2>/dev/null; then
+            pass "Output is valid JSON"
+        else
+            warn "Output is not valid JSON"
+        fi
+    else
+        fail "Programmatic mode failed (exit code $?)"
+        if [ -f "${PROBE_DIR}/captures/stderr.txt" ]; then
+            echo "stderr: $(cat "${PROBE_DIR}/captures/stderr.txt")"
+        fi
+    fi
+
+    # Find new session files
+    if [ -d "${SESSION_DIR}" ]; then
+        NEW_SESSIONS=$(find "${SESSION_DIR}" -maxdepth 1 -name "session_*" -type d -newer "${PROBE_DIR}/before-marker" 2>/dev/null)
+        if [ -n "${NEW_SESSIONS}" ]; then
+            pass "New session created: $(echo "${NEW_SESSIONS}" | head -1 | xargs basename)"
+        else
+            warn "No new session directory detected"
+        fi
+    fi
+
+elif [ "${1:-}" = "--manual-live" ]; then
+    echo "Manual mode: Run vibe interactively, then press Enter when done."
+    echo "Suggested test commands:"
+    echo "  1. vibe -p 'What is 2+2?' --output json"
+    echo "  2. vibe -p 'Create a file called test-probe.txt with hello world' --output json"
+    echo ""
+
+    mkdir -p "${PROBE_DIR}/captures"
+    touch "${PROBE_DIR}/before-marker"
+
+    read -r -p "Press Enter when done testing... "
+
+    # Find new session files
+    if [ -d "${SESSION_DIR}" ]; then
+        NEW_SESSIONS=$(find "${SESSION_DIR}" -maxdepth 1 -name "session_*" -type d -newer "${PROBE_DIR}/before-marker" 2>/dev/null)
+        if [ -n "${NEW_SESSIONS}" ]; then
+            for SESSION in ${NEW_SESSIONS}; do
+                echo ""
+                echo "── New session: $(basename "${SESSION}") ──"
+                if [ -f "${SESSION}/meta.json" ]; then
+                    cp "${SESSION}/meta.json" "${PROBE_DIR}/captures/$(basename "${SESSION}")-meta.json"
+                    echo "meta.json saved to captures"
+                fi
+                if [ -f "${SESSION}/messages.jsonl" ]; then
+                    cp "${SESSION}/messages.jsonl" "${PROBE_DIR}/captures/$(basename "${SESSION}")-messages.jsonl"
+                    echo "messages.jsonl saved to captures"
+                    echo "Lines: $(wc -l < "${SESSION}/messages.jsonl" | tr -d ' ')"
+                fi
+            done
+            pass "Captured ${NEW_SESSIONS} session(s)"
+        else
+            warn "No new sessions detected"
+        fi
+    fi
+else
+    echo "Skipping programmatic test (use --run-cmd '<prompt>' or --manual-live)"
+fi
+
+echo ""
+
+# ── Verdict ────────────────────────────────────────────────────────────
+
+echo "══════════════════════════════════════════"
+echo "Results: ${PASS} PASS, ${WARN} WARN, ${FAIL} FAIL"
+echo ""
+echo "Verdict: PARTIAL COMPATIBILITY"
+echo "  - Session management: YES (meta.json + messages.jsonl)"
+echo "  - Transcript analysis: YES (structured JSONL)"
+echo "  - Lifecycle hooks: NO (not supported by Vibe)"
+echo "  - Programmatic mode: YES (vibe -p)"
+echo "══════════════════════════════════════════"
+
+if [ "${FAIL}" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/e2e/agents/vibe.go
+++ b/e2e/agents/vibe.go
@@ -1,0 +1,106 @@
+package agents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func init() {
+	if env := os.Getenv("E2E_AGENT"); env != "" && env != "mistral-vibe" {
+		return
+	}
+	Register(&MistralVibe{})
+	RegisterGate("mistral-vibe", 2)
+}
+
+// MistralVibe implements Agent for the Mistral Vibe CLI.
+type MistralVibe struct{}
+
+func (v *MistralVibe) Name() string               { return "mistral-vibe" }
+func (v *MistralVibe) Binary() string             { return "vibe" }
+func (v *MistralVibe) EntireAgent() string        { return "mistral-vibe" }
+func (v *MistralVibe) PromptPattern() string      { return `>` }
+func (v *MistralVibe) TimeoutMultiplier() float64 { return 2.0 }
+func (v *MistralVibe) IsExternalAgent() bool      { return true }
+
+func (v *MistralVibe) IsTransientError(out Output, _ error) bool {
+	combined := out.Stdout + out.Stderr
+	transientPatterns := []string{
+		"Rate limits exceeded",
+		"overloaded",
+		"429",
+		"Too Many Requests",
+		"BackendError",
+		"timeout",
+		"503",
+	}
+	for _, p := range transientPatterns {
+		if strings.Contains(combined, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func (v *MistralVibe) Bootstrap() error {
+	return nil
+}
+
+func (v *MistralVibe) RunPrompt(ctx context.Context, dir string, prompt string, opts ...Option) (Output, error) {
+	cfg := &runConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	bin, err := exec.LookPath(v.Binary())
+	if err != nil {
+		return Output{}, fmt.Errorf("%s not in PATH: %w", v.Binary(), err)
+	}
+
+	args := []string{"-p", prompt, "--output", "json", "--workdir", dir}
+	displayArgs := []string{"-p", fmt.Sprintf("%q", prompt), "--output", "json", "--workdir", dir}
+
+	env := filterEnv(os.Environ(), "ENTIRE_TEST_TTY")
+
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	cmd.WaitDelay = 5 * time.Second
+
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+	exitCode := 0
+	if err != nil {
+		exitErr := &exec.ExitError{}
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = -1
+		}
+	}
+
+	return Output{
+		Command:  v.Binary() + " " + strings.Join(displayArgs, " "),
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+		ExitCode: exitCode,
+	}, err
+}
+
+func (v *MistralVibe) StartSession(ctx context.Context, dir string) (Session, error) {
+	// Vibe's interactive mode uses Textual TUI which is not tmux-friendly.
+	return nil, nil
+}

--- a/e2e/lifecycle_test.go
+++ b/e2e/lifecycle_test.go
@@ -160,16 +160,27 @@ func TestLifecycle_RewindAfterCommit(t *testing.T) {
 		s.Git(t, "commit", "-m", "add first.txt")
 		testutil.WaitForCheckpoint(t, s, 30*time.Second)
 
-		// Old shadow point should no longer be listed as non-logs-only.
-		pointsAfter := entire.RewindList(t, s.Dir)
-		found := false
-		for _, p := range pointsAfter {
-			if p.ID == oldID && !p.IsLogsOnly {
-				found = true
+		// Wait for condensation to convert old shadow point to logs-only.
+		// Condensation runs asynchronously after checkpoint advancement,
+		// so we poll the rewind list instead of checking once.
+		deadline := time.Now().Add(30 * time.Second)
+		condensed := false
+		for time.Now().Before(deadline) {
+			pointsAfter := entire.RewindList(t, s.Dir)
+			found := false
+			for _, p := range pointsAfter {
+				if p.ID == oldID && !p.IsLogsOnly {
+					found = true
+					break
+				}
+			}
+			if !found {
+				condensed = true
 				break
 			}
+			time.Sleep(500 * time.Millisecond)
 		}
-		assert.False(t, found, "old shadow branch rewind point %s should no longer be listed as non-logs-only", oldID)
+		assert.True(t, condensed, "old shadow branch rewind point %s should no longer be listed as non-logs-only within 30s", oldID)
 
 		// Attempting to rewind to the old shadow branch ID should fail.
 		err = entire.Rewind(t, s.Dir, oldID)

--- a/e2e/vibe/fixtures_test.go
+++ b/e2e/vibe/fixtures_test.go
@@ -1,0 +1,149 @@
+//go:build e2e
+
+package vibe
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	e2e "github.com/entireio/external-agents/e2e"
+)
+
+// VibeTranscript builds Vibe-format JSONL transcript files for testing.
+type VibeTranscript struct {
+	messages []vibeTranscriptMessage
+}
+
+type vibeTranscriptMessage struct {
+	Role       string                    `json:"role"`
+	Content    string                    `json:"content,omitempty"`
+	ToolCalls  []vibeTranscriptToolCall  `json:"tool_calls,omitempty"`
+	MessageID  string                    `json:"message_id,omitempty"`
+	Name       string                    `json:"name,omitempty"`
+	ToolCallID string                    `json:"tool_call_id,omitempty"`
+}
+
+type vibeTranscriptToolCall struct {
+	ID       string                        `json:"id"`
+	Index    int                           `json:"index"`
+	Function vibeTranscriptToolCallFunction `json:"function"`
+	Type     string                        `json:"type"`
+}
+
+type vibeTranscriptToolCallFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+// NewVibeTranscript creates a new JSONL transcript builder.
+func NewVibeTranscript() *VibeTranscript {
+	return &VibeTranscript{}
+}
+
+// AddPrompt adds a user message to the transcript.
+func (vt *VibeTranscript) AddPrompt(prompt string) *VibeTranscript {
+	vt.messages = append(vt.messages, vibeTranscriptMessage{
+		Role:      "user",
+		Content:   prompt,
+		MessageID: fmt.Sprintf("msg-user-%d", len(vt.messages)),
+	})
+	return vt
+}
+
+// AddResponse adds a user prompt followed by an assistant response.
+func (vt *VibeTranscript) AddResponse(prompt, response string) *VibeTranscript {
+	vt.AddPrompt(prompt)
+	vt.messages = append(vt.messages, vibeTranscriptMessage{
+		Role:      "assistant",
+		Content:   response,
+		MessageID: fmt.Sprintf("msg-asst-%d", len(vt.messages)),
+	})
+	return vt
+}
+
+// AddAssistantMessage adds a standalone assistant message.
+func (vt *VibeTranscript) AddAssistantMessage(content string) *VibeTranscript {
+	vt.messages = append(vt.messages, vibeTranscriptMessage{
+		Role:      "assistant",
+		Content:   content,
+		MessageID: fmt.Sprintf("msg-asst-%d", len(vt.messages)),
+	})
+	return vt
+}
+
+// AddToolUse adds an assistant message with a tool call, followed by the tool result.
+func (vt *VibeTranscript) AddToolUse(prompt, toolName, filePath string) *VibeTranscript {
+	vt.AddPrompt(prompt)
+	argsMap := map[string]string{"path": filePath, "content": "test content"}
+	argsJSON, _ := json.Marshal(argsMap)
+
+	vt.messages = append(vt.messages, vibeTranscriptMessage{
+		Role:      "assistant",
+		MessageID: fmt.Sprintf("msg-asst-%d", len(vt.messages)),
+		ToolCalls: []vibeTranscriptToolCall{
+			{
+				ID:    fmt.Sprintf("call-%d", len(vt.messages)),
+				Index: 0,
+				Function: vibeTranscriptToolCallFunction{
+					Name:      toolName,
+					Arguments: string(argsJSON),
+				},
+				Type: "function",
+			},
+		},
+	})
+	// Add tool result
+	vt.messages = append(vt.messages, vibeTranscriptMessage{
+		Role:       "tool",
+		Content:    fmt.Sprintf("path: %s\nbytes_written: 12", filePath),
+		Name:       toolName,
+		ToolCallID: fmt.Sprintf("call-%d", len(vt.messages)-1),
+	})
+	return vt
+}
+
+// JSONL returns the JSONL-encoded transcript string.
+func (vt *VibeTranscript) JSONL(t *testing.T) string {
+	t.Helper()
+	var lines []string
+	for _, msg := range vt.messages {
+		data, err := json.Marshal(msg)
+		if err != nil {
+			t.Fatalf("marshal VibeTranscript message: %v", err)
+		}
+		lines = append(lines, string(data))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+// WriteToFile writes the transcript JSONL to a file and returns the absolute path.
+func (vt *VibeTranscript) WriteToFile(t *testing.T, env *e2e.TestEnv, relPath string) string {
+	t.Helper()
+	env.WriteFile(relPath, vt.JSONL(t))
+	return env.AbsPath(relPath)
+}
+
+// VibeHookPayload builds stdin payloads matching Vibe's native hook format.
+type VibeHookPayload struct {
+	HookEventName string      `json:"hook_event_name"`
+	CWD           string      `json:"cwd"`
+	SessionID     string      `json:"session_id"`
+	Prompt        string      `json:"prompt,omitempty"`
+	ToolName      string      `json:"tool_name,omitempty"`
+	ToolInput     interface{} `json:"tool_input,omitempty"`
+	ToolOutcome   string      `json:"tool_outcome,omitempty"`
+	ToolResponse  interface{} `json:"tool_response,omitempty"`
+	ToolError     string      `json:"tool_error,omitempty"`
+}
+
+// JSON returns the JSON-encoded string for use as stdin.
+func (p VibeHookPayload) JSON(t *testing.T) string {
+	t.Helper()
+	data, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal VibeHookPayload: %v", err)
+	}
+	return string(data)
+}

--- a/e2e/vibe/setup_test.go
+++ b/e2e/vibe/setup_test.go
@@ -1,0 +1,37 @@
+//go:build e2e
+
+package vibe
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	e2e "github.com/entireio/external-agents/e2e"
+)
+
+// vibeBinary holds the path to the built entire-agent-mistral-vibe binary.
+var vibeBinary string
+
+func TestMain(m *testing.M) {
+	tmpDir, err := os.MkdirTemp("", "e2e-vibe-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp dir: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	fmt.Println("Building entire-agent-mistral-vibe...")
+	binPath, err := e2e.BuildAgent("entire-agent-mistral-vibe", tmpDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build entire-agent-mistral-vibe: %v\n", err)
+		os.Exit(1)
+	}
+	vibeBinary = binPath
+	fmt.Printf("Built entire-agent-mistral-vibe -> %s\n", binPath)
+
+	// Isolate git config to prevent user's ~/.gitconfig from interfering.
+	os.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+
+	os.Exit(m.Run())
+}

--- a/e2e/vibe/testenv_test.go
+++ b/e2e/vibe/testenv_test.go
@@ -1,0 +1,26 @@
+//go:build e2e
+
+package vibe
+
+import (
+	"testing"
+
+	e2e "github.com/entireio/external-agents/e2e"
+)
+
+// NewVibeTestEnv creates a test environment with .vibe/ and .entire/tmp/ directories.
+func NewVibeTestEnv(t *testing.T) *e2e.TestEnv {
+	t.Helper()
+	te := e2e.NewTestEnvWithBinary(t, vibeBinary)
+	te.MkdirAll(".vibe")
+	te.MkdirAll(".entire/tmp")
+	return te
+}
+
+// NewVibeGitEnv creates a Vibe test environment with git init.
+func NewVibeGitEnv(t *testing.T) *e2e.TestEnv {
+	t.Helper()
+	te := NewVibeTestEnv(t)
+	te.GitInit()
+	return te
+}

--- a/e2e/vibe/vibe_test.go
+++ b/e2e/vibe/vibe_test.go
@@ -1,0 +1,641 @@
+//go:build e2e
+
+package vibe
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	e2e "github.com/entireio/external-agents/e2e"
+)
+
+// --- Identity ---
+
+func TestVibe_Info(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	var resp struct {
+		ProtocolVersion int      `json:"protocol_version"`
+		Name            string   `json:"name"`
+		Type            string   `json:"type"`
+		Description     string   `json:"description"`
+		IsPreview       bool     `json:"is_preview"`
+		ProtectedDirs   []string `json:"protected_dirs"`
+		HookNames       []string `json:"hook_names"`
+		Capabilities    struct {
+			Hooks              bool `json:"hooks"`
+			TranscriptAnalyzer bool `json:"transcript_analyzer"`
+			TokenCalculator    bool `json:"token_calculator"`
+		} `json:"capabilities"`
+	}
+	env.Runner.RunJSON(t, &resp, "", "info")
+
+	if resp.ProtocolVersion != 1 {
+		t.Errorf("protocol_version = %d, want 1", resp.ProtocolVersion)
+	}
+	if resp.Name != "mistral-vibe" {
+		t.Errorf("name = %q, want %q", resp.Name, "mistral-vibe")
+	}
+	if resp.Type != "Mistral Vibe" {
+		t.Errorf("type = %q, want %q", resp.Type, "Mistral Vibe")
+	}
+	if !resp.Capabilities.Hooks {
+		t.Error("capabilities.hooks should be true")
+	}
+	if !resp.Capabilities.TranscriptAnalyzer {
+		t.Error("capabilities.transcript_analyzer should be true")
+	}
+	if !resp.Capabilities.TokenCalculator {
+		t.Error("capabilities.token_calculator should be true")
+	}
+	if len(resp.HookNames) != 5 {
+		t.Errorf("hook_names count = %d, want 5", len(resp.HookNames))
+	}
+	if len(resp.ProtectedDirs) != 1 || resp.ProtectedDirs[0] != ".vibe" {
+		t.Errorf("protected_dirs = %v, want [.vibe]", resp.ProtectedDirs)
+	}
+}
+
+func TestVibe_Detect_Present(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t) // has .vibe/
+
+	var resp struct {
+		Present bool `json:"present"`
+	}
+	env.Runner.RunJSON(t, &resp, "", "detect")
+
+	if !resp.Present {
+		t.Error("detect should return present=true when .vibe/ exists")
+	}
+}
+
+func TestVibe_Detect_Absent(t *testing.T) {
+	t.Parallel()
+	env := e2e.NewTestEnvWithBinary(t, vibeBinary) // no .vibe/
+
+	var resp struct {
+		Present bool `json:"present"`
+	}
+	env.Runner.RunJSON(t, &resp, "", "detect")
+
+	if resp.Present {
+		t.Error("detect should return present=false when .vibe/ is absent")
+	}
+}
+
+// --- Session Management ---
+
+func TestVibe_GetSessionID(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	input := e2e.HookInput{SessionID: "test-session-456"}
+
+	var resp struct {
+		SessionID string `json:"session_id"`
+	}
+	env.Runner.RunJSON(t, &resp, input.JSON(t), "get-session-id")
+
+	if resp.SessionID != "test-session-456" {
+		t.Errorf("session_id = %q, want %q", resp.SessionID, "test-session-456")
+	}
+}
+
+func TestVibe_GetSessionID_Generated(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	input := e2e.HookInput{}
+
+	var resp struct {
+		SessionID string `json:"session_id"`
+	}
+	env.Runner.RunJSON(t, &resp, input.JSON(t), "get-session-id")
+
+	if resp.SessionID == "" {
+		t.Error("session_id should not be empty when no ID provided")
+	}
+}
+
+func TestVibe_GetSessionDir(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	var resp struct {
+		SessionDir string `json:"session_dir"`
+	}
+	env.Runner.RunJSON(t, &resp, "", "get-session-dir", "-repo-path", env.Dir)
+
+	want := env.AbsPath(".entire/tmp")
+	if resp.SessionDir != want {
+		t.Errorf("session_dir = %q, want %q", resp.SessionDir, want)
+	}
+}
+
+func TestVibe_ResolveSessionFile(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	sessionDir := env.AbsPath(".entire/tmp")
+
+	var resp struct {
+		SessionFile string `json:"session_file"`
+	}
+	env.Runner.RunJSON(t, &resp, "", "resolve-session-file",
+		"-session-dir", sessionDir,
+		"-session-id", "abc-123")
+
+	want := sessionDir + "/abc-123.json"
+	if resp.SessionFile != want {
+		t.Errorf("session_file = %q, want %q", resp.SessionFile, want)
+	}
+}
+
+func TestVibe_WriteAndReadSession(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	sessionRef := env.AbsPath(".entire/tmp/sess-write-test.json")
+
+	writeInput := map[string]interface{}{
+		"session_id":  "sess-write-test",
+		"agent_name":  "mistral-vibe",
+		"repo_path":   env.Dir,
+		"session_ref": sessionRef,
+		"start_time":  "2026-01-01T00:00:00Z",
+		"native_data": []byte(`{"hello":"world"}`),
+	}
+	writeJSON, _ := json.Marshal(writeInput)
+	env.Runner.MustSucceed(t, string(writeJSON), "write-session")
+
+	if !env.FileExists(".entire/tmp/sess-write-test.json") {
+		t.Fatal("session file was not written")
+	}
+
+	readInput := e2e.HookInput{
+		SessionID:  "sess-write-test",
+		SessionRef: sessionRef,
+	}
+	var resp struct {
+		SessionID  string `json:"session_id"`
+		AgentName  string `json:"agent_name"`
+		NativeData []byte `json:"native_data"`
+	}
+	env.Runner.RunJSON(t, &resp, readInput.JSON(t), "read-session")
+
+	if resp.SessionID != "sess-write-test" {
+		t.Errorf("session_id = %q, want %q", resp.SessionID, "sess-write-test")
+	}
+	if resp.AgentName != "mistral-vibe" {
+		t.Errorf("agent_name = %q, want %q", resp.AgentName, "mistral-vibe")
+	}
+}
+
+// --- Transcript ---
+
+func TestVibe_ReadTranscript(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	transcript := NewVibeTranscript().AddResponse("hello", "Hello! How can I help?")
+	path := transcript.WriteToFile(t, env, "transcript.jsonl")
+
+	result := env.Runner.MustSucceed(t, "", "read-transcript", "-session-ref", path)
+	if len(result.Stdout) == 0 {
+		t.Error("read-transcript returned empty stdout")
+	}
+}
+
+func TestVibe_ChunkTranscript(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	content := strings.Repeat("abcdefghij", 10) // 100 bytes
+
+	var resp struct {
+		Chunks [][]byte `json:"chunks"`
+	}
+	env.Runner.RunJSON(t, &resp, content, "chunk-transcript", "-max-size", "30")
+
+	if len(resp.Chunks) < 3 {
+		t.Errorf("expected at least 3 chunks for 100 bytes with max-size 30, got %d", len(resp.Chunks))
+	}
+}
+
+func TestVibe_ReassembleTranscript(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	content := "hello world this is a test transcript"
+	var chunkResp struct {
+		Chunks [][]byte `json:"chunks"`
+	}
+	env.Runner.RunJSON(t, &chunkResp, content, "chunk-transcript", "-max-size", "10")
+
+	reassembleInput, _ := json.Marshal(chunkResp)
+	result := env.Runner.MustSucceed(t, string(reassembleInput), "reassemble-transcript")
+
+	if string(result.Stdout) != content {
+		t.Errorf("reassembled = %q, want %q", result.Stdout, content)
+	}
+}
+
+// --- Hooks ---
+
+func TestVibe_ParseHook_SessionStart(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	payload := VibeHookPayload{
+		HookEventName: "session_start",
+		CWD:           env.Dir,
+		SessionID:     "0e9f7293-0151-4178-ba58-2c48c5abb8df",
+	}
+
+	var resp struct {
+		Type      int    `json:"type"`
+		SessionID string `json:"session_id"`
+		Timestamp string `json:"timestamp"`
+	}
+	env.Runner.RunJSON(t, &resp, payload.JSON(t), "parse-hook", "-hook", "session-start")
+
+	if resp.Type != 1 {
+		t.Errorf("type = %d, want 1 (SessionStart)", resp.Type)
+	}
+	if resp.SessionID != "0e9f7293-0151-4178-ba58-2c48c5abb8df" {
+		t.Errorf("session_id = %q, want %q", resp.SessionID, "0e9f7293-0151-4178-ba58-2c48c5abb8df")
+	}
+	if resp.Timestamp == "" {
+		t.Error("timestamp should not be empty")
+	}
+}
+
+func TestVibe_ParseHook_UserPromptSubmit(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	payload := VibeHookPayload{
+		HookEventName: "user_prompt_submit",
+		CWD:           env.Dir,
+		SessionID:     "test-session-789",
+		Prompt:        "fix the login bug",
+	}
+
+	var resp struct {
+		Type      int    `json:"type"`
+		SessionID string `json:"session_id"`
+		Prompt    string `json:"prompt"`
+	}
+	env.Runner.RunJSON(t, &resp, payload.JSON(t), "parse-hook", "-hook", "user-prompt-submit")
+
+	if resp.Type != 2 {
+		t.Errorf("type = %d, want 2 (TurnStart)", resp.Type)
+	}
+	if resp.Prompt != "fix the login bug" {
+		t.Errorf("prompt = %q, want %q", resp.Prompt, "fix the login bug")
+	}
+}
+
+func TestVibe_ParseHook_PreToolUse(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	payload := VibeHookPayload{
+		HookEventName: "pre_tool_use",
+		CWD:           env.Dir,
+		SessionID:     "test-session",
+		ToolName:      "write_file",
+	}
+
+	result := env.Runner.MustSucceed(t, payload.JSON(t), "parse-hook", "-hook", "pre-tool-use")
+
+	if got := strings.TrimSpace(string(result.Stdout)); got != "null" {
+		t.Errorf("pre-tool-use should return null, got %q", got)
+	}
+}
+
+func TestVibe_ParseHook_PostToolUse(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	payload := VibeHookPayload{
+		HookEventName: "post_tool_use",
+		CWD:           env.Dir,
+		SessionID:     "test-session",
+		ToolName:      "write_file",
+		ToolOutcome:   "success",
+	}
+
+	result := env.Runner.MustSucceed(t, payload.JSON(t), "parse-hook", "-hook", "post-tool-use")
+
+	if got := strings.TrimSpace(string(result.Stdout)); got != "null" {
+		t.Errorf("post-tool-use should return null, got %q", got)
+	}
+}
+
+func TestVibe_ParseHook_TurnEnd(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	payload := VibeHookPayload{
+		HookEventName: "turn_end",
+		CWD:           env.Dir,
+		SessionID:     "0e9f7293-0151-4178-ba58-2c48c5abb8df",
+	}
+
+	var resp struct {
+		Type      int    `json:"type"`
+		SessionID string `json:"session_id"`
+	}
+	env.Runner.RunJSON(t, &resp, payload.JSON(t), "parse-hook", "-hook", "turn-end")
+
+	if resp.Type != 3 {
+		t.Errorf("type = %d, want 3 (TurnEnd)", resp.Type)
+	}
+	if resp.SessionID != "0e9f7293-0151-4178-ba58-2c48c5abb8df" {
+		t.Errorf("session_id = %q, want %q", resp.SessionID, "0e9f7293-0151-4178-ba58-2c48c5abb8df")
+	}
+}
+
+func TestVibe_InstallHooks(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	var resp struct {
+		HooksInstalled int `json:"hooks_installed"`
+	}
+	env.Runner.RunJSON(t, &resp, "", "install-hooks")
+
+	if resp.HooksInstalled == 0 {
+		t.Error("hooks_installed should be > 0")
+	}
+
+	if !env.FileExists(".vibe/config.toml") {
+		t.Error(".vibe/config.toml should exist after install")
+	}
+
+	content := env.ReadFile(".vibe/config.toml")
+	if !strings.Contains(content, "entire hooks mistral-vibe") {
+		t.Error("config.toml should contain 'entire hooks mistral-vibe'")
+	}
+	if !strings.Contains(content, "[[hooks.session_start]]") {
+		t.Error("config.toml should contain [[hooks.session_start]]")
+	}
+	if !strings.Contains(content, "[[hooks.turn_end]]") {
+		t.Error("config.toml should contain [[hooks.turn_end]]")
+	}
+}
+
+func TestVibe_UninstallHooks(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	env.Runner.MustSucceed(t, "", "install-hooks")
+
+	if !env.FileExists(".vibe/config.toml") {
+		t.Fatal("hooks should be installed before uninstall test")
+	}
+
+	env.Runner.MustSucceed(t, "", "uninstall-hooks")
+
+	if env.FileExists(".vibe/config.toml") {
+		content := env.ReadFile(".vibe/config.toml")
+		if strings.Contains(content, "entire hooks mistral-vibe") {
+			t.Error("config.toml should not contain 'entire hooks mistral-vibe' after uninstall")
+		}
+	}
+}
+
+func TestVibe_AreHooksInstalled_No(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	var resp struct {
+		Installed bool `json:"installed"`
+	}
+	env.Runner.RunJSON(t, &resp, "", "are-hooks-installed")
+
+	if resp.Installed {
+		t.Error("hooks should not be installed in fresh env")
+	}
+}
+
+func TestVibe_AreHooksInstalled_Yes(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	env.Runner.MustSucceed(t, "", "install-hooks")
+
+	var resp struct {
+		Installed bool `json:"installed"`
+	}
+	env.Runner.RunJSON(t, &resp, "", "are-hooks-installed")
+
+	if !resp.Installed {
+		t.Error("hooks should be installed after install-hooks")
+	}
+}
+
+func TestVibe_InstallHooks_Idempotent(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	var resp1 struct {
+		HooksInstalled int `json:"hooks_installed"`
+	}
+	env.Runner.RunJSON(t, &resp1, "", "install-hooks")
+	if resp1.HooksInstalled == 0 {
+		t.Fatal("first install should install hooks")
+	}
+
+	var resp2 struct {
+		HooksInstalled int `json:"hooks_installed"`
+	}
+	env.Runner.RunJSON(t, &resp2, "", "install-hooks")
+	if resp2.HooksInstalled != 0 {
+		t.Errorf("second install should be idempotent (0 hooks), got %d", resp2.HooksInstalled)
+	}
+}
+
+// --- Transcript Analysis ---
+
+func TestVibe_GetTranscriptPosition(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	transcript := NewVibeTranscript().
+		AddResponse("hello", "Hi there!").
+		AddResponse("what is 2+2", "4")
+	path := transcript.WriteToFile(t, env, "pos-transcript.jsonl")
+
+	var resp struct {
+		Position int `json:"position"`
+	}
+	env.Runner.RunJSON(t, &resp, "", "get-transcript-position", "-path", path)
+
+	// 2 user + 2 assistant = 4 messages
+	if resp.Position != 4 {
+		t.Errorf("position = %d, want 4", resp.Position)
+	}
+}
+
+func TestVibe_GetTranscriptPosition_Missing(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	var resp struct {
+		Position int `json:"position"`
+	}
+	env.Runner.RunJSON(t, &resp, "", "get-transcript-position", "-path", env.AbsPath("nonexistent.jsonl"))
+
+	if resp.Position != 0 {
+		t.Errorf("position for missing file = %d, want 0", resp.Position)
+	}
+}
+
+func TestVibe_ExtractModifiedFiles(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	transcript := NewVibeTranscript().
+		AddToolUse("create file", "write_file", "/tmp/foo.go").
+		AddToolUse("edit file", "search_replace", "/tmp/bar.go").
+		AddResponse("no edits here", "Sure, no problem")
+	path := transcript.WriteToFile(t, env, "files-transcript.jsonl")
+
+	var resp struct {
+		Files           []string `json:"files"`
+		CurrentPosition int      `json:"current_position"`
+	}
+	env.Runner.RunJSON(t, &resp, "", "extract-modified-files", "-path", path, "-offset", "0")
+
+	if len(resp.Files) != 2 {
+		t.Errorf("files count = %d, want 2: %v", len(resp.Files), resp.Files)
+	}
+}
+
+func TestVibe_ExtractPrompts(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	transcript := NewVibeTranscript().
+		AddResponse("first prompt", "response 1").
+		AddResponse("second prompt", "response 2").
+		AddPrompt("third prompt")
+	path := transcript.WriteToFile(t, env, "prompts-transcript.jsonl")
+
+	var resp struct {
+		Prompts []string `json:"prompts"`
+	}
+	env.Runner.RunJSON(t, &resp, "", "extract-prompts", "-session-ref", path, "-offset", "0")
+
+	if len(resp.Prompts) != 3 {
+		t.Errorf("prompts count = %d, want 3: %v", len(resp.Prompts), resp.Prompts)
+	}
+}
+
+func TestVibe_ExtractPrompts_WithOffset(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	transcript := NewVibeTranscript().
+		AddResponse("first", "resp1").
+		AddResponse("second", "resp2").
+		AddResponse("third", "resp3")
+	path := transcript.WriteToFile(t, env, "prompts-offset.jsonl")
+
+	var resp struct {
+		Prompts []string `json:"prompts"`
+	}
+	// Offset 4 = skip first 4 lines (user, assistant, user, assistant)
+	env.Runner.RunJSON(t, &resp, "", "extract-prompts", "-session-ref", path, "-offset", "4")
+
+	if len(resp.Prompts) != 1 {
+		t.Errorf("prompts count = %d, want 1: %v", len(resp.Prompts), resp.Prompts)
+	}
+}
+
+func TestVibe_ExtractSummary(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	transcript := NewVibeTranscript().
+		AddResponse("do the thing", "I completed the task successfully")
+	path := transcript.WriteToFile(t, env, "summary-transcript.jsonl")
+
+	var resp struct {
+		Summary    string `json:"summary"`
+		HasSummary bool   `json:"has_summary"`
+	}
+	env.Runner.RunJSON(t, &resp, "", "extract-summary", "-session-ref", path)
+
+	if !resp.HasSummary {
+		t.Error("has_summary should be true")
+	}
+	if resp.Summary != "I completed the task successfully" {
+		t.Errorf("summary = %q, want %q", resp.Summary, "I completed the task successfully")
+	}
+}
+
+func TestVibe_ExtractSummary_Empty(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	transcript := NewVibeTranscript().AddPrompt("hello")
+	path := transcript.WriteToFile(t, env, "no-summary.jsonl")
+
+	var resp struct {
+		Summary    string `json:"summary"`
+		HasSummary bool   `json:"has_summary"`
+	}
+	env.Runner.RunJSON(t, &resp, "", "extract-summary", "-session-ref", path)
+
+	if resp.HasSummary {
+		t.Error("has_summary should be false for prompt-only transcript")
+	}
+}
+
+// --- Other ---
+
+func TestVibe_FormatResumeCommand(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	var resp struct {
+		Command string `json:"command"`
+	}
+	env.Runner.RunJSON(t, &resp, "", "format-resume-command", "-session-id", "session-xyz")
+
+	if resp.Command == "" {
+		t.Error("command should not be empty")
+	}
+	if !strings.Contains(resp.Command, "resume") {
+		t.Errorf("command %q should contain 'resume'", resp.Command)
+	}
+	if !strings.Contains(resp.Command, "session-xyz") {
+		t.Errorf("command %q should contain session ID", resp.Command)
+	}
+}
+
+func TestVibe_UnknownSubcommand(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	result := env.Runner.MustFail(t, "", "nonexistent-command")
+	if !strings.Contains(string(result.Stderr), "unknown subcommand") {
+		t.Errorf("stderr should mention 'unknown subcommand', got: %s", result.Stderr)
+	}
+}
+
+func TestVibe_NoSubcommand(t *testing.T) {
+	t.Parallel()
+	env := NewVibeTestEnv(t)
+
+	result := env.Runner.Run("", "")
+	if result.ExitCode == 0 {
+		t.Error("expected non-zero exit for empty subcommand")
+	}
+}


### PR DESCRIPTION
## Summary

Add Mistral Vibe as an external agent plugin for the Entire CLI, implementing the full agent binary protocol.

- Research one-pager and verification script for Vibe's hook lifecycle, transcript format, and session storage
- Implementation spec for lifecycle hooks mapping (Vibe native → Entire protocol)
- Agent binary (`entire-agent-mistral-vibe`) with all protocol subcommands: `info`, `detect`, `get-session-id`, `get-session-dir`, `resolve-session-file`, `read-session`, `write-session`, `read-transcript`, `chunk-transcript`, `reassemble-transcript`, `format-resume-command`, `parse-hook`, `install-hooks`, `uninstall-hooks`, `are-hooks-installed`, `get-transcript-position`, `extract-modified-files`, `extract-prompts`, `extract-summary`
- Hook installation writes TOML config to `.vibe/config.toml` and trusts the repo directory via `~/.vibe/trusted_folders.toml`
- Transcript analysis (JSONL): position tracking, file extraction from tool calls, prompt extraction, summary extraction
- Session persistence: placeholder transcript fallback when Vibe native logs are absent (mirrors Kiro's `createPlaceholderTranscript` pattern)
- E2E test harness with transcript builder fixtures, hook payload helpers, and full binary-level coverage
- Unit tests for all agent methods, hook parsing, transcript analysis, and placeholder creation
- Fix lifecycle `RewindAfterCommit` test timing: condition-based polling for condensation instead of single check

## Test plan

- [x] Unit tests: `go test ./...` — 40/40 pass
- [x] E2E module vets cleanly: `go vet -tags=e2e ./...`
- [ ] E2E lifecycle tests: `SessionPersistence`, `RewindAfterCommit` (requires full Entire CLI + Vibe binary)
- [ ] Manual: `entire enable --agent mistral-vibe` in a repo with `.vibe/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)