### PR TITLE
pi: resolve live session file when snapshot is missing

### DIFF
--- a/agents/entire-agent-kiro/internal/kiro/transcript.go
+++ b/agents/entire-agent-kiro/internal/kiro/transcript.go
@@ -52,7 +52,7 @@ func (a *Agent) ChunkTranscript(content []byte, maxSize int) ([][]byte, error) {
 		return nil, errors.New("max-size must be greater than zero")
 	}
 	if len(content) == 0 {
-		return [][]byte{[]byte{}}, nil
+		return [][]byte{{}}, nil
 	}
 
 	var chunks [][]byte

--- a/agents/entire-agent-pi/internal/pi/paths.go
+++ b/agents/entire-agent-pi/internal/pi/paths.go
@@ -1,11 +1,139 @@
 package pi
 
-import "github.com/entireio/external-agents/agents/entire-agent-pi/internal/protocol"
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/entireio/external-agents/agents/entire-agent-pi/internal/protocol"
+)
 
 func (a *Agent) GetSessionDir(repoPath string) (string, error) {
 	return protocol.DefaultSessionDir(repoPath), nil
 }
 
+// ResolveSessionFile returns the transcript path for sessionID.
+//
+// Pi sessions live in two places:
+//
+//  1. <sessionDir>/<id>.json — a snapshot written by the agent_end hook so that
+//     Entire can read a stable transcript during condensation.
+//  2. ~/.pi/agent/sessions/--<escaped-repo>--/<timestamp>_<id>.jsonl — the live
+//     pi session file that exists whether or not Entire hooks ran.
+//
+// The captured snapshot is preferred when present (it matches what condense
+// already saw). For `entire attach` on sessions that ran without hooks
+// installed, the snapshot does not exist, so fall back to the live file.
+//
+// The live-file fallback is scoped to the repo derived from sessionDir, not
+// to the process-global ENTIRE_REPO_ROOT: the protocol accepts sessionDir as
+// an argument specifically so callers can resolve sessions for a repo other
+// than the one the binary was launched in.
 func (a *Agent) ResolveSessionFile(sessionDir, sessionID string) string {
-	return protocol.ResolveSessionFile(sessionDir, sessionID)
+	captured := protocol.ResolveSessionFile(sessionDir, sessionID)
+	if _, err := os.Stat(captured); err == nil {
+		return captured
+	}
+	if repoPath := repoRootFromSessionDir(sessionDir); repoPath != "" {
+		if live := findPiSessionFile(repoPath, sessionID); live != "" {
+			return live
+		}
+	}
+	return captured
+}
+
+// repoRootFromSessionDir reverses protocol.DefaultSessionDir, which appends
+// ".entire/tmp" to the repo root. Returns "" if sessionDir does not have that
+// suffix — in that case the caller is using a non-standard layout and we
+// cannot safely infer which repo to search for a live session file.
+func repoRootFromSessionDir(sessionDir string) string {
+	if sessionDir == "" {
+		return ""
+	}
+	cleaned := filepath.Clean(sessionDir)
+	parent := filepath.Dir(cleaned)
+	if filepath.Base(cleaned) != "tmp" || filepath.Base(parent) != ".entire" {
+		return ""
+	}
+	return filepath.Dir(parent)
+}
+
+// piSessionsBaseDir returns the root where the pi CLI stores per-repo session
+// directories. Returns "" if the home directory cannot be determined.
+func piSessionsBaseDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".pi", "agent", "sessions")
+}
+
+// piRepoDirName mirrors pi's session-directory naming scheme: the absolute
+// repo path with '/' replaced by '-', wrapped with '--' on both sides.
+//
+// Example: /Users/soph/Work/entire/devenv/go-git-api
+//
+//	-> --Users-soph-Work-entire-devenv-go-git-api--
+func piRepoDirName(repoPath string) string {
+	trimmed := strings.TrimPrefix(repoPath, "/")
+	return "--" + strings.ReplaceAll(trimmed, "/", "-") + "--"
+}
+
+// findPiSessionFile searches the live pi session directory for a transcript
+// matching sessionID. Accepts either the full "<timestamp>_<uuid>" form or
+// just the trailing "<uuid>". When multiple files match, the most recently
+// modified is returned.
+//
+// Entries whose Info() fails (e.g., the file was rotated between ReadDir and
+// the stat) are skipped rather than crashing the resolver: this code reads a
+// live session directory, so transient disappearances are expected.
+func findPiSessionFile(repoPath, sessionID string) string {
+	if sessionID == "" || repoPath == "" {
+		return ""
+	}
+	base := piSessionsBaseDir()
+	if base == "" {
+		return ""
+	}
+	dir := filepath.Join(base, piRepoDirName(repoPath))
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	type match struct {
+		path    string
+		modTime time.Time
+	}
+	var matches []match
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		stem := strings.TrimSuffix(name, ".jsonl")
+		if stem == name {
+			continue // not a .jsonl file
+		}
+		if stem != sessionID && !strings.HasSuffix(stem, "_"+sessionID) {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue // file vanished between ReadDir and stat — skip
+		}
+		matches = append(matches, match{
+			path:    filepath.Join(dir, name),
+			modTime: info.ModTime(),
+		})
+	}
+	if len(matches) == 0 {
+		return ""
+	}
+	// Prefer newest mtime when a short UUID matches multiple timestamped files.
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].modTime.After(matches[j].modTime)
+	})
+	return matches[0].path
 }

--- a/agents/entire-agent-pi/internal/pi/paths_test.go
+++ b/agents/entire-agent-pi/internal/pi/paths_test.go
@@ -1,0 +1,225 @@
+package pi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestPiRepoDirName(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"/Users/soph/Work/entire/devenv/go-git-api", "--Users-soph-Work-entire-devenv-go-git-api--"},
+		{"/Users/test", "--Users-test--"},
+		{"/a", "--a--"},
+	}
+	for _, tt := range tests {
+		if got := piRepoDirName(tt.in); got != tt.want {
+			t.Errorf("piRepoDirName(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestRepoRootFromSessionDir(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"/some/repo/.entire/tmp", "/some/repo"},
+		{"/some/repo/.entire/tmp/", "/some/repo"},
+		{"", ""},
+		{"/some/repo/.entire", ""},      // missing tmp suffix
+		{"/some/repo/.other/tmp", ""},   // wrong parent name
+		{"/some/repo/.entire/logs", ""}, // wrong leaf name
+	}
+	for _, tt := range tests {
+		if got := repoRootFromSessionDir(tt.in); got != tt.want {
+			t.Errorf("repoRootFromSessionDir(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestFindPiSessionFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoPath := "/Users/tester/Work/demo"
+	sessionsDir := filepath.Join(home, ".pi", "agent", "sessions", piRepoDirName(repoPath))
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write two files: one plain .jsonl and one timestamped.
+	older := filepath.Join(sessionsDir, "2026-01-01T00-00-00-000Z_abc123.jsonl")
+	newer := filepath.Join(sessionsDir, "2026-02-01T00-00-00-000Z_abc123.jsonl")
+	for _, p := range []string{older, newer} {
+		if err := os.WriteFile(p, []byte("{}\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Force distinct mtimes so newest-wins is deterministic.
+	past := time.Now().Add(-1 * time.Hour)
+	if err := os.Chtimes(older, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("short uuid matches newest timestamped file", func(t *testing.T) {
+		got := findPiSessionFile(repoPath, "abc123")
+		if got != newer {
+			t.Errorf("got %q, want %q", got, newer)
+		}
+	})
+
+	t.Run("full filename stem matches exactly", func(t *testing.T) {
+		got := findPiSessionFile(repoPath, "2026-01-01T00-00-00-000Z_abc123")
+		if got != older {
+			t.Errorf("got %q, want %q", got, older)
+		}
+	})
+
+	t.Run("unknown session returns empty", func(t *testing.T) {
+		if got := findPiSessionFile(repoPath, "does-not-exist"); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("missing repo dir returns empty", func(t *testing.T) {
+		if got := findPiSessionFile("/Users/tester/not/a/repo", "abc123"); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}
+
+// TestResolveSessionFile_HonorsSessionDirOverEnv ensures the live-file
+// fallback is scoped to the repo derived from sessionDir, not from
+// ENTIRE_REPO_ROOT. Two repos have the same sessionID; the fallback must
+// return the file under the sessionDir-derived repo.
+func TestResolveSessionFile_HonorsSessionDirOverEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Process cwd / ENTIRE_REPO_ROOT points at repoA, but the caller asks
+	// about repoB. The returned path must reflect repoB.
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repoA)
+
+	sessionID := "shared123"
+
+	// Live file exists in repoA under the right pi sessions key.
+	liveA := filepath.Join(home, ".pi", "agent", "sessions", piRepoDirName(repoA),
+		"2026-01-01T00-00-00-000Z_"+sessionID+".jsonl")
+	if err := os.MkdirAll(filepath.Dir(liveA), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(liveA, []byte("A"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Live file also exists in repoB.
+	liveB := filepath.Join(home, ".pi", "agent", "sessions", piRepoDirName(repoB),
+		"2026-01-01T00-00-00-000Z_"+sessionID+".jsonl")
+	if err := os.MkdirAll(filepath.Dir(liveB), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(liveB, []byte("B"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionDirB := filepath.Join(repoB, ".entire", "tmp")
+
+	a := New()
+	got := a.ResolveSessionFile(sessionDirB, sessionID)
+	if got != liveB {
+		t.Errorf("got %q, want %q (must follow sessionDir, not ENTIRE_REPO_ROOT)", got, liveB)
+	}
+}
+
+// TestResolveSessionFile_NonStandardSessionDirReturnsCaptured covers the
+// case where sessionDir doesn't decompose into <repo>/.entire/tmp. The
+// resolver cannot infer a repo for the live-file search, so it returns the
+// captured path unchanged rather than silently falling back to process
+// state.
+func TestResolveSessionFile_NonStandardSessionDirReturnsCaptured(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ENTIRE_REPO_ROOT", t.TempDir())
+
+	// Non-standard sessionDir.
+	sessionDir := filepath.Join(t.TempDir(), "custom")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	a := New()
+	sessionID := "abc"
+	got := a.ResolveSessionFile(sessionDir, sessionID)
+	want := filepath.Join(sessionDir, sessionID+".json")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveSessionFile_PrefersCaptured(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoPath := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repoPath)
+
+	sessionDir := filepath.Join(repoPath, ".entire", "tmp")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	captured := filepath.Join(sessionDir, "abc123.json")
+	if err := os.WriteFile(captured, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Also place a live pi file — captured should still win.
+	liveDir := filepath.Join(home, ".pi", "agent", "sessions", piRepoDirName(repoPath))
+	if err := os.MkdirAll(liveDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	live := filepath.Join(liveDir, "2026-01-01T00-00-00-000Z_abc123.jsonl")
+	if err := os.WriteFile(live, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := New()
+	got := a.ResolveSessionFile(sessionDir, "abc123")
+	if got != captured {
+		t.Errorf("got %q, want captured %q", got, captured)
+	}
+}
+
+func TestResolveSessionFile_FallsBackToLive(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Deliberately point ENTIRE_REPO_ROOT at an unrelated dir to prove the
+	// fallback uses sessionDir, not the env var.
+	t.Setenv("ENTIRE_REPO_ROOT", t.TempDir())
+
+	repoPath := t.TempDir()
+	sessionDir := filepath.Join(repoPath, ".entire", "tmp")
+	// Don't create captured file — force fallback.
+
+	liveDir := filepath.Join(home, ".pi", "agent", "sessions", piRepoDirName(repoPath))
+	if err := os.MkdirAll(liveDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	live := filepath.Join(liveDir, "2026-01-01T00-00-00-000Z_abc123.jsonl")
+	if err := os.WriteFile(live, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := New()
+	got := a.ResolveSessionFile(sessionDir, "abc123")
+	if got != live {
+		t.Errorf("got %q, want live %q", got, live)
+	}
+}


### PR DESCRIPTION
This is on top #11 
Related PR on the cli repo https://github.com/entireio/cli/pull/986

`entire attach` is used precisely when Entire hooks didn't fire, so the <sessionDir>/<id>.json snapshot that `agent_end` would normally write doesn't exist and pi reported "transcript not found" even when the live pi JSONL was sitting at ~/.pi/agent/sessions/--<escaped-repo>--/. Added a fallback to that path (accepts both the full `<ts>_<uuid>` form and bare `<uuid>`, newest-mtime wins on ambiguity).

Two subtleties:
- Repo root for the fallback is derived from `sessionDir`, not `ENTIRE_REPO_ROOT`. The protocol lets callers resolve sessions for repos other than the process cwd, so coupling to process state would return false misses. Non-standard sessionDir shapes skip the fallback rather than silently reach into env state.
- `findPiSessionFile` captures `modTime` eagerly and skips entries whose `Info()` fails; a file rotated between `ReadDir` and stat is a soft miss instead of a nil-deref panic.

Test plan:
- [ ] New unit tests pass (`go test ./internal/pi/... -run "TestResolveSessionFile|TestFindPiSessionFile|TestRepoRootFromSessionDir"`)
- [ ] Against a real session: `entire attach <id> --agent pi` now resolves to the `.jsonl` under `~/.pi/agent/sessions/`
- [ ] Pre-existing `TestGenerateExtension` failure is unrelated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3f411402fd4428ee9e3c1e6778a18fd977d02c18. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->