### PR TITLE
Add checkpoints v2 + compact transcript support to Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ External agents communicate with Entire CLI via subcommands that accept and retu
 | Agent | Directory | Status |
 |-------|-----------|--------|
 | [Kiro](agents/entire-agent-kiro/) | `agents/entire-agent-kiro/` | Implemented — hooks + transcript analysis |
-| [Pi](agents/entire-agent-pi/) | `agents/entire-agent-pi/` | Implemented — hooks + transcript analysis + token calculation |
+| [Pi](agents/entire-agent-pi/) | `agents/entire-agent-pi/` | Implemented — hooks + transcript analysis + token calculation + compact transcripts |
 
 See each agent's own README for setup and usage instructions.
 

--- a/agents/entire-agent-pi/AGENT.md
+++ b/agents/entire-agent-pi/AGENT.md
@@ -156,6 +156,7 @@ File-modifying tools:
 | `read-transcript` | JSONL file bytes | Read raw bytes from Pi session or cached `.entire/tmp/<id>.json` | Required |
 | `chunk-transcript` | raw bytes | Base64 chunk by max size | Required |
 | `reassemble-transcript` | base64 chunks | Reassemble chunks | Required |
+| `compact-transcript` | compact JSONL | Emit normalized Entire compact transcript JSONL for checkpoints v2 | Compact transcript |
 | `format-resume-command` | `pi --continue` | Return `pi --continue` or `pi --session <path>` | Required |
 | `parse-hook` | extension event JSON | Map extension JSON to EventJSON (type 1/2/3) | Hooks |
 | `install-hooks` | `.pi/extensions/entire/` | Write TypeScript extension that calls `entire agent hook pi <event>` | Hooks |
@@ -173,6 +174,7 @@ File-modifying tools:
 | transcript_analyzer | true | JSONL transcripts contain full structured data — tool calls, prompts, responses (verified) |
 | transcript_preparer | false | JSONL files are directly readable, no pre-processing needed |
 | token_calculator | true | Assistant messages contain `usage` with input/output/cache tokens (verified) |
+| compact_transcript | true | JSONL transcripts can be converted to agent-agnostic compact transcript entries with inlined tool results |
 | text_generator | false | Pi CLI is used for agent execution, not standalone text generation |
 | hook_response_writer | false | No mechanism for writing structured responses back through hooks |
 | subagent_aware_extractor | false | Pi does not expose a subagent transcript tree |

--- a/agents/entire-agent-pi/README.md
+++ b/agents/entire-agent-pi/README.md
@@ -9,6 +9,7 @@ External agent binary that teaches the [Entire CLI](https://github.com/entireio/
 | hooks | Yes — TypeScript extension in `.pi/extensions/entire/` |
 | transcript_analyzer | Yes — parses JSONL session files for prompts, files, summary |
 | token_calculator | Yes — sums token usage from assistant messages |
+| compact_transcript | Yes — emits Entire compact transcript JSONL for checkpoints v2 |
 
 ## Installation
 

--- a/agents/entire-agent-pi/cmd/entire-agent-pi/main.go
+++ b/agents/entire-agent-pi/cmd/entire-agent-pi/main.go
@@ -38,6 +38,8 @@ func main() {
 		err = protocol.HandleChunkTranscript(os.Args[2:], os.Stdin, os.Stdout, agent)
 	case "reassemble-transcript":
 		err = protocol.HandleReassembleTranscript(os.Stdin, os.Stdout, agent)
+	case "compact-transcript":
+		err = protocol.HandleCompactTranscript(os.Args[2:], os.Stdout, agent)
 	case "format-resume-command":
 		err = protocol.HandleFormatResumeCommand(os.Args[2:], os.Stdout, agent)
 	case "parse-hook":

--- a/agents/entire-agent-pi/internal/pi/agent.go
+++ b/agents/entire-agent-pi/internal/pi/agent.go
@@ -25,6 +25,7 @@ func (a *Agent) Info() protocol.InfoResponse {
 			Hooks:              true,
 			TranscriptAnalyzer: true,
 			TokenCalculator:    true,
+			CompactTranscript:  true,
 			UsesTerminal:       true,
 		},
 	}

--- a/agents/entire-agent-pi/internal/pi/compact.go
+++ b/agents/entire-agent-pi/internal/pi/compact.go
@@ -1,0 +1,314 @@
+package pi
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/entireio/external-agents/agents/entire-agent-pi/internal/protocol"
+)
+
+const (
+	compactTranscriptAgent      = "pi"
+	compactTranscriptCLIVersion = "unknown"
+	compactToolResultSuccess    = "success"
+	compactToolResultError      = "error"
+)
+
+var compactToolNameMap = map[string]string{
+	"edit":  "Edit",
+	"read":  "Read",
+	"write": "Write",
+}
+
+type compactTranscriptLine struct {
+	V            int    `json:"v"`
+	Agent        string `json:"agent"`
+	CLIVersion   string `json:"cli_version"`
+	Type         string `json:"type"`
+	TS           string `json:"ts,omitempty"`
+	ID           string `json:"id,omitempty"`
+	InputTokens  int    `json:"input_tokens,omitempty"`
+	OutputTokens int    `json:"output_tokens,omitempty"`
+	Content      any    `json:"content"`
+}
+
+type compactUserTextBlock struct {
+	Text string `json:"text"`
+}
+
+type compactAssistantTextBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type compactAssistantToolUseBlock struct {
+	Type   string                 `json:"type"`
+	ID     string                 `json:"id,omitempty"`
+	Name   string                 `json:"name"`
+	Input  any                    `json:"input"`
+	Result *compactToolResultJSON `json:"result,omitempty"`
+}
+
+type compactToolResultJSON struct {
+	Output string `json:"output"`
+	Status string `json:"status"`
+}
+
+func (a *Agent) CompactTranscript(sessionRef string) (protocol.CompactTranscriptResponse, error) {
+	data, err := os.ReadFile(sessionRef)
+	if err != nil {
+		return protocol.CompactTranscriptResponse{}, fmt.Errorf("failed to read transcript: %w", err)
+	}
+
+	compacted, err := compactTranscriptBytes(data)
+	if err != nil {
+		return protocol.CompactTranscriptResponse{}, err
+	}
+
+	return protocol.CompactTranscriptResponse{
+		Transcript: base64.StdEncoding.EncodeToString(compacted),
+	}, nil
+}
+
+func compactTranscriptBytes(data []byte) ([]byte, error) {
+	active := resolveActiveBranch(data)
+	results, err := collectCompactToolResults(data, active)
+	if err != nil {
+		return nil, err
+	}
+
+	cliVersion := compactCLIVersion()
+	var buf bytes.Buffer
+
+	scanner := newJSONLScanner(data)
+	for scanner.Scan() {
+		var entry messageEntry
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue
+		}
+		if entry.Type != entryTypeMessage {
+			continue
+		}
+		if active != nil && !active[entry.ID] {
+			continue
+		}
+
+		switch entry.Message.Role {
+		case "user":
+			content := compactUserContent(entry.Message.Content)
+			if len(content) == 0 {
+				continue
+			}
+			if err := writeCompactTranscriptLine(&buf, compactTranscriptLine{
+				V:          1,
+				Agent:      compactTranscriptAgent,
+				CLIVersion: cliVersion,
+				Type:       "user",
+				TS:         entry.Timestamp,
+				Content:    content,
+			}); err != nil {
+				return nil, err
+			}
+
+		case "assistant":
+			content := compactAssistantContent(entry.Message.Content, results)
+			if len(content) == 0 {
+				continue
+			}
+			line := compactTranscriptLine{
+				V:          1,
+				Agent:      compactTranscriptAgent,
+				CLIVersion: cliVersion,
+				Type:       "assistant",
+				TS:         entry.Timestamp,
+				ID:         entry.ID,
+				Content:    content,
+			}
+			if entry.Message.Usage != nil {
+				line.InputTokens = entry.Message.Usage.Input
+				line.OutputTokens = entry.Message.Usage.Output
+			}
+			if err := writeCompactTranscriptLine(&buf, line); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan transcript: %w", err)
+	}
+	if buf.Len() == 0 {
+		return nil, errors.New("compact transcript produced no output")
+	}
+	return buf.Bytes(), nil
+}
+
+func compactUserContent(raw json.RawMessage) []compactUserTextBlock {
+	if text := decodeCompactString(raw); text != "" {
+		return []compactUserTextBlock{{Text: text}}
+	}
+
+	var items []contentItem
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return nil
+	}
+
+	blocks := make([]compactUserTextBlock, 0, len(items))
+	for _, item := range items {
+		if item.Type == "text" && item.Text != "" {
+			blocks = append(blocks, compactUserTextBlock{Text: item.Text})
+		}
+	}
+	return blocks
+}
+
+func compactAssistantContent(raw json.RawMessage, results map[string]compactToolResultJSON) []any {
+	if text := decodeCompactString(raw); text != "" {
+		return []any{compactAssistantTextBlock{Type: "text", Text: text}}
+	}
+
+	var items []contentItem
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return nil
+	}
+
+	blocks := make([]any, 0, len(items))
+	for _, item := range items {
+		switch item.Type {
+		case "text":
+			if item.Text != "" {
+				blocks = append(blocks, compactAssistantTextBlock{
+					Type: "text",
+					Text: item.Text,
+				})
+			}
+		case "toolCall":
+			block := compactAssistantToolUseBlock{
+				Type:  "tool_use",
+				ID:    item.ID,
+				Name:  normalizeCompactToolName(item.Name),
+				Input: decodeCompactInput(item.Arguments),
+			}
+			if result, ok := results[item.ID]; ok {
+				block.Result = &result
+			}
+			blocks = append(blocks, block)
+		}
+	}
+	return blocks
+}
+
+func collectCompactToolResults(data []byte, active map[string]bool) (map[string]compactToolResultJSON, error) {
+	results := map[string]compactToolResultJSON{}
+	scanner := newJSONLScanner(data)
+	for scanner.Scan() {
+		var entry messageEntry
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue
+		}
+		if entry.Type != entryTypeMessage || entry.Message.Role != "toolResult" {
+			continue
+		}
+		if active != nil && !active[entry.ID] {
+			continue
+		}
+		if entry.Message.ToolCallID == "" {
+			continue
+		}
+		results[entry.Message.ToolCallID] = compactToolResultJSON{
+			Output: compactResultOutput(entry.Message.Content),
+			Status: compactResultStatus(entry.Message.IsError),
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan tool results: %w", err)
+	}
+	return results, nil
+}
+
+func writeCompactTranscriptLine(buf *bytes.Buffer, line compactTranscriptLine) error {
+	encoded, err := json.Marshal(line)
+	if err != nil {
+		return fmt.Errorf("marshal compact transcript line: %w", err)
+	}
+	if _, err := buf.Write(encoded); err != nil {
+		return fmt.Errorf("write compact transcript line: %w", err)
+	}
+	if err := buf.WriteByte('\n'); err != nil {
+		return fmt.Errorf("terminate compact transcript line: %w", err)
+	}
+	return nil
+}
+
+func compactCLIVersion() string {
+	if version := strings.TrimSpace(os.Getenv("ENTIRE_CLI_VERSION")); version != "" {
+		return version
+	}
+	return compactTranscriptCLIVersion
+}
+
+func normalizeCompactToolName(name string) string {
+	if normalized, ok := compactToolNameMap[name]; ok {
+		return normalized
+	}
+	return name
+}
+
+func decodeCompactInput(raw json.RawMessage) any {
+	if len(raw) == 0 {
+		return map[string]any{}
+	}
+
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return map[string]any{}
+	}
+	return decoded
+}
+
+func decodeCompactString(raw json.RawMessage) string {
+	var text string
+	if err := json.Unmarshal(raw, &text); err != nil {
+		return ""
+	}
+	return text
+}
+
+func compactResultOutput(raw json.RawMessage) string {
+	if text := decodeCompactString(raw); text != "" {
+		return text
+	}
+
+	var items []contentItem
+	if err := json.Unmarshal(raw, &items); err == nil {
+		texts := make([]string, 0, len(items))
+		for _, item := range items {
+			if item.Type == "text" && item.Text != "" {
+				texts = append(texts, item.Text)
+			}
+		}
+		if len(texts) > 0 {
+			return strings.Join(texts, "\n")
+		}
+	}
+
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err == nil {
+		encoded, err := json.Marshal(decoded)
+		if err == nil {
+			return string(encoded)
+		}
+	}
+	return string(raw)
+}
+
+func compactResultStatus(isError bool) string {
+	if isError {
+		return compactToolResultError
+	}
+	return compactToolResultSuccess
+}

--- a/agents/entire-agent-pi/internal/pi/compact.go
+++ b/agents/entire-agent-pi/internal/pi/compact.go
@@ -15,6 +15,7 @@ import (
 const (
 	compactTranscriptAgent      = "pi"
 	compactTranscriptCLIVersion = "unknown"
+	contentTypeText             = "text"
 	compactToolResultSuccess    = "success"
 	compactToolResultError      = "error"
 )
@@ -159,7 +160,7 @@ func compactUserContent(raw json.RawMessage) []compactUserTextBlock {
 
 	blocks := make([]compactUserTextBlock, 0, len(items))
 	for _, item := range items {
-		if item.Type == "text" && item.Text != "" {
+		if item.Type == contentTypeText && item.Text != "" {
 			blocks = append(blocks, compactUserTextBlock{Text: item.Text})
 		}
 	}
@@ -168,7 +169,7 @@ func compactUserContent(raw json.RawMessage) []compactUserTextBlock {
 
 func compactAssistantContent(raw json.RawMessage, results map[string]compactToolResultJSON) []any {
 	if text := decodeCompactString(raw); text != "" {
-		return []any{compactAssistantTextBlock{Type: "text", Text: text}}
+		return []any{compactAssistantTextBlock{Type: contentTypeText, Text: text}}
 	}
 
 	var items []contentItem
@@ -179,10 +180,10 @@ func compactAssistantContent(raw json.RawMessage, results map[string]compactTool
 	blocks := make([]any, 0, len(items))
 	for _, item := range items {
 		switch item.Type {
-		case "text":
+		case contentTypeText:
 			if item.Text != "" {
 				blocks = append(blocks, compactAssistantTextBlock{
-					Type: "text",
+					Type: contentTypeText,
 					Text: item.Text,
 				})
 			}
@@ -287,7 +288,7 @@ func compactResultOutput(raw json.RawMessage) string {
 	if err := json.Unmarshal(raw, &items); err == nil {
 		texts := make([]string, 0, len(items))
 		for _, item := range items {
-			if item.Type == "text" && item.Text != "" {
+			if item.Type == contentTypeText && item.Text != "" {
 				texts = append(texts, item.Text)
 			}
 		}

--- a/agents/entire-agent-pi/internal/pi/compact_test.go
+++ b/agents/entire-agent-pi/internal/pi/compact_test.go
@@ -1,0 +1,121 @@
+package pi
+
+import (
+	"encoding/base64"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestCompactTranscriptFromJSONLTranscript(t *testing.T) {
+	t.Setenv("ENTIRE_CLI_VERSION", "9.9.9")
+
+	path := writeCompactTranscriptFixture(t, testSessionJSONL)
+
+	resp, err := New().CompactTranscript(path)
+	if err != nil {
+		t.Fatalf("CompactTranscript() error = %v", err)
+	}
+
+	data, err := base64.StdEncoding.DecodeString(resp.Transcript)
+	if err != nil {
+		t.Fatalf("decode transcript: %v", err)
+	}
+
+	want := strings.Join([]string{
+		`{"v":1,"agent":"pi","cli_version":"9.9.9","type":"user","ts":"2026-03-27T21:00:01.000Z","content":[{"text":"Create hello.txt"}]}`,
+		`{"v":1,"agent":"pi","cli_version":"9.9.9","type":"assistant","ts":"2026-03-27T21:00:02.000Z","id":"m2","input_tokens":100,"output_tokens":50,"content":[{"type":"tool_use","id":"tc1","name":"Write","input":{"content":"hello world\n","path":"hello.txt"},"result":{"output":"Written 12 bytes","status":"success"}}]}`,
+		`{"v":1,"agent":"pi","cli_version":"9.9.9","type":"assistant","ts":"2026-03-27T21:00:04.000Z","id":"m4","input_tokens":200,"output_tokens":30,"content":[{"type":"text","text":"Created hello.txt with the content hello world."}]}`,
+		"",
+	}, "\n")
+
+	if string(data) != want {
+		t.Fatalf("compact transcript = %q, want %q", string(data), want)
+	}
+}
+
+func TestCompactTranscriptUsesUnknownCLIVersionFallback(t *testing.T) {
+	path := writeCompactTranscriptFixture(t, testFlatSessionJSONL)
+
+	resp, err := New().CompactTranscript(path)
+	if err != nil {
+		t.Fatalf("CompactTranscript() error = %v", err)
+	}
+
+	data, err := base64.StdEncoding.DecodeString(resp.Transcript)
+	if err != nil {
+		t.Fatalf("decode transcript: %v", err)
+	}
+	if !strings.Contains(string(data), `"cli_version":"unknown"`) {
+		t.Fatalf("compact transcript should include unknown cli_version fallback, got %q", string(data))
+	}
+}
+
+func TestCompactTranscriptFiltersAbandonedBranches(t *testing.T) {
+	t.Setenv("ENTIRE_CLI_VERSION", "1.2.3")
+
+	path := writeCompactTranscriptFixture(t, testBranchingSessionJSONL)
+
+	resp, err := New().CompactTranscript(path)
+	if err != nil {
+		t.Fatalf("CompactTranscript() error = %v", err)
+	}
+
+	data, err := base64.StdEncoding.DecodeString(resp.Transcript)
+	if err != nil {
+		t.Fatalf("decode transcript: %v", err)
+	}
+	got := string(data)
+	if strings.Contains(got, "old.txt") || strings.Contains(got, "Created old.txt") {
+		t.Fatalf("compact transcript should exclude abandoned branch, got %q", got)
+	}
+	if !strings.Contains(got, "new.txt") || !strings.Contains(got, "Created new.txt") {
+		t.Fatalf("compact transcript should include active branch, got %q", got)
+	}
+}
+
+func TestCompactTranscriptMarksToolResultErrors(t *testing.T) {
+	t.Setenv("ENTIRE_CLI_VERSION", "1.2.3")
+
+	jsonl := `{"type":"session","id":"s1"}
+{"type":"message","id":"m1","parentId":null,"timestamp":"2026-03-27T21:00:01.000Z","message":{"role":"user","content":[{"type":"text","text":"Edit app.go"}]}}
+{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-03-27T21:00:02.000Z","message":{"role":"assistant","content":[{"type":"toolCall","id":"tc1","name":"edit","arguments":{"path":"app.go"}}]}}
+{"type":"message","id":"m3","parentId":"m2","timestamp":"2026-03-27T21:00:03.000Z","message":{"role":"toolResult","toolCallId":"tc1","toolName":"edit","content":[{"type":"text","text":"file not found"}],"isError":true}}
+`
+	path := writeCompactTranscriptFixture(t, jsonl)
+
+	resp, err := New().CompactTranscript(path)
+	if err != nil {
+		t.Fatalf("CompactTranscript() error = %v", err)
+	}
+
+	data, err := base64.StdEncoding.DecodeString(resp.Transcript)
+	if err != nil {
+		t.Fatalf("decode transcript: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, `"name":"Edit"`) || !strings.Contains(got, `"status":"error"`) {
+		t.Fatalf("compact transcript should normalize edit error result, got %q", got)
+	}
+}
+
+func TestCompactTranscriptRejectsEmptyTranscript(t *testing.T) {
+	path := writeCompactTranscriptFixture(t, `{}`)
+
+	_, err := New().CompactTranscript(path)
+	if err == nil {
+		t.Fatal("expected error for empty transcript, got nil")
+	}
+	if !strings.Contains(err.Error(), "no output") {
+		t.Fatalf("error = %v, want no output", err)
+	}
+}
+
+func writeCompactTranscriptFixture(t *testing.T, content string) string {
+	t.Helper()
+	path := t.TempDir() + "/transcript.jsonl"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write transcript fixture: %v", err)
+	}
+	return path
+}

--- a/agents/entire-agent-pi/internal/pi/hooks_test.go
+++ b/agents/entire-agent-pi/internal/pi/hooks_test.go
@@ -244,4 +244,7 @@ func TestInfo(t *testing.T) {
 	if !info.Capabilities.TokenCalculator {
 		t.Error("expected token_calculator capability")
 	}
+	if !info.Capabilities.CompactTranscript {
+		t.Error("expected compact_transcript capability")
+	}
 }

--- a/agents/entire-agent-pi/internal/pi/transcript.go
+++ b/agents/entire-agent-pi/internal/pi/transcript.go
@@ -63,9 +63,10 @@ type sessionEntry struct {
 }
 
 type messageEntry struct {
-	Type    string  `json:"type"`
-	ID      string  `json:"id"`
-	Message message `json:"message"`
+	Type      string  `json:"type"`
+	ID        string  `json:"id"`
+	Timestamp string  `json:"timestamp"`
+	Message   message `json:"message"`
 }
 
 type message struct {
@@ -74,6 +75,9 @@ type message struct {
 	Timestamp  json.Number     `json:"timestamp"`
 	Usage      *tokenUsage     `json:"usage,omitempty"`
 	StopReason string          `json:"stopReason,omitempty"`
+	ToolCallID string          `json:"toolCallId,omitempty"`
+	ToolName   string          `json:"toolName,omitempty"`
+	IsError    bool            `json:"isError,omitempty"`
 }
 
 type tokenUsage struct {

--- a/agents/entire-agent-pi/internal/pi/transcript.go
+++ b/agents/entire-agent-pi/internal/pi/transcript.go
@@ -334,7 +334,7 @@ func (a *Agent) ExtractPrompts(sessionRef string, offset int) ([]string, error) 
 		}
 
 		for _, item := range items {
-			if item.Type == "text" && item.Text != "" {
+			if item.Type == contentTypeText && item.Text != "" {
 				prompts = append(prompts, item.Text)
 			}
 		}
@@ -371,7 +371,7 @@ func (a *Agent) ExtractSummary(sessionRef string) (string, bool, error) {
 		}
 
 		for _, item := range items {
-			if item.Type == "text" && item.Text != "" {
+			if item.Type == contentTypeText && item.Text != "" {
 				lastAssistantText = item.Text
 			}
 		}

--- a/agents/entire-agent-pi/internal/protocol/handlers_test.go
+++ b/agents/entire-agent-pi/internal/protocol/handlers_test.go
@@ -1,0 +1,29 @@
+package protocol
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+type testTranscriptCompactor struct {
+	response CompactTranscriptResponse
+	err      error
+}
+
+func (c testTranscriptCompactor) CompactTranscript(_ string) (CompactTranscriptResponse, error) {
+	return c.response, c.err
+}
+
+func TestHandleCompactTranscript(t *testing.T) {
+	var stdout bytes.Buffer
+	err := HandleCompactTranscript([]string{"--session-ref", "/tmp/repo/.entire/tmp/abc123.json"}, &stdout, testTranscriptCompactor{
+		response: CompactTranscriptResponse{Transcript: "eyJ2IjoxfQo="},
+	})
+	if err != nil {
+		t.Fatalf("HandleCompactTranscript() error = %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, `"transcript":"eyJ2IjoxfQo="`) {
+		t.Fatalf("stdout = %s", got)
+	}
+}

--- a/agents/entire-agent-pi/internal/protocol/protocol.go
+++ b/agents/entire-agent-pi/internal/protocol/protocol.go
@@ -38,6 +38,10 @@ type transcriptChunker interface {
 	ReassembleTranscript(chunks [][]byte) ([]byte, error)
 }
 
+type transcriptCompactor interface {
+	CompactTranscript(sessionRef string) (CompactTranscriptResponse, error)
+}
+
 type resumeFormatter interface {
 	FormatResumeCommand(sessionID string) string
 }
@@ -179,6 +183,20 @@ func HandleReassembleTranscript(stdin io.Reader, stdout io.Writer, chunker trans
 	}
 	_, err = stdout.Write(data)
 	return err
+}
+
+func HandleCompactTranscript(args []string, stdout io.Writer, compactor transcriptCompactor) error {
+	fs := flag.NewFlagSet("compact-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	compacted, err := compactor.CompactTranscript(*sessionRef)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, compacted)
 }
 
 func HandleFormatResumeCommand(args []string, stdout io.Writer, formatter resumeFormatter) error {

--- a/agents/entire-agent-pi/internal/protocol/types.go
+++ b/agents/entire-agent-pi/internal/protocol/types.go
@@ -9,6 +9,7 @@ type DeclaredCapabilities struct {
 	TranscriptAnalyzer     bool `json:"transcript_analyzer"`
 	TranscriptPreparer     bool `json:"transcript_preparer"`
 	TokenCalculator        bool `json:"token_calculator"`
+	CompactTranscript      bool `json:"compact_transcript"`
 	TextGenerator          bool `json:"text_generator"`
 	HookResponseWriter     bool `json:"hook_response_writer"`
 	SubagentAwareExtractor bool `json:"subagent_aware_extractor"`
@@ -82,6 +83,17 @@ type TokenUsageResponse struct {
 	CacheReadTokens     int `json:"cache_read_tokens"`
 	OutputTokens        int `json:"output_tokens"`
 	APICallCount        int `json:"api_call_count"`
+}
+
+type CompactTranscriptResponse struct {
+	Transcript string                       `json:"transcript"`
+	Assets     []CompactTranscriptAssetJSON `json:"assets,omitempty"`
+}
+
+type CompactTranscriptAssetJSON struct {
+	Name      string `json:"name"`
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
 }
 
 type AgentSessionJSON struct {


### PR DESCRIPTION
Same as https://github.com/entireio/external-agents/pull/13, adds compact transcript support to Pi.

Follow the [external agent protocol](https://github.com/entireio/cli/blob/main/docs/architecture/external-agent-protocol.md#capability-compact_transcript) for compact transcripts so Pi can support checkpoints v2.

Tested with my test repo:

```
➜  entire-agent-pi git:(compact-transcript-pi) ✗ entire-agent-pi info | jq .capabilities
{
  "hooks": true,
  "transcript_analyzer": true,
  "transcript_preparer": false,
  "token_calculator": true,
  "compact_transcript": true,
  "text_generator": false,
  "hook_response_writer": false,
  "subagent_aware_extractor": false,
  "uses_terminal": true
}
```

```
{"v":1,"agent":"pi","cli_version":"unknown","type":"user","ts":"2026-04-24T20:34:05.190Z","content":[{"text":"add a test folder and readme for pi"}]}
{"v":1,"agent":"pi","cli_version":"unknown","type":"assistant","ts":"2026-04-24T20:34:08.310Z","id":"02c90599","input_tokens":6,"output_tokens":113,"content":[{"type":"tool_use","id":"toolu_01HVMDrKMRGae44Vc77fdCt5","name":"bash","input":{"command":"ls -la"},"result":{"output":"[redacted]","status":"success"}}]}
{"v":1,"agent":"pi","cli_version":"unknown","type":"assistant","ts":"2026-04-24T20:34:10.107Z","id":"a60d616f","input_tokens":1,"output_tokens":72,"content":[{"type":"tool_use","id":"toolu_01Va3NEgutL9z8ZmD5x3yCVr","name":"bash","input":{"command":"mkdir -p pi/test"},"result":{"output":"(no output)","status":"success"}}]}
{"v":1,"agent":"pi","cli_version":"unknown","type":"assistant","ts":"2026-04-24T20:34:13.722Z","id":"d2349f6e","input_tokens":1,"output_tokens":205,"content":[{"type":"tool_use","id":"toolu_01KBX331b5KPkSQ3YnNMVoKK","name":"Write","input":{"content":"# pi\n\nThis folder contains pi-related files, including a `test/` directory for tests.\n\n## Structure\n\n- `test/` — test files for pi\n","path":"pi/README.md"},"result":{"output":"Successfully wrote 131 bytes to pi/README.md","status":"success"}},{"type":"tool_use","id":"toolu_01RfXhMy7fQh8JB6TvWhoEYQ","name":"Write","input":{"content":"","path":"pi/test/.gitkeep"},"result":{"output":"Successfully wrote 0 bytes to pi/test/.gitkeep","status":"success"}}]}
{"v":1,"agent":"pi","cli_version":"unknown","type":"assistant","ts":"2026-04-24T20:34:16.148Z","id":"9535d5f9","input_tokens":1,"output_tokens":56,"content":[{"type":"text","text":"Created:\n- `pi/README.md` — readme for the pi folder\n- `pi/test/` — test directory (with `.gitkeep` so it's tracked)"}]}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new protocol surface area (`compact-transcript`) and non-trivial transcript transformation logic (branch filtering + tool result inlining), which could affect checkpoint/transcript correctness if edge cases are missed.
> 
> **Overview**
> Adds **compact transcript** support to the Pi external agent for *checkpoints v2*. The `entire-agent-pi` binary now exposes a new `compact-transcript` subcommand and advertises the `compact_transcript` capability in `info`.
> 
> Implements compaction that converts Pi JSONL into Entire’s compact JSONL format, including active-branch filtering, tool name normalization (`write`/`edit`/`read`), and inlining `toolResult` outputs/status; also extends transcript parsing structs to include timestamps and tool result fields. Updates protocol types/handler plumbing and adds unit tests covering compaction output, branch filtering, CLI version fallback, and error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d238a3845a327c3b8ed9325e6e4954e4ef4265af. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->