### PR TITLE
pi: signal non-interactive git commands via env var

### DIFF
--- a/agents/entire-agent-pi/internal/pi/hooks.go
+++ b/agents/entire-agent-pi/internal/pi/hooks.go
@@ -147,6 +147,22 @@ export default function (pi: ExtensionAPI) {
     }
   }
 
+  pi.on("tool_call", async (event) => {
+    if (event.toolName !== "bash") {
+      return;
+    }
+
+    const input = event.input as { command?: string };
+    if (typeof input.command !== "string" || input.command.includes("GIT_TERMINAL_PROMPT=")) {
+      return;
+    }
+
+    // Pi tool subprocesses may inherit a real TTY even though the agent cannot
+    // answer hook prompts. Disable git/Entire terminal prompts for bash calls so
+    // Entire treats agent-driven commits as non-interactive.
+    input.command = "export GIT_TERMINAL_PROMPT=0\n" + input.command;
+  });
+
   pi.on("session_start", async (_event, ctx) => {
     fireHook("session_start", {
       type: "session_start",


### PR DESCRIPTION
## Summary
- add a Pi extension tool_call hook for bash commands
- prefix bash commands with `GIT_TERMINAL_PROMPT=0`
- avoid the `commit_linking=always` workaround entirely

## Testing
- cd agents/entire-agent-pi && go test ./...
