### PR TITLE
Add support to Kiro for compact transcripts and checkpoints v2

### DIFF
--- a/agents/entire-agent-kiro/cmd/entire-agent-kiro/main.go
+++ b/agents/entire-agent-kiro/cmd/entire-agent-kiro/main.go
@@ -38,6 +38,8 @@ func main() {
 		err = protocol.HandleChunkTranscript(os.Args[2:], os.Stdin, os.Stdout, agent)
 	case "reassemble-transcript":
 		err = protocol.HandleReassembleTranscript(os.Stdin, os.Stdout, agent)
+	case "compact-transcript":
+		err = protocol.HandleCompactTranscript(os.Args[2:], os.Stdout, agent)
 	case "format-resume-command":
 		err = protocol.HandleFormatResumeCommand(os.Args[2:], os.Stdout, agent)
 	case "parse-hook":

--- a/agents/entire-agent-kiro/internal/kiro/agent.go
+++ b/agents/entire-agent-kiro/internal/kiro/agent.go
@@ -35,6 +35,7 @@ func (a *Agent) Info() protocol.InfoResponse {
 		Capabilities: protocol.DeclaredCapabilities{
 			Hooks:              true,
 			TranscriptAnalyzer: true,
+			CompactTranscript:  true,
 			UsesTerminal:       true,
 		},
 	}

--- a/agents/entire-agent-kiro/internal/kiro/agent.go
+++ b/agents/entire-agent-kiro/internal/kiro/agent.go
@@ -97,7 +97,8 @@ func (a *Agent) WriteSession(session protocol.AgentSessionJSON) error {
 	if err := os.MkdirAll(filepath.Dir(session.SessionRef), 0o700); err != nil {
 		return err
 	}
-	return os.WriteFile(session.SessionRef, session.NativeData, 0o600)
+	data := injectTranscriptCLIVersion(session.NativeData, currentCLIVersion())
+	return os.WriteFile(session.SessionRef, data, 0o600)
 }
 
 func (a *Agent) FormatResumeCommand(_ string) string {

--- a/agents/entire-agent-kiro/internal/kiro/agent_test.go
+++ b/agents/entire-agent-kiro/internal/kiro/agent_test.go
@@ -1,6 +1,7 @@
 package kiro
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,6 +86,7 @@ func TestReadSessionReturnsErrorWhenTranscriptReadFails(t *testing.T) {
 func TestWriteSessionPersistsNativeData(t *testing.T) {
 	repoRoot := t.TempDir()
 	t.Setenv("ENTIRE_REPO_ROOT", repoRoot)
+	t.Setenv("ENTIRE_CLI_VERSION", "7.8.9")
 
 	sessionRef := filepath.Join(repoRoot, ".entire", "tmp", "session-456.json")
 	wantData := []byte(`{"conversation_id":"session-456","history":[]}`)
@@ -104,8 +106,12 @@ func TestWriteSessionPersistsNativeData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read session ref: %v", err)
 	}
-	if string(gotData) != string(wantData) {
-		t.Fatalf("written data = %q, want %q", string(gotData), string(wantData))
+	var got kiroTranscript
+	if err := json.Unmarshal(gotData, &got); err != nil {
+		t.Fatalf("parse written session: %v", err)
+	}
+	if got.ConversationID != "session-456" || got.CLIVersion != "7.8.9" {
+		t.Fatalf("written transcript = %+v, want conversation/session version preserved", got)
 	}
 }
 

--- a/agents/entire-agent-kiro/internal/kiro/compact.go
+++ b/agents/entire-agent-kiro/internal/kiro/compact.go
@@ -116,10 +116,7 @@ func compactTranscriptBytes(data []byte) ([]byte, error) {
 			nextUserContent = transcript.History[i+1].User.Content
 		}
 
-		line, ok, err := compactAssistantEntry(entry, nextUserContent)
-		if err != nil {
-			return nil, err
-		}
+		line, ok := compactAssistantEntry(entry, nextUserContent)
 		if !ok {
 			continue
 		}
@@ -134,9 +131,9 @@ func compactTranscriptBytes(data []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func compactAssistantEntry(entry kiroHistoryEntry, nextUserContent json.RawMessage) (compactTranscriptLine, bool, error) {
+func compactAssistantEntry(entry kiroHistoryEntry, nextUserContent json.RawMessage) (compactTranscriptLine, bool) {
 	if len(entry.Assistant) == 0 {
-		return compactTranscriptLine{}, false, nil
+		return compactTranscriptLine{}, false
 	}
 
 	base := compactTranscriptLine{
@@ -154,7 +151,7 @@ func compactAssistantEntry(entry kiroHistoryEntry, nextUserContent json.RawMessa
 			Type: "text",
 			Text: responseContent.Response.Content,
 		}}
-		return base, true, nil
+		return base, true
 	}
 
 	var toolUseContent kiroToolUseContent
@@ -175,10 +172,10 @@ func compactAssistantEntry(entry kiroHistoryEntry, nextUserContent json.RawMessa
 			blocks = append(blocks, block)
 		}
 		base.Content = blocks
-		return base, true, nil
+		return base, true
 	}
 
-	return compactTranscriptLine{}, false, nil
+	return compactTranscriptLine{}, false
 }
 
 func writeCompactTranscriptLine(buf *bytes.Buffer, line compactTranscriptLine) error {
@@ -186,8 +183,12 @@ func writeCompactTranscriptLine(buf *bytes.Buffer, line compactTranscriptLine) e
 	if err != nil {
 		return fmt.Errorf("marshal compact transcript line: %w", err)
 	}
-	buf.Write(encoded)
-	buf.WriteByte('\n')
+	if _, err := buf.Write(encoded); err != nil {
+		return fmt.Errorf("write compact transcript line: %w", err)
+	}
+	if err := buf.WriteByte('\n'); err != nil {
+		return fmt.Errorf("terminate compact transcript line: %w", err)
+	}
 	return nil
 }
 

--- a/agents/entire-agent-kiro/internal/kiro/compact.go
+++ b/agents/entire-agent-kiro/internal/kiro/compact.go
@@ -93,6 +93,7 @@ func compactTranscriptBytes(data []byte) ([]byte, error) {
 	if len(transcript.History) == 0 {
 		return nil, errors.New("transcript has no history entries")
 	}
+	cliVersion := compactCLIVersion(transcript)
 
 	var buf bytes.Buffer
 	for i := range transcript.History {
@@ -102,7 +103,7 @@ func compactTranscriptBytes(data []byte) ([]byte, error) {
 			if err := writeCompactTranscriptLine(&buf, compactTranscriptLine{
 				V:          1,
 				Agent:      compactTranscriptAgent,
-				CLIVersion: compactCLIVersion(),
+				CLIVersion: cliVersion,
 				Type:       "user",
 				TS:         entry.User.Timestamp,
 				Content:    []compactUserTextBlock{{Text: prompt}},
@@ -116,7 +117,7 @@ func compactTranscriptBytes(data []byte) ([]byte, error) {
 			nextUserContent = transcript.History[i+1].User.Content
 		}
 
-		line, ok := compactAssistantEntry(entry, nextUserContent)
+		line, ok := compactAssistantEntry(entry, nextUserContent, cliVersion)
 		if !ok {
 			continue
 		}
@@ -131,7 +132,7 @@ func compactTranscriptBytes(data []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func compactAssistantEntry(entry kiroHistoryEntry, nextUserContent json.RawMessage) (compactTranscriptLine, bool) {
+func compactAssistantEntry(entry kiroHistoryEntry, nextUserContent json.RawMessage, cliVersion string) (compactTranscriptLine, bool) {
 	if len(entry.Assistant) == 0 {
 		return compactTranscriptLine{}, false
 	}
@@ -139,7 +140,7 @@ func compactAssistantEntry(entry kiroHistoryEntry, nextUserContent json.RawMessa
 	base := compactTranscriptLine{
 		V:          1,
 		Agent:      compactTranscriptAgent,
-		CLIVersion: compactCLIVersion(),
+		CLIVersion: cliVersion,
 		Type:       "assistant",
 		TS:         entry.User.Timestamp,
 	}
@@ -192,8 +193,13 @@ func writeCompactTranscriptLine(buf *bytes.Buffer, line compactTranscriptLine) e
 	return nil
 }
 
-func compactCLIVersion() string {
-	if version := strings.TrimSpace(os.Getenv("ENTIRE_CLI_VERSION")); version != "" {
+func compactCLIVersion(transcript *kiroTranscript) string {
+	if transcript != nil {
+		if version := strings.TrimSpace(transcript.CLIVersion); version != "" {
+			return version
+		}
+	}
+	if version := currentCLIVersion(); version != "" {
 		return version
 	}
 	return compactTranscriptCLIVersion
@@ -247,7 +253,7 @@ func compactResultOutput(raw json.RawMessage) string {
 		return text
 	}
 
-	encoded, err := json.Marshal(json.RawMessage(raw))
+	encoded, err := json.Marshal(raw)
 	if err != nil {
 		return string(raw)
 	}

--- a/agents/entire-agent-kiro/internal/kiro/compact.go
+++ b/agents/entire-agent-kiro/internal/kiro/compact.go
@@ -1,0 +1,265 @@
+package kiro
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/entireio/external-agents/agents/entire-agent-kiro/internal/protocol"
+)
+
+const (
+	compactTranscriptAgent      = "kiro"
+	compactTranscriptCLIVersion = "unknown"
+	compactToolResultSuccess    = "success"
+	compactToolResultError      = "error"
+)
+
+var compactToolNameMap = map[string]string{
+	"fs_write": "Write",
+	"fs_edit":  "Edit",
+}
+
+type compactTranscriptLine struct {
+	V          int    `json:"v"`
+	Agent      string `json:"agent"`
+	CLIVersion string `json:"cli_version"`
+	Type       string `json:"type"`
+	TS         string `json:"ts,omitempty"`
+	ID         string `json:"id,omitempty"`
+	Content    any    `json:"content"`
+}
+
+type compactUserTextBlock struct {
+	Text string `json:"text"`
+}
+
+type compactAssistantTextBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type compactAssistantToolUseBlock struct {
+	Type   string                 `json:"type"`
+	ID     string                 `json:"id,omitempty"`
+	Name   string                 `json:"name"`
+	Input  any                    `json:"input"`
+	Result *compactToolResultJSON `json:"result,omitempty"`
+}
+
+type compactToolResultJSON struct {
+	Output string `json:"output"`
+	Status string `json:"status"`
+}
+
+type kiroToolUseResultsContent struct {
+	ToolUseResults struct {
+		ToolUseResults []kiroToolUseResult `json:"tool_use_results"`
+	} `json:"ToolUseResults"`
+}
+
+type kiroToolUseResult struct {
+	ID      string          `json:"id"`
+	Result  json.RawMessage `json:"result"`
+	Status  string          `json:"status,omitempty"`
+	IsError bool            `json:"is_error,omitempty"`
+}
+
+func (a *Agent) CompactTranscript(sessionRef string) (protocol.CompactTranscriptResponse, error) {
+	data, err := os.ReadFile(sessionRef)
+	if err != nil {
+		return protocol.CompactTranscriptResponse{}, fmt.Errorf("failed to read transcript: %w", err)
+	}
+
+	compacted, err := compactTranscriptBytes(data)
+	if err != nil {
+		return protocol.CompactTranscriptResponse{}, err
+	}
+
+	return protocol.CompactTranscriptResponse{
+		Transcript: base64.StdEncoding.EncodeToString(compacted),
+	}, nil
+}
+
+func compactTranscriptBytes(data []byte) ([]byte, error) {
+	transcript, err := parseTranscript(data)
+	if err != nil {
+		return nil, err
+	}
+	if len(transcript.History) == 0 {
+		return nil, errors.New("transcript has no history entries")
+	}
+
+	var buf bytes.Buffer
+	for i := range transcript.History {
+		entry := transcript.History[i]
+
+		if prompt := extractUserPrompt(entry.User.Content); prompt != "" {
+			if err := writeCompactTranscriptLine(&buf, compactTranscriptLine{
+				V:          1,
+				Agent:      compactTranscriptAgent,
+				CLIVersion: compactCLIVersion(),
+				Type:       "user",
+				TS:         entry.User.Timestamp,
+				Content:    []compactUserTextBlock{{Text: prompt}},
+			}); err != nil {
+				return nil, err
+			}
+		}
+
+		nextUserContent := json.RawMessage(nil)
+		if i+1 < len(transcript.History) {
+			nextUserContent = transcript.History[i+1].User.Content
+		}
+
+		line, ok, err := compactAssistantEntry(entry, nextUserContent)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		if err := writeCompactTranscriptLine(&buf, line); err != nil {
+			return nil, err
+		}
+	}
+
+	if buf.Len() == 0 {
+		return nil, errors.New("compact transcript produced no output")
+	}
+	return buf.Bytes(), nil
+}
+
+func compactAssistantEntry(entry kiroHistoryEntry, nextUserContent json.RawMessage) (compactTranscriptLine, bool, error) {
+	if len(entry.Assistant) == 0 {
+		return compactTranscriptLine{}, false, nil
+	}
+
+	base := compactTranscriptLine{
+		V:          1,
+		Agent:      compactTranscriptAgent,
+		CLIVersion: compactCLIVersion(),
+		Type:       "assistant",
+		TS:         entry.User.Timestamp,
+	}
+
+	var responseContent kiroResponseContent
+	if err := json.Unmarshal(entry.Assistant, &responseContent); err == nil && responseContent.Response.Content != "" {
+		base.ID = responseContent.Response.MessageID
+		base.Content = []compactAssistantTextBlock{{
+			Type: "text",
+			Text: responseContent.Response.Content,
+		}}
+		return base, true, nil
+	}
+
+	var toolUseContent kiroToolUseContent
+	if err := json.Unmarshal(entry.Assistant, &toolUseContent); err == nil && len(toolUseContent.ToolUse.ToolUses) > 0 {
+		base.ID = toolUseContent.ToolUse.MessageID
+		results := extractCompactToolResults(nextUserContent)
+		blocks := make([]compactAssistantToolUseBlock, 0, len(toolUseContent.ToolUse.ToolUses))
+		for _, call := range toolUseContent.ToolUse.ToolUses {
+			block := compactAssistantToolUseBlock{
+				Type:  "tool_use",
+				ID:    call.ID,
+				Name:  normalizeCompactToolName(call.Name),
+				Input: decodeCompactInput(call.Args),
+			}
+			if result, ok := results[call.ID]; ok {
+				block.Result = &result
+			}
+			blocks = append(blocks, block)
+		}
+		base.Content = blocks
+		return base, true, nil
+	}
+
+	return compactTranscriptLine{}, false, nil
+}
+
+func writeCompactTranscriptLine(buf *bytes.Buffer, line compactTranscriptLine) error {
+	encoded, err := json.Marshal(line)
+	if err != nil {
+		return fmt.Errorf("marshal compact transcript line: %w", err)
+	}
+	buf.Write(encoded)
+	buf.WriteByte('\n')
+	return nil
+}
+
+func compactCLIVersion() string {
+	if version := strings.TrimSpace(os.Getenv("ENTIRE_CLI_VERSION")); version != "" {
+		return version
+	}
+	return compactTranscriptCLIVersion
+}
+
+func normalizeCompactToolName(name string) string {
+	if normalized, ok := compactToolNameMap[name]; ok {
+		return normalized
+	}
+	return name
+}
+
+func decodeCompactInput(raw json.RawMessage) any {
+	if len(raw) == 0 {
+		return map[string]any{}
+	}
+
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return map[string]any{}
+	}
+	return decoded
+}
+
+func extractCompactToolResults(content json.RawMessage) map[string]compactToolResultJSON {
+	var parsed kiroToolUseResultsContent
+	if err := json.Unmarshal(content, &parsed); err != nil || len(parsed.ToolUseResults.ToolUseResults) == 0 {
+		return nil
+	}
+
+	results := make(map[string]compactToolResultJSON, len(parsed.ToolUseResults.ToolUseResults))
+	for _, result := range parsed.ToolUseResults.ToolUseResults {
+		if result.ID == "" {
+			continue
+		}
+		results[result.ID] = compactToolResultJSON{
+			Output: compactResultOutput(result.Result),
+			Status: compactResultStatus(result),
+		}
+	}
+	return results
+}
+
+func compactResultOutput(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return text
+	}
+
+	encoded, err := json.Marshal(json.RawMessage(raw))
+	if err != nil {
+		return string(raw)
+	}
+	return string(encoded)
+}
+
+func compactResultStatus(result kiroToolUseResult) string {
+	switch strings.ToLower(strings.TrimSpace(result.Status)) {
+	case compactToolResultSuccess, compactToolResultError:
+		return strings.ToLower(strings.TrimSpace(result.Status))
+	}
+	if result.IsError {
+		return compactToolResultError
+	}
+	return compactToolResultSuccess
+}

--- a/agents/entire-agent-kiro/internal/kiro/compact_test.go
+++ b/agents/entire-agent-kiro/internal/kiro/compact_test.go
@@ -1,0 +1,87 @@
+package kiro
+
+import (
+	"encoding/base64"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestCompactTranscriptFromCLITranscript(t *testing.T) {
+	t.Setenv("ENTIRE_CLI_VERSION", "9.9.9")
+
+	path := writeCompactTranscriptFixture(t, testCLIAnalyzerTranscript)
+
+	resp, err := New().CompactTranscript(path)
+	if err != nil {
+		t.Fatalf("CompactTranscript() error = %v", err)
+	}
+
+	data, err := base64.StdEncoding.DecodeString(resp.Transcript)
+	if err != nil {
+		t.Fatalf("decode transcript: %v", err)
+	}
+
+	want := strings.Join([]string{
+		`{"v":1,"agent":"kiro","cli_version":"9.9.9","type":"user","ts":"2026-01-01T00:00:00Z","content":[{"text":"Create a hello.go file"}]}`,
+		`{"v":1,"agent":"kiro","cli_version":"9.9.9","type":"assistant","ts":"2026-01-01T00:00:00Z","id":"msg-1","content":[{"type":"text","text":"I'll create that file for you."}]}`,
+		`{"v":1,"agent":"kiro","cli_version":"9.9.9","type":"user","ts":"2026-01-01T00:01:00Z","content":[{"text":"Now add a test"}]}`,
+		`{"v":1,"agent":"kiro","cli_version":"9.9.9","type":"assistant","ts":"2026-01-01T00:01:00Z","id":"msg-2","content":[{"type":"tool_use","id":"tu-1","name":"Write","input":{"content":"package main","path":"/repo/hello.go"},"result":{"output":"ok","status":"success"}}]}`,
+		`{"v":1,"agent":"kiro","cli_version":"9.9.9","type":"assistant","id":"msg-3","content":[{"type":"tool_use","id":"tu-2","name":"Write","input":{"content":"package main","path":"/repo/hello_test.go"},"result":{"output":"ok","status":"success"}}]}`,
+		`{"v":1,"agent":"kiro","cli_version":"9.9.9","type":"assistant","id":"msg-4","content":[{"type":"text","text":"Done! I created both files."}]}`,
+		"",
+	}, "\n")
+
+	if string(data) != want {
+		t.Fatalf("compact transcript = %q, want %q", string(data), want)
+	}
+}
+
+func TestCompactTranscriptFromIDETranscript(t *testing.T) {
+	t.Setenv("ENTIRE_CLI_VERSION", "1.2.3")
+
+	path := writeCompactTranscriptFixture(t, testIDEAnalyzerTranscript)
+
+	resp, err := New().CompactTranscript(path)
+	if err != nil {
+		t.Fatalf("CompactTranscript() error = %v", err)
+	}
+
+	data, err := base64.StdEncoding.DecodeString(resp.Transcript)
+	if err != nil {
+		t.Fatalf("decode transcript: %v", err)
+	}
+
+	want := strings.Join([]string{
+		`{"v":1,"agent":"kiro","cli_version":"1.2.3","type":"user","content":[{"text":"Open the workspace"}]}`,
+		`{"v":1,"agent":"kiro","cli_version":"1.2.3","type":"assistant","content":[{"type":"text","text":"I opened the workspace."}]}`,
+		`{"v":1,"agent":"kiro","cli_version":"1.2.3","type":"user","content":[{"text":"Create app.js"}]}`,
+		`{"v":1,"agent":"kiro","cli_version":"1.2.3","type":"assistant","content":[{"type":"text","text":"Created app.js."}]}`,
+		"",
+	}, "\n")
+
+	if string(data) != want {
+		t.Fatalf("compact transcript = %q, want %q", string(data), want)
+	}
+}
+
+func TestCompactTranscriptRejectsEmptyTranscript(t *testing.T) {
+	path := writeCompactTranscriptFixture(t, `{}`)
+
+	_, err := New().CompactTranscript(path)
+	if err == nil {
+		t.Fatal("expected error for empty transcript, got nil")
+	}
+	if !strings.Contains(err.Error(), "no history entries") {
+		t.Fatalf("error = %v, want no history entries", err)
+	}
+}
+
+func writeCompactTranscriptFixture(t *testing.T, content string) string {
+	t.Helper()
+	path := t.TempDir() + "/transcript.json"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write transcript fixture: %v", err)
+	}
+	return path
+}

--- a/agents/entire-agent-kiro/internal/kiro/compact_test.go
+++ b/agents/entire-agent-kiro/internal/kiro/compact_test.go
@@ -65,6 +65,28 @@ func TestCompactTranscriptFromIDETranscript(t *testing.T) {
 	}
 }
 
+func TestCompactTranscriptPrefersPreservedCLIVersion(t *testing.T) {
+	t.Setenv("ENTIRE_CLI_VERSION", "9.9.9")
+
+	path := writeCompactTranscriptFixture(t, strings.Replace(testCLIAnalyzerTranscript, `  "history": [`, "  \"cli_version\": \"1.2.3\",\n  \"history\": [", 1))
+
+	resp, err := New().CompactTranscript(path)
+	if err != nil {
+		t.Fatalf("CompactTranscript() error = %v", err)
+	}
+
+	data, err := base64.StdEncoding.DecodeString(resp.Transcript)
+	if err != nil {
+		t.Fatalf("decode transcript: %v", err)
+	}
+	if !strings.Contains(string(data), `"cli_version":"1.2.3"`) {
+		t.Fatalf("compact transcript should preserve stored cli_version, got %q", string(data))
+	}
+	if strings.Contains(string(data), `"cli_version":"9.9.9"`) {
+		t.Fatalf("compact transcript should not overwrite stored cli_version, got %q", string(data))
+	}
+}
+
 func TestCompactTranscriptRejectsEmptyTranscript(t *testing.T) {
 	path := writeCompactTranscriptFixture(t, `{}`)
 

--- a/agents/entire-agent-kiro/internal/kiro/transcript.go
+++ b/agents/entire-agent-kiro/internal/kiro/transcript.go
@@ -150,6 +150,7 @@ func (a *Agent) ensureCachedTranscript(cwd string, sessionID string, conversatio
 	if filtered, ok := a.trimTranscriptHistory([]byte(raw)); ok {
 		data = filtered
 	}
+	data = injectTranscriptCLIVersion(data, currentCLIVersion())
 
 	// If the transcript has no history (e.g., offset trimmed everything),
 	// return error so captureTranscriptForStop can try other sources (IDE).
@@ -300,6 +301,7 @@ func (a *Agent) ensureIDETranscript(cwd string, sessionID string) (string, error
 	if filtered, ok := a.trimTranscriptHistory(data); ok {
 		data = filtered
 	}
+	data = injectTranscriptCLIVersion(data, currentCLIVersion())
 
 	if parsed, parseErr := parseTranscript(data); parseErr == nil && len(parsed.History) == 0 {
 		return "", errors.New("IDE transcript has no history entries after trimming")
@@ -539,7 +541,7 @@ func tryParseIDETranscript(data []byte) *kiroTranscript {
 }
 
 func convertIDETranscript(ide *kiroIDETranscript) *kiroTranscript {
-	transcript := &kiroTranscript{}
+	transcript := &kiroTranscript{CLIVersion: ide.CLIVersion}
 
 	var pendingUser *kiroIDEHistoryEntry
 	for i := range ide.History {
@@ -561,6 +563,43 @@ func convertIDETranscript(ide *kiroIDETranscript) *kiroTranscript {
 	}
 
 	return transcript
+}
+
+func currentCLIVersion() string {
+	return strings.TrimSpace(os.Getenv("ENTIRE_CLI_VERSION"))
+}
+
+func injectTranscriptCLIVersion(data []byte, version string) []byte {
+	if len(data) == 0 || version == "" {
+		return data
+	}
+
+	var transcript kiroTranscript
+	if err := json.Unmarshal(data, &transcript); err == nil {
+		if transcript.CLIVersion != "" {
+			return data
+		}
+		if transcript.ConversationID != "" || isCLITranscript(&transcript) {
+			transcript.CLIVersion = version
+			if encoded, err := json.Marshal(transcript); err == nil {
+				return encoded
+			}
+			return data
+		}
+	}
+
+	var ide kiroIDETranscript
+	if err := json.Unmarshal(data, &ide); err == nil {
+		if ide.CLIVersion != "" || len(ide.History) == 0 {
+			return data
+		}
+		ide.CLIVersion = version
+		if encoded, err := json.Marshal(ide); err == nil {
+			return encoded
+		}
+	}
+
+	return data
 }
 
 func ideEntryToPaired(user, assistant *kiroIDEHistoryEntry) kiroHistoryEntry {

--- a/agents/entire-agent-kiro/internal/kiro/transcript_test.go
+++ b/agents/entire-agent-kiro/internal/kiro/transcript_test.go
@@ -145,6 +145,7 @@ func TestEnsureCachedTranscriptWritesSQLiteTranscript(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("ENTIRE_REPO_ROOT", repoRoot)
 	t.Setenv("HOME", home)
+	t.Setenv("ENTIRE_CLI_VERSION", "3.4.5")
 
 	stubData := buildTranscript("cli-session", 2)
 	db := createFakeKiroDB(t, home)
@@ -178,8 +179,8 @@ func TestEnsureCachedTranscriptWritesSQLiteTranscript(t *testing.T) {
 	if err := json.Unmarshal(data, &result); err != nil {
 		t.Fatalf("parse cached transcript: %v", err)
 	}
-	if result.ConversationID != "cli-session" || len(result.History) != 2 {
-		t.Fatalf("cached transcript conv=%q history=%d, want cli-session/2", result.ConversationID, len(result.History))
+	if result.ConversationID != "cli-session" || len(result.History) != 2 || result.CLIVersion != "3.4.5" {
+		t.Fatalf("cached transcript conv=%q history=%d cli_version=%q, want cli-session/2/3.4.5", result.ConversationID, len(result.History), result.CLIVersion)
 	}
 }
 
@@ -189,6 +190,7 @@ func TestEnsureIDETranscriptCopiesLatestWorkspaceSession(t *testing.T) {
 	cwd := filepath.Join(repoRoot, "workspace")
 	t.Setenv("ENTIRE_REPO_ROOT", repoRoot)
 	t.Setenv("HOME", home)
+	t.Setenv("ENTIRE_CLI_VERSION", "4.5.6")
 	if err := os.MkdirAll(cwd, 0o750); err != nil {
 		t.Fatalf("mkdir cwd: %v", err)
 	}
@@ -222,8 +224,12 @@ func TestEnsureIDETranscriptCopiesLatestWorkspaceSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read cached IDE transcript: %v", err)
 	}
-	if string(data) != `{"history":[{"message":{"role":"assistant","content":"new"}}]}` {
-		t.Fatalf("cached IDE transcript = %q", string(data))
+	var result kiroIDETranscript
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("parse cached IDE transcript: %v", err)
+	}
+	if result.CLIVersion != "4.5.6" || len(result.History) != 1 || result.History[0].Message.Content == nil {
+		t.Fatalf("cached IDE transcript = %+v", result)
 	}
 }
 
@@ -233,6 +239,7 @@ func TestEnsureIDETranscriptRejectsPathTraversal(t *testing.T) {
 	cwd := filepath.Join(repoRoot, "workspace")
 	t.Setenv("ENTIRE_REPO_ROOT", repoRoot)
 	t.Setenv("HOME", home)
+	t.Setenv("ENTIRE_CLI_VERSION", "4.5.6")
 	if err := os.MkdirAll(cwd, 0o750); err != nil {
 		t.Fatalf("mkdir cwd: %v", err)
 	}
@@ -315,6 +322,7 @@ func TestParseHookStopFallsBackToIDETranscript(t *testing.T) {
 	cwd := filepath.Join(repoRoot, "workspace")
 	t.Setenv("ENTIRE_REPO_ROOT", repoRoot)
 	t.Setenv("HOME", home)
+	t.Setenv("ENTIRE_CLI_VERSION", "4.5.6")
 	if err := os.MkdirAll(cwd, 0o750); err != nil {
 		t.Fatalf("mkdir cwd: %v", err)
 	}
@@ -343,8 +351,12 @@ func TestParseHookStopFallsBackToIDETranscript(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read cached transcript: %v", err)
 	}
-	if string(data) != `{"history":[{"message":{"role":"assistant","content":"ide"}}]}` {
-		t.Fatalf("cached IDE transcript = %q", string(data))
+	var result kiroIDETranscript
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("parse cached IDE transcript: %v", err)
+	}
+	if result.CLIVersion != "4.5.6" || len(result.History) != 1 {
+		t.Fatalf("cached IDE transcript = %+v", result)
 	}
 }
 

--- a/agents/entire-agent-kiro/internal/kiro/types.go
+++ b/agents/entire-agent-kiro/internal/kiro/types.go
@@ -57,6 +57,7 @@ type kiroIDEHookThen struct {
 
 type kiroTranscript struct {
 	ConversationID string             `json:"conversation_id"`
+	CLIVersion     string             `json:"cli_version,omitempty"`
 	History        []kiroHistoryEntry `json:"history"`
 }
 
@@ -101,7 +102,8 @@ type kiroToolCall struct {
 }
 
 type kiroIDETranscript struct {
-	History []kiroIDEHistoryEntry `json:"history"`
+	CLIVersion string                `json:"cli_version,omitempty"`
+	History    []kiroIDEHistoryEntry `json:"history"`
 }
 
 type kiroIDEHistoryEntry struct {

--- a/agents/entire-agent-kiro/internal/protocol/handlers_test.go
+++ b/agents/entire-agent-kiro/internal/protocol/handlers_test.go
@@ -68,6 +68,15 @@ func (c testTranscriptChunker) ReassembleTranscript(_ [][]byte) ([]byte, error) 
 	return c.data, c.err
 }
 
+type testTranscriptCompactor struct {
+	response CompactTranscriptResponse
+	err      error
+}
+
+func (c testTranscriptCompactor) CompactTranscript(_ string) (CompactTranscriptResponse, error) {
+	return c.response, c.err
+}
+
 type testResumeFormatter struct{}
 
 func (testResumeFormatter) FormatResumeCommand(sessionID string) string {
@@ -250,6 +259,19 @@ func TestHandlerRoundTripForCoreProtocolCommands(t *testing.T) {
 			t.Fatalf("HandleFormatResumeCommand() error = %v", err)
 		}
 		if got := stdout.String(); !strings.Contains(got, `"command":"resume abc123"`) {
+			t.Fatalf("stdout = %s", got)
+		}
+	})
+
+	t.Run("compact-transcript", func(t *testing.T) {
+		var stdout bytes.Buffer
+		err := HandleCompactTranscript([]string{"--session-ref", "/tmp/repo/.entire/tmp/abc123.json"}, &stdout, testTranscriptCompactor{
+			response: CompactTranscriptResponse{Transcript: "eyJ2IjoxfQo="},
+		})
+		if err != nil {
+			t.Fatalf("HandleCompactTranscript() error = %v", err)
+		}
+		if got := stdout.String(); !strings.Contains(got, `"transcript":"eyJ2IjoxfQo="`) {
 			t.Fatalf("stdout = %s", got)
 		}
 	})

--- a/agents/entire-agent-kiro/internal/protocol/info_test.go
+++ b/agents/entire-agent-kiro/internal/protocol/info_test.go
@@ -49,6 +49,9 @@ func TestInfoResponseShape(t *testing.T) {
 	if !info.Capabilities.TranscriptAnalyzer {
 		t.Fatal("transcript_analyzer capability should be true")
 	}
+	if !info.Capabilities.CompactTranscript {
+		t.Fatal("compact_transcript capability should be true")
+	}
 	if !info.Capabilities.UsesTerminal {
 		t.Fatal("uses_terminal capability should be true")
 	}

--- a/agents/entire-agent-kiro/internal/protocol/protocol.go
+++ b/agents/entire-agent-kiro/internal/protocol/protocol.go
@@ -38,6 +38,10 @@ type transcriptChunker interface {
 	ReassembleTranscript(chunks [][]byte) ([]byte, error)
 }
 
+type transcriptCompactor interface {
+	CompactTranscript(sessionRef string) (CompactTranscriptResponse, error)
+}
+
 type resumeFormatter interface {
 	FormatResumeCommand(sessionID string) string
 }
@@ -175,6 +179,20 @@ func HandleReassembleTranscript(stdin io.Reader, stdout io.Writer, chunker trans
 	}
 	_, err = stdout.Write(data)
 	return err
+}
+
+func HandleCompactTranscript(args []string, stdout io.Writer, compactor transcriptCompactor) error {
+	fs := flag.NewFlagSet("compact-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	compacted, err := compactor.CompactTranscript(*sessionRef)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, compacted)
 }
 
 func HandleFormatResumeCommand(args []string, stdout io.Writer, formatter resumeFormatter) error {

--- a/agents/entire-agent-kiro/internal/protocol/types.go
+++ b/agents/entire-agent-kiro/internal/protocol/types.go
@@ -9,6 +9,7 @@ type DeclaredCapabilities struct {
 	TranscriptAnalyzer     bool `json:"transcript_analyzer"`
 	TranscriptPreparer     bool `json:"transcript_preparer"`
 	TokenCalculator        bool `json:"token_calculator"`
+	CompactTranscript      bool `json:"compact_transcript"`
 	TextGenerator          bool `json:"text_generator"`
 	HookResponseWriter     bool `json:"hook_response_writer"`
 	SubagentAwareExtractor bool `json:"subagent_aware_extractor"`
@@ -74,6 +75,17 @@ type ExtractPromptsResponse struct {
 type ExtractSummaryResponse struct {
 	Summary    string `json:"summary"`
 	HasSummary bool   `json:"has_summary"`
+}
+
+type CompactTranscriptResponse struct {
+	Transcript string                       `json:"transcript"`
+	Assets     []CompactTranscriptAssetJSON `json:"assets,omitempty"`
+}
+
+type CompactTranscriptAssetJSON struct {
+	Name      string `json:"name"`
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
 }
 
 type AgentSessionJSON struct {


### PR DESCRIPTION
Follows specification in the [external agent protocol](https://github.com/entireio/cli/blob/main/docs/architecture/external-agent-protocol.md#capability-compact_transcript) to support the agent-agnostic `transcript.jsonl` files that are used by Entire.

```
➜  test-repo git:(v2-testing) ✗ entire-agent-kiro info | jq .capabilities
{
  "hooks": true,
  "transcript_analyzer": true,
  "transcript_preparer": false,
  "token_calculator": false,
  "compact_transcript": true,
  "text_generator": false,
  "hook_response_writer": false,
  "subagent_aware_extractor": false,
  "uses_terminal": true
}
```

Example snippet of the compact format:

```
{"v":1,"agent":"kiro","cli_version":"unknown","type":"user","content":[{"text":"add a comment to the kiro readme in this repo"}]}
{"v":1,"agent":"kiro","cli_version":"unknown","type":"assistant","content":[{"type":"text","text":"Added a comment to the kiro README."}]}
```

The `cli_version` set to `unknown` is actually a bug in the CLI repo, not the compact transcript implementation here. Fixed here: https://github.com/entireio/cli/pull/1032

```
➜  entire-agent-kiro info | jq .capabilities
{
  "hooks": true,
  "transcript_analyzer": true,
  "transcript_preparer": false,
  "token_calculator": false,
  "compact_transcript": true,
  "text_generator": false,
  "hook_response_writer": false,
  "subagent_aware_extractor": false,
  "uses_terminal": true
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds a new protocol surface (`compact-transcript`) and non-trivial transcript transformation/parsing logic that could affect downstream consumers if the output shape or tool-result mapping is incorrect.
> 
> **Overview**
> Adds support for the protocol `compact_transcript` capability by wiring a new `compact-transcript` CLI subcommand through the protocol layer and advertising the capability in `Info()`.
> 
> Implements transcript compaction for Kiro by converting existing transcript JSON into an agent-agnostic `transcript.jsonl`-style format (user text, assistant text, and tool-use blocks with normalized tool names and attached tool results), base64-encoding the output in `CompactTranscriptResponse`, and adding unit tests covering CLI/IDE transcripts plus empty-transcript rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21b5890d71cd32bd8bbf373046f91d8ea88a3316. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->