### PR TITLE
pi: force non-interactive commit linking on install

### DIFF
--- a/agents/entire-agent-pi/README.md
+++ b/agents/entire-agent-pi/README.md
@@ -36,7 +36,7 @@ mise run build
 
 ### Hooks
 
-`install-hooks` creates a TypeScript extension at `.pi/extensions/entire/index.ts` that intercepts Pi lifecycle events and forwards them to `entire agent hook pi <event>`:
+`install-hooks` creates a TypeScript extension at `.pi/extensions/entire/index.ts` that intercepts Pi lifecycle events and forwards them to `entire agent hook pi <event>`. It also writes `.entire/settings.local.json` with `"commit_linking": "always"` so Pi-driven git commits do not trigger an interactive Entire prompt inside the agent loop:
 
 | Pi Event | Protocol Event |
 |----------|---------------|

--- a/agents/entire-agent-pi/internal/pi/hooks.go
+++ b/agents/entire-agent-pi/internal/pi/hooks.go
@@ -1,7 +1,9 @@
 package pi
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,9 +13,12 @@ import (
 )
 
 const (
-	extensionDir      = ".pi/extensions/entire"
-	extensionFile     = ".pi/extensions/entire/index.ts"
-	activeSessionFile = "pi-active-session"
+	extensionDir       = ".pi/extensions/entire"
+	extensionFile      = ".pi/extensions/entire/index.ts"
+	activeSessionFile  = "pi-active-session"
+	settingsLocalFile  = ".entire/settings.local.json"
+	commitLinkingKey   = "commit_linking"
+	commitLinkingValue = "always"
 )
 
 // piHookPayload is the JSON the TypeScript extension sends to
@@ -112,6 +117,9 @@ func (a *Agent) InstallHooks(_ bool, force bool) (int, error) {
 	if err := os.WriteFile(path, []byte(ext), 0o600); err != nil {
 		return 0, fmt.Errorf("write extension: %w", err)
 	}
+	if err := ensureCommitLinkingAlways(root); err != nil {
+		return 0, err
+	}
 
 	return 4, nil // 4 hooks: session_start, before_agent_start, agent_end, session_shutdown
 }
@@ -179,6 +187,51 @@ export default function (pi: ExtensionAPI) {
   });
 }
 `
+}
+
+func ensureCommitLinkingAlways(root string) error {
+	path := filepath.Join(root, settingsLocalFile)
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("create entire settings dir: %w", err)
+	}
+
+	settings, err := readSettings(path)
+	if err != nil {
+		return err
+	}
+	settings[commitLinkingKey] = commitLinkingValue
+
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", settingsLocalFile, err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", settingsLocalFile, err)
+	}
+	return nil
+}
+
+func readSettings(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]any{}, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", settingsLocalFile, err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return map[string]any{}, nil
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", settingsLocalFile, err)
+	}
+	if settings == nil {
+		return map[string]any{}, nil
+	}
+	return settings, nil
 }
 
 // cacheSessionID writes the session ID to .entire/tmp/pi-active-session.

--- a/agents/entire-agent-pi/internal/pi/hooks_test.go
+++ b/agents/entire-agent-pi/internal/pi/hooks_test.go
@@ -151,7 +151,6 @@ func TestInstallAndUninstallHooks(t *testing.T) {
 		t.Error("hooks should be installed after InstallHooks")
 	}
 
-	// Verify the extension file exists and contains expected content.
 	extPath := filepath.Join(tmp, extensionFile)
 	data, err := os.ReadFile(extPath)
 	if err != nil {
@@ -186,6 +185,62 @@ func TestInstallAndUninstallHooks(t *testing.T) {
 
 	if agent.AreHooksInstalled() {
 		t.Error("hooks should not be installed after UninstallHooks")
+	}
+}
+
+func TestInstallHooks_WritesCommitLinkingAlways(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	agent := New()
+	if _, err := agent.InstallHooks(false, false); err != nil {
+		t.Fatal(err)
+	}
+
+	settingsPath := filepath.Join(tmp, settingsLocalFile)
+	settingsData, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(settingsData, &settings); err != nil {
+		t.Fatal(err)
+	}
+	if settings[commitLinkingKey] != commitLinkingValue {
+		t.Fatalf("%s = %v, want %q", commitLinkingKey, settings[commitLinkingKey], commitLinkingValue)
+	}
+}
+
+func TestEnsureCommitLinkingAlways_PreservesExistingSettings(t *testing.T) {
+	tmp := t.TempDir()
+	settingsPath := filepath.Join(tmp, settingsLocalFile)
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsPath, []byte("{\n  \"enabled\": true,\n  \"strategy\": \"manual-commit\"\n}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureCommitLinkingAlways(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatal(err)
+	}
+	if settings["enabled"] != true {
+		t.Fatalf("enabled = %v, want true", settings["enabled"])
+	}
+	if settings["strategy"] != "manual-commit" {
+		t.Fatalf("strategy = %v, want %q", settings["strategy"], "manual-commit")
+	}
+	if settings[commitLinkingKey] != commitLinkingValue {
+		t.Fatalf("%s = %v, want %q", commitLinkingKey, settings[commitLinkingKey], commitLinkingValue)
 	}
 }
 


### PR DESCRIPTION
## Summary
- write `.entire/settings.local.json` with `"commit_linking": "always"` during hook install
- preserve existing local Entire settings when adding the Pi-specific override
- document and test the install-time behavior

## Testing
- go test ./...
