### PR TITLE
Add amp external agent

### DIFF
--- a/agents/entire-agent-amp/.gitignore
+++ b/agents/entire-agent-amp/.gitignore
@@ -1,0 +1,2 @@
+entire-agent-amp
+.probe-amp-*

--- a/agents/entire-agent-amp/.gitignore
+++ b/agents/entire-agent-amp/.gitignore
@@ -1,2 +1,2 @@
-entire-agent-amp
+/entire-agent-amp
 .probe-amp-*

--- a/agents/entire-agent-amp/AGENT.md
+++ b/agents/entire-agent-amp/AGENT.md
@@ -5,95 +5,104 @@
 Amp has a TypeScript plugin system with lifecycle events for `agent.start` and `agent.end`. Project plugins require launching Amp with `PLUGINS=all` in classic Amp clients. Amp threads are server-side, so the integration uses plugin hooks to discover the active thread ID and then retrieves the authoritative transcript with `amp threads export <thread-id>` directly from the `session.start` and `agent.end` hooks.
 
 ## Static Checks
-| Check | Result | Notes |
-|-------|--------|-------|
-| Binary present | PASS | `amp` found locally |
-| Help available | PASS | `amp --help` |
-| Version info | PASS | `amp --version` |
-| Hook keywords | PASS | Plugin docs provide lifecycle events |
-| Session keywords | PASS | `threads continue`, `threads export` |
-| Config directory | PASS | `~/.config/amp` documented |
-| Documentation | PASS | https://ampcode.com/manual/plugins.md and https://ampcode.com/manual/plugin-api.md |
+
+| Check            | Result | Notes                                                                              |
+| ---------------- | ------ | ---------------------------------------------------------------------------------- |
+| Binary present   | PASS   | `amp` found locally                                                                |
+| Help available   | PASS   | `amp --help`                                                                       |
+| Version info     | PASS   | `amp --version`                                                                    |
+| Hook keywords    | PASS   | Plugin docs provide lifecycle events                                               |
+| Session keywords | PASS   | `threads continue`, `threads export`                                               |
+| Config directory | PASS   | `~/.config/amp` documented                                                         |
+| Documentation    | PASS   | https://ampcode.com/manual/plugins.md and https://ampcode.com/manual/plugin-api.md |
 
 ## Binary
+
 - Name: `amp`
 - Install: Amp CLI from AmpCode distribution.
 - Plugin loading: run `PLUGINS=all amp ...`.
 
 ## Hook Mechanism
+
 - Config file: `.amp/plugins/entire.ts`
 - Config format: TypeScript plugin running on Amp's Bun-provided runtime.
 - Hook registration: plugin default export receives `PluginAPI`, registers handlers with `amp.on(event, handler)`.
 - Hook names and protocol mapping:
 
-| Native Hook Name | When It Fires | Protocol Event Type |
-|------------------|---------------|---------------------|
-| synthetic `session.start` | before first `agent.start` per thread | 1 = SessionStart |
-| `agent.start` | user submits a prompt | 2 = TurnStart |
-| `agent.end` | agent finishes a turn | 3 = TurnEnd |
+| Native Hook Name          | When It Fires                         | Protocol Event Type |
+| ------------------------- | ------------------------------------- | ------------------- |
+| synthetic `session.start` | before first `agent.start` per thread | 1 = SessionStart    |
+| `agent.start`             | user submits a prompt                 | 2 = TurnStart       |
+| `agent.end`               | agent finishes a turn                 | 3 = TurnEnd         |
 
 `session.start` from Amp itself does not always include `thread.id`, so the plugin does not rely on it for session identity.
 
 ## Session Management
+
 - Session ID source: Amp `thread.id`.
 - Session directory: `.entire/tmp/amp/`.
 - Session file format: exported Amp thread JSON, parsed as `Thread` from `internal/amp/types.go`. The binary writes this file on `session.start` and refreshes it on `agent.end`.
 - Resume mechanism: `PLUGINS=all amp threads continue <thread-id>`.
 
 ## Transcript
+
 - Authoritative storage: `session_ref` always contains the exported Amp thread JSON byte-for-byte (the output of `amp threads export <thread-id>`). This JSON is the session's native data and the input for all transcript operations.
 - Retrieval: the binary runs `amp threads export <thread-id>` during the `session.start` and `agent.end` plugin hooks and writes the result to `session_ref`. `prepare-transcript --session-ref <path>` is available as a refresh — it parses the existing prepared transcript to recover `thread.id` and re-exports.
 - Authoritative parser: `internal/amp/types.go` models the exported transcript as `Thread`, `ThreadMessage`, `ThreadContentBlock`, `ThreadToolRun`, and `ThreadUsage`.
 - User prompt extraction: `Thread.Messages[].Content[]` text blocks on `role: "user"` messages.
 - Assistant summary extraction: last non-empty text block on `role: "assistant"` messages.
-- Modified file extraction: `ThreadToolRun.TrackFiles`, tool input path fields (`path`, `filePath`, `filepath`, `file`, `absolutePath`, `paths`, `files`), and common tool result `absolutePath` fields.
+- Modified file extraction: `ThreadToolRun.TrackFiles`, tool input path fields (`path`, `filePath`, `filepath`, `file`, `absolutePath`, `paths`, `files`) from known mutating tool calls, and write-result `absolutePath` fields.
 - Token usage extraction: `ThreadMessage.Usage` on exported messages.
 - Unprepared behavior: transcript analyzer, compact transcript, token calculation, and read-session operations require exported `Thread` JSON and return an error if called on a `session_ref` that has not yet been populated by an export.
 
 ## Protocol Mapping
-| Subcommand | Native Concept | Implementation Notes | Feasibility |
-|-----------|----------------|----------------------|-------------|
-| `info` | static metadata | Return name `amp`, capabilities | Required |
-| `detect` | `amp` binary | Check `command -v amp` | Required |
-| `get-session-id` | Amp thread ID | Read from hook input | Required |
-| `get-session-dir` | `.entire/tmp` | Standard Entire temp dir | Required |
-| `resolve-session-file` | `.entire/tmp/<id>.json` | Standard path resolution | Required |
-| `read-session` | exported Amp JSON | Validate and parse `Thread`; use `Thread.ID`, raw JSON `native_data`, and extracted modified files | Required |
-| `write-session` | exported Amp JSON | Write native data to session ref | Required |
-| `read-transcript` | exported Amp JSON | Return raw bytes after validating `Thread` JSON | Required |
-| `chunk-transcript` | raw bytes | Base64 chunking via protocol JSON encoding | Required |
-| `reassemble-transcript` | chunks | Reassemble raw bytes | Required |
-| `format-resume-command` | Amp thread continue | `PLUGINS=all amp threads continue <id>` | Required |
-| `parse-hook` | plugin event JSON | Map hook payloads to protocol events; export Amp thread on `session.start` and `agent.end` | Hooks |
-| `install-hooks` | project plugin | Write `.amp/plugins/entire.ts` | Hooks |
-| `uninstall-hooks` | project plugin | Remove `.amp/plugins/entire.ts` | Hooks |
-| `are-hooks-installed` | project plugin | Check plugin marker | Hooks |
-| `get-transcript-position` | exported Amp JSON | Validate `Thread` and return byte length | Transcript analyzer |
-| `extract-modified-files` | exported Amp JSON | Parse `Thread` tool inputs/results and `trackFiles` | Transcript analyzer |
-| `extract-prompts` | exported Amp JSON | Parse user text blocks from `Thread.Messages` | Transcript analyzer |
-| `extract-summary` | exported Amp JSON | Parse last assistant text block from `Thread.Messages` | Transcript analyzer |
-| `prepare-transcript` | `amp threads export` | Re-export the Amp thread using the thread ID from the existing prepared transcript at `session_ref` | Transcript preparer |
-| `compact-transcript` | exported Amp JSON | Emit Entire compact JSONL from `Thread` | Compact transcript |
-| `calculate-tokens` | exported Amp JSON | Sum `ThreadMessage.Usage` token fields | Token calculator |
+
+| Subcommand                | Native Concept          | Implementation Notes                                                                                | Feasibility         |
+| ------------------------- | ----------------------- | --------------------------------------------------------------------------------------------------- | ------------------- |
+| `info`                    | static metadata         | Return name `amp`, capabilities                                                                     | Required            |
+| `detect`                  | `amp` binary            | Check `command -v amp`                                                                              | Required            |
+| `get-session-id`          | Amp thread ID           | Read from hook input                                                                                | Required            |
+| `get-session-dir`         | `.entire/tmp`           | Standard Entire temp dir                                                                            | Required            |
+| `resolve-session-file`    | `.entire/tmp/<id>.json` | Standard path resolution                                                                            | Required            |
+| `read-session`            | exported Amp JSON       | Validate and parse `Thread`; use `Thread.ID`, raw JSON `native_data`, and extracted modified files  | Required            |
+| `write-session`           | exported Amp JSON       | Write native data to session ref                                                                    | Required            |
+| `read-transcript`         | exported Amp JSON       | Return raw bytes after validating `Thread` JSON                                                     | Required            |
+| `chunk-transcript`        | raw bytes               | Base64 chunking via protocol JSON encoding                                                          | Required            |
+| `reassemble-transcript`   | chunks                  | Reassemble raw bytes                                                                                | Required            |
+| `format-resume-command`   | Amp thread continue     | `PLUGINS=all amp threads continue <id>`                                                             | Required            |
+| `parse-hook`              | plugin event JSON       | Map hook payloads to protocol events; export Amp thread on `session.start` and `agent.end`          | Hooks               |
+| `install-hooks`           | project plugin          | Write `.amp/plugins/entire.ts`                                                                      | Hooks               |
+| `uninstall-hooks`         | project plugin          | Remove `.amp/plugins/entire.ts`                                                                     | Hooks               |
+| `are-hooks-installed`     | project plugin          | Check plugin marker                                                                                 | Hooks               |
+| `get-transcript-position` | exported Amp JSON       | Validate `Thread` and return message count                                                          | Transcript analyzer |
+| `extract-modified-files`  | exported Amp JSON       | Parse `Thread` tool inputs/results and `trackFiles`                                                 | Transcript analyzer |
+| `extract-prompts`         | exported Amp JSON       | Parse user text blocks from `Thread.Messages`                                                       | Transcript analyzer |
+| `extract-summary`         | exported Amp JSON       | Parse last assistant text block from `Thread.Messages`                                              | Transcript analyzer |
+| `prepare-transcript`      | `amp threads export`    | Re-export the Amp thread using the thread ID from the existing prepared transcript at `session_ref` | Transcript preparer |
+| `compact-transcript`      | exported Amp JSON       | Emit Entire compact JSONL from `Thread`                                                             | Compact transcript  |
+| `calculate-tokens`        | exported Amp JSON       | Sum `ThreadMessage.Usage` token fields                                                              | Token calculator    |
 
 ## Selected Capabilities
-| Capability | Declared | Justification |
-|-----------|----------|---------------|
-| hooks | true | Amp plugins expose lifecycle events |
-| transcript_analyzer | true | Exported Amp JSON contains prompts, tool calls/results, and assistant messages |
-| compact_transcript | true | Exported Amp JSON maps to Entire compact transcript format |
-| transcript_preparer | true | Exports Amp thread JSON into the session ref |
-| token_calculator | true | Exported Amp JSON contains `ThreadMessage.usage` |
-| text_generator | false | Amp CLI is used for agent execution, not summary generation |
-| hook_response_writer | false | Not needed for lifecycle hooks |
-| subagent_aware_extractor | false | No documented subagent transcript tree |
+
+| Capability               | Declared | Justification                                                                  |
+| ------------------------ | -------- | ------------------------------------------------------------------------------ |
+| hooks                    | true     | Amp plugins expose lifecycle events                                            |
+| transcript_analyzer      | true     | Exported Amp JSON contains prompts, tool calls/results, and assistant messages |
+| compact_transcript       | true     | Exported Amp JSON maps to Entire compact transcript format                     |
+| transcript_preparer      | true     | Exports Amp thread JSON into the session ref                                   |
+| token_calculator         | true     | Exported Amp JSON contains `ThreadMessage.usage`                               |
+| text_generator           | false    | Amp CLI is used for agent execution, not summary generation                    |
+| hook_response_writer     | false    | Not needed for lifecycle hooks                                                 |
+| subagent_aware_extractor | false    | No documented subagent transcript tree                                         |
 
 ## Gaps & Limitations
+
 - Amp must be launched with `PLUGINS=all` for hooks to fire.
 - All transcript operations require the prepared `amp threads export` JSON at `session_ref`. The binary triggers this export from the `session.start` and `agent.end` plugin hooks; operations called before either of those hooks fires will return an error.
 - `session.start` cannot be trusted for thread identity because `thread.id` is optional there.
 
 ## E2E Test Prerequisites
+
 - Entire CLI binary: `entire` from PATH or `E2E_ENTIRE_BIN`.
 - Agent CLI binary: `amp`.
 - Non-interactive prompt command: `PLUGINS=all amp --dangerously-allow-all --no-notifications --no-ide -x '<prompt>'`.

--- a/agents/entire-agent-amp/AGENT.md
+++ b/agents/entire-agent-amp/AGENT.md
@@ -2,7 +2,7 @@
 
 ## Verdict: COMPATIBLE
 
-Amp has a TypeScript plugin system with lifecycle events for `agent.start` and `agent.end`. Project plugins require launching Amp with `PLUGINS=all`. The public plugin API does not expose a stable native transcript file path, so the integration captures event/message payloads into `.entire/tmp/amp/*.jsonl` and implements transcript analysis from that cache.
+Amp has a TypeScript plugin system with lifecycle events for `agent.start` and `agent.end`. Project plugins require launching Amp with `PLUGINS=all` in classic Amp clients. Amp threads are server-side, so the integration uses plugin hooks only to discover the active thread ID, then retrieves the authoritative transcript with `amp threads export <thread-id>` during `prepare-transcript`.
 
 ## Static Checks
 | Check | Result | Notes |
@@ -37,16 +37,20 @@ Amp has a TypeScript plugin system with lifecycle events for `agent.start` and `
 ## Session Management
 - Session ID source: Amp `thread.id`.
 - Session directory: `.entire/tmp/amp/`.
-- Session file format: JSONL cache written by the external agent binary from hook payloads.
+- Bootstrap session file format: JSONL hook cache written by the external agent binary from plugin payloads.
+- Prepared session file format: exported Amp thread JSON, parsed as `AmpThread` from `internal/amp/types.go`.
 - Resume mechanism: `PLUGINS=all amp threads continue <thread-id>`.
 
 ## Transcript
-- Bootstrap location: `.entire/tmp/amp/<safe-thread-id>.jsonl` before preparation.
-- Authoritative location: the same `session_ref` after `prepare-transcript` overwrites it with `amp threads export <thread-id>` JSON.
-- Authoritative format: `AmpThread` JSON modeled in `internal/amp/types.go`.
-- User prompt field: `AmpThread.messages[].content[]` text blocks on `role: "user"` messages.
-- Modified files field: `ThreadToolRun.trackFiles`, tool input path fields, and common tool result path fields.
-- Token usage field: `ThreadMessage.usage` on exported assistant messages.
+- Bootstrap location: `.entire/tmp/amp/<safe-thread-id>.json` before preparation. The file contains JSONL hook entries with at least `type`, `thread_id`, and optional prompt text.
+- Retrieval: `prepare-transcript --session-ref <path>` reads the bootstrap JSONL, extracts `thread_id`, runs `amp threads export <thread-id>`, and writes the exported JSON back to the same `session_ref` path.
+- Authoritative storage: after preparation, `session_ref` contains the exported Amp thread JSON byte-for-byte. This JSON is the session's native data and the input for all transcript operations.
+- Authoritative parser: `internal/amp/types.go` models the exported transcript as `AmpThread`, `ThreadMessage`, `ThreadContentBlock`, `ThreadToolRun`, and `ThreadUsage`.
+- User prompt extraction: `AmpThread.Messages[].Content[]` text blocks on `role: "user"` messages.
+- Assistant summary extraction: last non-empty text block on `role: "assistant"` messages.
+- Modified file extraction: `ThreadToolRun.TrackFiles`, tool input path fields (`path`, `filePath`, `filepath`, `file`, `absolutePath`, `paths`, `files`), and common tool result `absolutePath` fields.
+- Token usage extraction: `ThreadMessage.Usage` on exported messages.
+- Unprepared behavior: transcript analyzer, compact transcript, token calculation, and read-session operations require exported `AmpThread` JSON and return an error if called on the bootstrap JSONL cache before `prepare-transcript`.
 
 ## Protocol Mapping
 | Subcommand | Native Concept | Implementation Notes | Feasibility |
@@ -56,22 +60,23 @@ Amp has a TypeScript plugin system with lifecycle events for `agent.start` and `
 | `get-session-id` | Amp thread ID | Read from hook input | Required |
 | `get-session-dir` | `.entire/tmp` | Standard Entire temp dir | Required |
 | `resolve-session-file` | `.entire/tmp/<id>.json` | Standard path resolution | Required |
-| `read-session` | exported Amp JSON | Build AgentSession from authoritative `AmpThread` JSON | Required |
+| `read-session` | exported Amp JSON | Validate and parse `AmpThread`; use `AmpThread.ID`, raw JSON `native_data`, and extracted modified files | Required |
 | `write-session` | exported Amp JSON | Write native data to session ref | Required |
 | `read-transcript` | exported Amp JSON | Return raw bytes after validating `AmpThread` JSON | Required |
 | `chunk-transcript` | raw bytes | Base64 chunking via protocol JSON encoding | Required |
 | `reassemble-transcript` | chunks | Reassemble raw bytes | Required |
 | `format-resume-command` | Amp thread continue | `PLUGINS=all amp threads continue <id>` | Required |
-| `parse-hook` | plugin event JSON | Map hook payloads to protocol events | Hooks |
+| `parse-hook` | plugin event JSON | Map hook payloads to protocol events and append minimal bootstrap JSONL with `thread_id` | Hooks |
 | `install-hooks` | project plugin | Write `.amp/plugins/entire.ts` | Hooks |
 | `uninstall-hooks` | project plugin | Remove `.amp/plugins/entire.ts` | Hooks |
 | `are-hooks-installed` | project plugin | Check plugin marker | Hooks |
-| `get-transcript-position` | exported Amp JSON | Return byte length | Transcript analyzer |
-| `extract-modified-files` | exported Amp JSON | Parse `AmpThread` tool inputs/results | Transcript analyzer |
-| `extract-prompts` | exported Amp JSON | Parse user text blocks from `AmpThread.messages` | Transcript analyzer |
-| `extract-summary` | exported Amp JSON | Parse last assistant text block from `AmpThread.messages` | Transcript analyzer |
-| `prepare-transcript` | `amp threads export` | Export server-side thread JSON into `session_ref` | Transcript preparer |
+| `get-transcript-position` | exported Amp JSON | Validate `AmpThread` and return byte length | Transcript analyzer |
+| `extract-modified-files` | exported Amp JSON | Parse `AmpThread` tool inputs/results and `trackFiles` | Transcript analyzer |
+| `extract-prompts` | exported Amp JSON | Parse user text blocks from `AmpThread.Messages` | Transcript analyzer |
+| `extract-summary` | exported Amp JSON | Parse last assistant text block from `AmpThread.Messages` | Transcript analyzer |
+| `prepare-transcript` | `amp threads export` | Read bootstrap `thread_id`, export server-side thread JSON, overwrite `session_ref` | Transcript preparer |
 | `compact-transcript` | exported Amp JSON | Emit Entire compact JSONL from `AmpThread` | Compact transcript |
+| `calculate-tokens` | exported Amp JSON | Sum `ThreadMessage.Usage` token fields | Token calculator |
 
 ## Selected Capabilities
 | Capability | Declared | Justification |
@@ -87,7 +92,8 @@ Amp has a TypeScript plugin system with lifecycle events for `agent.start` and `
 
 ## Gaps & Limitations
 - Amp must be launched with `PLUGINS=all` for hooks to fire.
-- Transcript data starts as plugin-captured JSONL only for bootstrap thread ID discovery and is later prepared into authoritative `amp threads export` JSON.
+- The bootstrap JSONL cache is intentionally not a transcript. It only carries enough state for `prepare-transcript` to retrieve the real server-side thread.
+- All transcript operations require the prepared `amp threads export` JSON. Calling them before preparation fails by design.
 - `session.start` cannot be trusted for thread identity because `thread.id` is optional there.
 
 ## E2E Test Prerequisites

--- a/agents/entire-agent-amp/AGENT.md
+++ b/agents/entire-agent-amp/AGENT.md
@@ -1,0 +1,99 @@
+# Amp — External Agent Research
+
+## Verdict: COMPATIBLE
+
+Amp has a TypeScript plugin system with lifecycle events for `agent.start` and `agent.end`. Project plugins require launching Amp with `PLUGINS=all`. The public plugin API does not expose a stable native transcript file path, so the integration captures event/message payloads into `.entire/tmp/amp/*.jsonl` and implements transcript analysis from that cache.
+
+## Static Checks
+| Check | Result | Notes |
+|-------|--------|-------|
+| Binary present | PASS | `amp` found locally |
+| Help available | PASS | `amp --help` |
+| Version info | PASS | `amp --version` |
+| Hook keywords | PASS | Plugin docs provide lifecycle events |
+| Session keywords | PASS | `threads continue`, `threads export` |
+| Config directory | PASS | `~/.config/amp` documented |
+| Documentation | PASS | https://ampcode.com/manual/plugins.md and https://ampcode.com/manual/plugin-api.md |
+
+## Binary
+- Name: `amp`
+- Install: Amp CLI from AmpCode distribution.
+- Plugin loading: run `PLUGINS=all amp ...`.
+
+## Hook Mechanism
+- Config file: `.amp/plugins/entire.ts`
+- Config format: TypeScript plugin running on Amp's Bun-provided runtime.
+- Hook registration: plugin default export receives `PluginAPI`, registers handlers with `amp.on(event, handler)`.
+- Hook names and protocol mapping:
+
+| Native Hook Name | When It Fires | Protocol Event Type |
+|------------------|---------------|---------------------|
+| synthetic `session.start` | before first `agent.start` per thread | 1 = SessionStart |
+| `agent.start` | user submits a prompt | 2 = TurnStart |
+| `agent.end` | agent finishes a turn | 3 = TurnEnd |
+
+`session.start` from Amp itself does not always include `thread.id`, so the plugin does not rely on it for session identity.
+
+## Session Management
+- Session ID source: Amp `thread.id`.
+- Session directory: `.entire/tmp/amp/`.
+- Session file format: JSONL cache written by the external agent binary from hook payloads.
+- Resume mechanism: `PLUGINS=all amp threads continue <thread-id>`.
+
+## Transcript
+- Bootstrap location: `.entire/tmp/amp/<safe-thread-id>.jsonl` before preparation.
+- Authoritative location: the same `session_ref` after `prepare-transcript` overwrites it with `amp threads export <thread-id>` JSON.
+- Authoritative format: `AmpThread` JSON modeled in `internal/amp/types.go`.
+- User prompt field: `AmpThread.messages[].content[]` text blocks on `role: "user"` messages.
+- Modified files field: `ThreadToolRun.trackFiles`, tool input path fields, and common tool result path fields.
+- Token usage field: `ThreadMessage.usage` on exported assistant messages.
+
+## Protocol Mapping
+| Subcommand | Native Concept | Implementation Notes | Feasibility |
+|-----------|----------------|----------------------|-------------|
+| `info` | static metadata | Return name `amp`, capabilities | Required |
+| `detect` | `amp` binary | Check `command -v amp` | Required |
+| `get-session-id` | Amp thread ID | Read from hook input | Required |
+| `get-session-dir` | `.entire/tmp` | Standard Entire temp dir | Required |
+| `resolve-session-file` | `.entire/tmp/<id>.json` | Standard path resolution | Required |
+| `read-session` | exported Amp JSON | Build AgentSession from authoritative `AmpThread` JSON | Required |
+| `write-session` | exported Amp JSON | Write native data to session ref | Required |
+| `read-transcript` | exported Amp JSON | Return raw bytes after validating `AmpThread` JSON | Required |
+| `chunk-transcript` | raw bytes | Base64 chunking via protocol JSON encoding | Required |
+| `reassemble-transcript` | chunks | Reassemble raw bytes | Required |
+| `format-resume-command` | Amp thread continue | `PLUGINS=all amp threads continue <id>` | Required |
+| `parse-hook` | plugin event JSON | Map hook payloads to protocol events | Hooks |
+| `install-hooks` | project plugin | Write `.amp/plugins/entire.ts` | Hooks |
+| `uninstall-hooks` | project plugin | Remove `.amp/plugins/entire.ts` | Hooks |
+| `are-hooks-installed` | project plugin | Check plugin marker | Hooks |
+| `get-transcript-position` | exported Amp JSON | Return byte length | Transcript analyzer |
+| `extract-modified-files` | exported Amp JSON | Parse `AmpThread` tool inputs/results | Transcript analyzer |
+| `extract-prompts` | exported Amp JSON | Parse user text blocks from `AmpThread.messages` | Transcript analyzer |
+| `extract-summary` | exported Amp JSON | Parse last assistant text block from `AmpThread.messages` | Transcript analyzer |
+| `prepare-transcript` | `amp threads export` | Export server-side thread JSON into `session_ref` | Transcript preparer |
+| `compact-transcript` | exported Amp JSON | Emit Entire compact JSONL from `AmpThread` | Compact transcript |
+
+## Selected Capabilities
+| Capability | Declared | Justification |
+|-----------|----------|---------------|
+| hooks | true | Amp plugins expose lifecycle events |
+| transcript_analyzer | true | Exported Amp JSON contains prompts, tool calls/results, and assistant messages |
+| compact_transcript | true | Exported Amp JSON maps to Entire compact transcript format |
+| transcript_preparer | true | Exports Amp thread JSON into the session ref |
+| token_calculator | true | Exported Amp JSON contains `ThreadMessage.usage` |
+| text_generator | false | Amp CLI is used for agent execution, not summary generation |
+| hook_response_writer | false | Not needed for lifecycle hooks |
+| subagent_aware_extractor | false | No documented subagent transcript tree |
+
+## Gaps & Limitations
+- Amp must be launched with `PLUGINS=all` for hooks to fire.
+- Transcript data starts as plugin-captured JSONL only for bootstrap thread ID discovery and is later prepared into authoritative `amp threads export` JSON.
+- `session.start` cannot be trusted for thread identity because `thread.id` is optional there.
+
+## E2E Test Prerequisites
+- Entire CLI binary: `entire` from PATH or `E2E_ENTIRE_BIN`.
+- Agent CLI binary: `amp`.
+- Non-interactive prompt command: `PLUGINS=all amp --dangerously-allow-all --no-notifications --no-ide -x '<prompt>'`.
+- Interactive mode: `PLUGINS=all amp`.
+- Expected prompt pattern: `>`.
+- Timeout multiplier: 1.5.

--- a/agents/entire-agent-amp/AGENT.md
+++ b/agents/entire-agent-amp/AGENT.md
@@ -2,7 +2,7 @@
 
 ## Verdict: COMPATIBLE
 
-Amp has a TypeScript plugin system with lifecycle events for `agent.start` and `agent.end`. Project plugins require launching Amp with `PLUGINS=all` in classic Amp clients. Amp threads are server-side, so the integration uses plugin hooks only to discover the active thread ID, then retrieves the authoritative transcript with `amp threads export <thread-id>` during `prepare-transcript`.
+Amp has a TypeScript plugin system with lifecycle events for `agent.start` and `agent.end`. Project plugins require launching Amp with `PLUGINS=all` in classic Amp clients. Amp threads are server-side, so the integration uses plugin hooks to discover the active thread ID and then retrieves the authoritative transcript with `amp threads export <thread-id>` directly from the `session.start` and `agent.end` hooks.
 
 ## Static Checks
 | Check | Result | Notes |
@@ -37,20 +37,18 @@ Amp has a TypeScript plugin system with lifecycle events for `agent.start` and `
 ## Session Management
 - Session ID source: Amp `thread.id`.
 - Session directory: `.entire/tmp/amp/`.
-- Bootstrap session file format: JSONL hook cache written by the external agent binary from plugin payloads.
-- Prepared session file format: exported Amp thread JSON, parsed as `AmpThread` from `internal/amp/types.go`.
+- Session file format: exported Amp thread JSON, parsed as `AmpThread` from `internal/amp/types.go`. The binary writes this file on `session.start` and refreshes it on `agent.end`.
 - Resume mechanism: `PLUGINS=all amp threads continue <thread-id>`.
 
 ## Transcript
-- Bootstrap location: `.entire/tmp/amp/<safe-thread-id>.json` before preparation. The file contains JSONL hook entries with at least `type`, `thread_id`, and optional prompt text.
-- Retrieval: `prepare-transcript --session-ref <path>` reads the bootstrap JSONL, extracts `thread_id`, runs `amp threads export <thread-id>`, and writes the exported JSON back to the same `session_ref` path.
-- Authoritative storage: after preparation, `session_ref` contains the exported Amp thread JSON byte-for-byte. This JSON is the session's native data and the input for all transcript operations.
+- Authoritative storage: `session_ref` always contains the exported Amp thread JSON byte-for-byte (the output of `amp threads export <thread-id>`). This JSON is the session's native data and the input for all transcript operations.
+- Retrieval: the binary runs `amp threads export <thread-id>` during the `session.start` and `agent.end` plugin hooks and writes the result to `session_ref`. `prepare-transcript --session-ref <path>` is available as a refresh — it parses the existing prepared transcript to recover `thread.id` and re-exports.
 - Authoritative parser: `internal/amp/types.go` models the exported transcript as `AmpThread`, `ThreadMessage`, `ThreadContentBlock`, `ThreadToolRun`, and `ThreadUsage`.
 - User prompt extraction: `AmpThread.Messages[].Content[]` text blocks on `role: "user"` messages.
 - Assistant summary extraction: last non-empty text block on `role: "assistant"` messages.
 - Modified file extraction: `ThreadToolRun.TrackFiles`, tool input path fields (`path`, `filePath`, `filepath`, `file`, `absolutePath`, `paths`, `files`), and common tool result `absolutePath` fields.
 - Token usage extraction: `ThreadMessage.Usage` on exported messages.
-- Unprepared behavior: transcript analyzer, compact transcript, token calculation, and read-session operations require exported `AmpThread` JSON and return an error if called on the bootstrap JSONL cache before `prepare-transcript`.
+- Unprepared behavior: transcript analyzer, compact transcript, token calculation, and read-session operations require exported `AmpThread` JSON and return an error if called on a `session_ref` that has not yet been populated by an export.
 
 ## Protocol Mapping
 | Subcommand | Native Concept | Implementation Notes | Feasibility |
@@ -66,7 +64,7 @@ Amp has a TypeScript plugin system with lifecycle events for `agent.start` and `
 | `chunk-transcript` | raw bytes | Base64 chunking via protocol JSON encoding | Required |
 | `reassemble-transcript` | chunks | Reassemble raw bytes | Required |
 | `format-resume-command` | Amp thread continue | `PLUGINS=all amp threads continue <id>` | Required |
-| `parse-hook` | plugin event JSON | Map hook payloads to protocol events and append minimal bootstrap JSONL with `thread_id` | Hooks |
+| `parse-hook` | plugin event JSON | Map hook payloads to protocol events; export Amp thread on `session.start` and `agent.end` | Hooks |
 | `install-hooks` | project plugin | Write `.amp/plugins/entire.ts` | Hooks |
 | `uninstall-hooks` | project plugin | Remove `.amp/plugins/entire.ts` | Hooks |
 | `are-hooks-installed` | project plugin | Check plugin marker | Hooks |
@@ -74,7 +72,7 @@ Amp has a TypeScript plugin system with lifecycle events for `agent.start` and `
 | `extract-modified-files` | exported Amp JSON | Parse `AmpThread` tool inputs/results and `trackFiles` | Transcript analyzer |
 | `extract-prompts` | exported Amp JSON | Parse user text blocks from `AmpThread.Messages` | Transcript analyzer |
 | `extract-summary` | exported Amp JSON | Parse last assistant text block from `AmpThread.Messages` | Transcript analyzer |
-| `prepare-transcript` | `amp threads export` | Read bootstrap `thread_id`, export server-side thread JSON, overwrite `session_ref` | Transcript preparer |
+| `prepare-transcript` | `amp threads export` | Re-export the Amp thread using the thread ID from the existing prepared transcript at `session_ref` | Transcript preparer |
 | `compact-transcript` | exported Amp JSON | Emit Entire compact JSONL from `AmpThread` | Compact transcript |
 | `calculate-tokens` | exported Amp JSON | Sum `ThreadMessage.Usage` token fields | Token calculator |
 
@@ -92,8 +90,7 @@ Amp has a TypeScript plugin system with lifecycle events for `agent.start` and `
 
 ## Gaps & Limitations
 - Amp must be launched with `PLUGINS=all` for hooks to fire.
-- The bootstrap JSONL cache is intentionally not a transcript. It only carries enough state for `prepare-transcript` to retrieve the real server-side thread.
-- All transcript operations require the prepared `amp threads export` JSON. Calling them before preparation fails by design.
+- All transcript operations require the prepared `amp threads export` JSON at `session_ref`. The binary triggers this export from the `session.start` and `agent.end` plugin hooks; operations called before either of those hooks fires will return an error.
 - `session.start` cannot be trusted for thread identity because `thread.id` is optional there.
 
 ## E2E Test Prerequisites

--- a/agents/entire-agent-amp/AGENT.md
+++ b/agents/entire-agent-amp/AGENT.md
@@ -37,18 +37,18 @@ Amp has a TypeScript plugin system with lifecycle events for `agent.start` and `
 ## Session Management
 - Session ID source: Amp `thread.id`.
 - Session directory: `.entire/tmp/amp/`.
-- Session file format: exported Amp thread JSON, parsed as `AmpThread` from `internal/amp/types.go`. The binary writes this file on `session.start` and refreshes it on `agent.end`.
+- Session file format: exported Amp thread JSON, parsed as `Thread` from `internal/amp/types.go`. The binary writes this file on `session.start` and refreshes it on `agent.end`.
 - Resume mechanism: `PLUGINS=all amp threads continue <thread-id>`.
 
 ## Transcript
 - Authoritative storage: `session_ref` always contains the exported Amp thread JSON byte-for-byte (the output of `amp threads export <thread-id>`). This JSON is the session's native data and the input for all transcript operations.
 - Retrieval: the binary runs `amp threads export <thread-id>` during the `session.start` and `agent.end` plugin hooks and writes the result to `session_ref`. `prepare-transcript --session-ref <path>` is available as a refresh — it parses the existing prepared transcript to recover `thread.id` and re-exports.
-- Authoritative parser: `internal/amp/types.go` models the exported transcript as `AmpThread`, `ThreadMessage`, `ThreadContentBlock`, `ThreadToolRun`, and `ThreadUsage`.
-- User prompt extraction: `AmpThread.Messages[].Content[]` text blocks on `role: "user"` messages.
+- Authoritative parser: `internal/amp/types.go` models the exported transcript as `Thread`, `ThreadMessage`, `ThreadContentBlock`, `ThreadToolRun`, and `ThreadUsage`.
+- User prompt extraction: `Thread.Messages[].Content[]` text blocks on `role: "user"` messages.
 - Assistant summary extraction: last non-empty text block on `role: "assistant"` messages.
 - Modified file extraction: `ThreadToolRun.TrackFiles`, tool input path fields (`path`, `filePath`, `filepath`, `file`, `absolutePath`, `paths`, `files`), and common tool result `absolutePath` fields.
 - Token usage extraction: `ThreadMessage.Usage` on exported messages.
-- Unprepared behavior: transcript analyzer, compact transcript, token calculation, and read-session operations require exported `AmpThread` JSON and return an error if called on a `session_ref` that has not yet been populated by an export.
+- Unprepared behavior: transcript analyzer, compact transcript, token calculation, and read-session operations require exported `Thread` JSON and return an error if called on a `session_ref` that has not yet been populated by an export.
 
 ## Protocol Mapping
 | Subcommand | Native Concept | Implementation Notes | Feasibility |
@@ -58,9 +58,9 @@ Amp has a TypeScript plugin system with lifecycle events for `agent.start` and `
 | `get-session-id` | Amp thread ID | Read from hook input | Required |
 | `get-session-dir` | `.entire/tmp` | Standard Entire temp dir | Required |
 | `resolve-session-file` | `.entire/tmp/<id>.json` | Standard path resolution | Required |
-| `read-session` | exported Amp JSON | Validate and parse `AmpThread`; use `AmpThread.ID`, raw JSON `native_data`, and extracted modified files | Required |
+| `read-session` | exported Amp JSON | Validate and parse `Thread`; use `Thread.ID`, raw JSON `native_data`, and extracted modified files | Required |
 | `write-session` | exported Amp JSON | Write native data to session ref | Required |
-| `read-transcript` | exported Amp JSON | Return raw bytes after validating `AmpThread` JSON | Required |
+| `read-transcript` | exported Amp JSON | Return raw bytes after validating `Thread` JSON | Required |
 | `chunk-transcript` | raw bytes | Base64 chunking via protocol JSON encoding | Required |
 | `reassemble-transcript` | chunks | Reassemble raw bytes | Required |
 | `format-resume-command` | Amp thread continue | `PLUGINS=all amp threads continue <id>` | Required |
@@ -68,12 +68,12 @@ Amp has a TypeScript plugin system with lifecycle events for `agent.start` and `
 | `install-hooks` | project plugin | Write `.amp/plugins/entire.ts` | Hooks |
 | `uninstall-hooks` | project plugin | Remove `.amp/plugins/entire.ts` | Hooks |
 | `are-hooks-installed` | project plugin | Check plugin marker | Hooks |
-| `get-transcript-position` | exported Amp JSON | Validate `AmpThread` and return byte length | Transcript analyzer |
-| `extract-modified-files` | exported Amp JSON | Parse `AmpThread` tool inputs/results and `trackFiles` | Transcript analyzer |
-| `extract-prompts` | exported Amp JSON | Parse user text blocks from `AmpThread.Messages` | Transcript analyzer |
-| `extract-summary` | exported Amp JSON | Parse last assistant text block from `AmpThread.Messages` | Transcript analyzer |
+| `get-transcript-position` | exported Amp JSON | Validate `Thread` and return byte length | Transcript analyzer |
+| `extract-modified-files` | exported Amp JSON | Parse `Thread` tool inputs/results and `trackFiles` | Transcript analyzer |
+| `extract-prompts` | exported Amp JSON | Parse user text blocks from `Thread.Messages` | Transcript analyzer |
+| `extract-summary` | exported Amp JSON | Parse last assistant text block from `Thread.Messages` | Transcript analyzer |
 | `prepare-transcript` | `amp threads export` | Re-export the Amp thread using the thread ID from the existing prepared transcript at `session_ref` | Transcript preparer |
-| `compact-transcript` | exported Amp JSON | Emit Entire compact JSONL from `AmpThread` | Compact transcript |
+| `compact-transcript` | exported Amp JSON | Emit Entire compact JSONL from `Thread` | Compact transcript |
 | `calculate-tokens` | exported Amp JSON | Sum `ThreadMessage.Usage` token fields | Token calculator |
 
 ## Selected Capabilities

--- a/agents/entire-agent-amp/README.md
+++ b/agents/entire-agent-amp/README.md
@@ -1,0 +1,56 @@
+# entire-agent-amp
+
+External agent binary that teaches the Entire CLI how to work with Amp.
+
+## Capabilities
+
+| Capability          | Status                                                            |
+| ------------------- | ----------------------------------------------------------------- |
+| hooks               | Yes, project plugin in `.amp/plugins/entire.ts`                   |
+| transcript_analyzer | Yes, parses prepared `amp threads export` JSON                  |
+| transcript_preparer | Yes, exports `amp threads export <thread-id>` JSON to session ref |
+| compact_transcript  | Yes, emits Entire compact transcript JSONL for checkpoints v2     |
+| token_calculator    | Yes, sums token usage from exported Amp thread JSON               |
+
+## Installation
+
+```bash
+cd agents/entire-agent-amp
+go build -o entire-agent-amp ./cmd/entire-agent-amp
+cp entire-agent-amp /usr/local/bin/
+```
+
+Or use mise:
+
+```bash
+cd agents/entire-agent-amp
+mise run build
+```
+
+## Prerequisites
+
+- Amp CLI installed as `amp` on `PATH`.
+- Amp must be launched with `PLUGINS=all` for project plugins to load except for users using the [Neo](https://ampcode.com/news/neo) version of Amp, which supports project plugins without the env var.
+
+## How It Works
+
+`install-hooks` creates `.amp/plugins/entire.ts`. The plugin forwards Amp lifecycle events to `entire hooks amp <event>`:
+
+| Amp Event                                                         | Protocol Event        |
+| ----------------------------------------------------------------- | --------------------- |
+| synthetic `session.start` before first `agent.start` for a thread | SessionStart (type 1) |
+| `agent.start`                                                     | TurnStart (type 2)    |
+| `agent.end`                                                       | TurnEnd (type 3)      |
+
+Amp threads are server-side, so hook payloads are cached as JSONL only long enough to identify the thread. When Entire calls `prepare-transcript`, the binary replaces that cache with the JSON output from `amp threads export <thread-id>`. That exported JSON is the authoritative payload for session reads, transcript analysis, compaction, and token calculation.
+
+## Development
+
+```bash
+go build -o entire-agent-amp ./cmd/entire-agent-amp
+go test ./...
+external-agents-tests verify ./entire-agent-amp
+
+cd ../../
+E2E_AGENT=amp mise run test:e2e
+```

--- a/agents/entire-agent-amp/cmd/entire-agent-amp/main.go
+++ b/agents/entire-agent-amp/cmd/entire-agent-amp/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/entireio/external-agents/agents/entire-agent-amp/internal/amp"
+	"github.com/entireio/external-agents/agents/entire-agent-amp/internal/protocol"
+)
+
+func main() {
+	agent := amp.New()
+
+	if len(os.Args) < 2 {
+		fatalf("usage: entire-agent-amp <subcommand> [args]")
+	}
+
+	var err error
+
+	switch os.Args[1] {
+	case "info":
+		err = protocol.WriteJSON(os.Stdout, agent.Info())
+	case "detect":
+		err = protocol.WriteJSON(os.Stdout, agent.Detect())
+	case "get-session-id":
+		err = protocol.HandleGetSessionID(os.Stdin, os.Stdout, agent)
+	case "get-session-dir":
+		err = protocol.HandleGetSessionDir(os.Args[2:], os.Stdout, agent)
+	case "resolve-session-file":
+		err = protocol.HandleResolveSessionFile(os.Args[2:], os.Stdout, agent)
+	case "read-session":
+		err = protocol.HandleReadSession(os.Stdin, os.Stdout, agent)
+	case "write-session":
+		err = protocol.HandleWriteSession(os.Stdin, agent)
+	case "read-transcript":
+		err = protocol.HandleReadTranscript(os.Args[2:], os.Stdout, agent)
+	case "chunk-transcript":
+		err = protocol.HandleChunkTranscript(os.Args[2:], os.Stdin, os.Stdout, agent)
+	case "reassemble-transcript":
+		err = protocol.HandleReassembleTranscript(os.Stdin, os.Stdout, agent)
+	case "compact-transcript":
+		err = protocol.HandleCompactTranscript(os.Args[2:], os.Stdout, agent)
+	case "prepare-transcript":
+		err = protocol.HandlePrepareTranscript(os.Args[2:], agent)
+	case "format-resume-command":
+		err = protocol.HandleFormatResumeCommand(os.Args[2:], os.Stdout, agent)
+	case "parse-hook":
+		err = protocol.HandleParseHook(os.Args[2:], os.Stdin, os.Stdout, agent)
+	case "install-hooks":
+		err = protocol.HandleInstallHooks(os.Args[2:], os.Stdout, agent)
+	case "uninstall-hooks":
+		err = agent.UninstallHooks()
+	case "are-hooks-installed":
+		err = protocol.WriteJSON(os.Stdout, protocol.AreHooksInstalledResponse{
+			Installed: agent.AreHooksInstalled(),
+		})
+	case "get-transcript-position":
+		err = protocol.HandleGetTranscriptPosition(os.Args[2:], os.Stdout, agent)
+	case "extract-modified-files":
+		err = protocol.HandleExtractModifiedFiles(os.Args[2:], os.Stdout, agent)
+	case "extract-prompts":
+		err = protocol.HandleExtractPrompts(os.Args[2:], os.Stdout, agent)
+	case "extract-summary":
+		err = protocol.HandleExtractSummary(os.Args[2:], os.Stdout, agent)
+	case "calculate-tokens":
+		err = protocol.HandleCalculateTokens(os.Args[2:], os.Stdin, os.Stdout, agent)
+	default:
+		fatalf("unknown subcommand: %s", os.Args[1])
+	}
+
+	if err != nil {
+		fatalf("%v", err)
+	}
+}
+
+func fatalf(format string, args ...any) {
+	_, _ = fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/agents/entire-agent-amp/go.mod
+++ b/agents/entire-agent-amp/go.mod
@@ -1,0 +1,3 @@
+module github.com/entireio/external-agents/agents/entire-agent-amp
+
+go 1.26.0

--- a/agents/entire-agent-amp/internal/amp/agent.go
+++ b/agents/entire-agent-amp/internal/amp/agent.go
@@ -1,0 +1,55 @@
+package amp
+
+import (
+	"os/exec"
+
+	"github.com/entireio/external-agents/agents/entire-agent-amp/internal/protocol"
+)
+
+type Agent struct {
+	CommandRunner CommandRunner
+}
+
+func New() *Agent {
+	return &Agent{CommandRunner: &DefaultCommandRunner{}}
+}
+
+func (a *Agent) Info() protocol.InfoResponse {
+	return protocol.InfoResponse{
+		ProtocolVersion: protocol.ProtocolVersion,
+		Name:            "amp",
+		Type:            "Amp",
+		Description:     "Amp coding agent integration for Entire",
+		IsPreview:       true,
+		ProtectedDirs:   []string{".amp"},
+		ProtectedFiles:  []string{".amp/plugins/entire.ts"},
+		HookNames:       []string{"session.start", "agent.start", "agent.end"},
+		Capabilities: protocol.DeclaredCapabilities{
+			Hooks:              true,
+			TranscriptAnalyzer: true,
+			TranscriptPreparer: true,
+			TokenCalculator:    true,
+			CompactTranscript:  true,
+			UsesTerminal:       true,
+		},
+	}
+}
+
+func (a *Agent) Detect() protocol.DetectResponse {
+	_, err := exec.LookPath("amp")
+	return protocol.DetectResponse{Present: err == nil}
+}
+
+func (a *Agent) GetSessionID(input *protocol.HookInputJSON) string {
+	if input != nil && input.SessionID != "" {
+		return input.SessionID
+	}
+	return ""
+}
+
+func (a *Agent) FormatResumeCommand(sessionID string) string {
+	if sessionID == "" {
+		return "PLUGINS=all amp threads continue --last"
+	}
+	return "PLUGINS=all amp threads continue " + sessionID
+}

--- a/agents/entire-agent-amp/internal/amp/command_runner.go
+++ b/agents/entire-agent-amp/internal/amp/command_runner.go
@@ -30,7 +30,7 @@ func (r *DefaultCommandRunner) ExportThread(ctx context.Context, threadID string
 	}
 
 	cmd := exec.CommandContext(ctx, "amp", "threads", "export", threadID)
-	cmd.Env = append(os.Environ(), "PLUGINS=all")
+	cmd.Env = append(ampEnv(), "PLUGINS=all")
 	out, err := cmd.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
@@ -43,4 +43,34 @@ func (r *DefaultCommandRunner) ExportThread(ctx context.Context, threadID string
 	}
 
 	return outputPath, nil
+}
+
+// ampEnv returns the parent environment with Bun-specific variables stripped.
+//
+// The `amp` CLI is distributed as a Bun-compiled native binary. When invoked
+// from inside an Amp plugin (which itself runs on Bun), variables like
+// `BUN_BE_BUN` leak into the child process and make the compiled binary
+// re-interpret its argv as a Bun script invocation. The visible symptom is
+// `amp threads export <id>` failing with `error: Script not found "threads"`.
+// Removing the Bun bootstrap variables forces `amp` to execute its compiled
+// entrypoint instead.
+func ampEnv() []string {
+	parent := os.Environ()
+	out := make([]string, 0, len(parent))
+	for _, kv := range parent {
+		key, _, _ := strings.Cut(kv, "=")
+		if isBunEnvVar(key) {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+func isBunEnvVar(key string) bool {
+	switch key {
+	case "BUN_BE_BUN", "BUN_INTERNAL_IPC_FD", "BUN_INSPECT", "BUN_INSPECT_NOTIFY", "BUN_INSPECT_CONNECT_TO":
+		return true
+	}
+	return strings.HasPrefix(key, "BUN_DEBUG_")
 }

--- a/agents/entire-agent-amp/internal/amp/command_runner.go
+++ b/agents/entire-agent-amp/internal/amp/command_runner.go
@@ -1,0 +1,46 @@
+package amp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// CommandRunner defines the interface for running `amp` commands, allowing for easier testing and abstraction.
+type CommandRunner interface {
+	// ExportThread runs the `amp threads export <threadID>` command for the given thread ID, stores the output at the specified outputPath and returns the path to the exported transcript file.
+	ExportThread(ctx context.Context, threadID string, outputPath string) (string, error)
+}
+
+// DefaultCommandRunner is the default implementation of CommandRunner that actually runs the `amp` commands.
+type DefaultCommandRunner struct{}
+
+func (r *DefaultCommandRunner) ExportThread(ctx context.Context, threadID string, outputPath string) (string, error) {
+	if strings.TrimSpace(threadID) == "" {
+		return "", fmt.Errorf("thread ID is required")
+	}
+	if strings.TrimSpace(outputPath) == "" {
+		return "", fmt.Errorf("output path is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o750); err != nil {
+		return "", fmt.Errorf("create output dir: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, "amp", "threads", "export", threadID)
+	cmd.Env = append(os.Environ(), "PLUGINS=all")
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("amp threads export %s: %w: %s", threadID, err, strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return "", fmt.Errorf("amp threads export %s: %w", threadID, err)
+	}
+	if err := os.WriteFile(outputPath, out, 0o600); err != nil {
+		return "", fmt.Errorf("write exported transcript: %w", err)
+	}
+
+	return outputPath, nil
+}

--- a/agents/entire-agent-amp/internal/amp/command_runner.go
+++ b/agents/entire-agent-amp/internal/amp/command_runner.go
@@ -2,6 +2,7 @@ package amp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -20,10 +21,10 @@ type DefaultCommandRunner struct{}
 
 func (r *DefaultCommandRunner) ExportThread(ctx context.Context, threadID string, outputPath string) (string, error) {
 	if strings.TrimSpace(threadID) == "" {
-		return "", fmt.Errorf("thread ID is required")
+		return "", errors.New("thread ID is required")
 	}
 	if strings.TrimSpace(outputPath) == "" {
-		return "", fmt.Errorf("output path is required")
+		return "", errors.New("output path is required")
 	}
 	if err := os.MkdirAll(filepath.Dir(outputPath), 0o750); err != nil {
 		return "", fmt.Errorf("create output dir: %w", err)
@@ -33,7 +34,7 @@ func (r *DefaultCommandRunner) ExportThread(ctx context.Context, threadID string
 	cmd.Env = append(ampEnv(), "PLUGINS=all")
 	out, err := cmd.Output()
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			return "", fmt.Errorf("amp threads export %s: %w: %s", threadID, err, strings.TrimSpace(string(exitErr.Stderr)))
 		}
 		return "", fmt.Errorf("amp threads export %s: %w", threadID, err)

--- a/agents/entire-agent-amp/internal/amp/command_runner_test.go
+++ b/agents/entire-agent-amp/internal/amp/command_runner_test.go
@@ -41,14 +41,14 @@ func TestAmpEnvStripsBunVars(t *testing.T) {
 
 func TestIsBunEnvVar(t *testing.T) {
 	cases := map[string]bool{
-		"BUN_BE_BUN":           true,
-		"BUN_INSPECT":          true,
-		"BUN_DEBUG_FOO":        true,
-		"BUN_INSTALL":          false,
-		"BUN_INSTALL_CACHE":    false,
-		"PATH":                 false,
-		"PLUGINS":              false,
-		"BUN_INTERNAL_IPC_FD":  true,
+		"BUN_BE_BUN":          true,
+		"BUN_INSPECT":         true,
+		"BUN_DEBUG_FOO":       true,
+		"BUN_INSTALL":         false,
+		"BUN_INSTALL_CACHE":   false,
+		"PATH":                false,
+		"PLUGINS":             false,
+		"BUN_INTERNAL_IPC_FD": true,
 	}
 	for key, want := range cases {
 		if got := isBunEnvVar(key); got != want {

--- a/agents/entire-agent-amp/internal/amp/command_runner_test.go
+++ b/agents/entire-agent-amp/internal/amp/command_runner_test.go
@@ -1,0 +1,58 @@
+package amp
+
+import (
+	"os"
+	"testing"
+)
+
+func TestAmpEnvStripsBunVars(t *testing.T) {
+	t.Setenv("BUN_BE_BUN", "1")
+	t.Setenv("BUN_INSPECT", "0.0.0.0:9229")
+	t.Setenv("BUN_DEBUG_QUIET_LOGS", "1")
+	t.Setenv("BUN_INSTALL", "/keep/me")
+	t.Setenv("KEEP_ME", "yes")
+	env := ampEnv()
+	stripped := []string{"BUN_BE_BUN", "BUN_INSPECT", "BUN_DEBUG_QUIET_LOGS"}
+	for _, kv := range env {
+		for _, bad := range stripped {
+			if len(kv) > len(bad) && kv[:len(bad)+1] == bad+"=" {
+				t.Fatalf("env still contains %q: %q", bad, kv)
+			}
+		}
+	}
+	wantPresent := map[string]string{"KEEP_ME=yes": "user env", "BUN_INSTALL=/keep/me": "non-bootstrap Bun var"}
+	for kv, desc := range wantPresent {
+		found := false
+		for _, got := range env {
+			if got == kv {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected %s %q to be preserved", desc, kv)
+		}
+	}
+	// sanity: actual process env hasn't been mutated
+	if os.Getenv("KEEP_ME") != "yes" {
+		t.Fatal("test setup error")
+	}
+}
+
+func TestIsBunEnvVar(t *testing.T) {
+	cases := map[string]bool{
+		"BUN_BE_BUN":           true,
+		"BUN_INSPECT":          true,
+		"BUN_DEBUG_FOO":        true,
+		"BUN_INSTALL":          false,
+		"BUN_INSTALL_CACHE":    false,
+		"PATH":                 false,
+		"PLUGINS":              false,
+		"BUN_INTERNAL_IPC_FD":  true,
+	}
+	for key, want := range cases {
+		if got := isBunEnvVar(key); got != want {
+			t.Errorf("isBunEnvVar(%q) = %v, want %v", key, got, want)
+		}
+	}
+}

--- a/agents/entire-agent-amp/internal/amp/compact.go
+++ b/agents/entire-agent-amp/internal/amp/compact.go
@@ -112,6 +112,8 @@ func compactTranscriptBytes(data []byte) ([]byte, error) {
 			if err := writeCompactTranscriptLine(&buf, line); err != nil {
 				return nil, err
 			}
+		case ThreadMessageRoleInfo:
+			// Informational messages have no compact transcript representation.
 		}
 	}
 	if buf.Len() == 0 {
@@ -150,6 +152,12 @@ func compactAssistantContent(blocks []ThreadContentBlock, messages []ThreadMessa
 				tool.Result = &result
 			}
 			out = append(out, tool)
+		case ThreadContentThinking,
+			ThreadContentImage,
+			ThreadContentToolResult,
+			ThreadContentServerToolUse,
+			ThreadContentToolSearchResult:
+			// Non-text/non-tool_use blocks are not represented in compact assistant content.
 		}
 	}
 	return out

--- a/agents/entire-agent-amp/internal/amp/compact.go
+++ b/agents/entire-agent-amp/internal/amp/compact.go
@@ -1,0 +1,242 @@
+package amp
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/entireio/external-agents/agents/entire-agent-amp/internal/protocol"
+)
+
+const (
+	compactTranscriptAgent      = "amp"
+	compactTranscriptCLIVersion = "unknown"
+)
+
+type compactTranscriptLine struct {
+	V            int    `json:"v"`
+	Agent        string `json:"agent"`
+	CLIVersion   string `json:"cli_version"`
+	Type         string `json:"type"`
+	TS           string `json:"ts,omitempty"`
+	ID           string `json:"id,omitempty"`
+	InputTokens  int    `json:"input_tokens,omitempty"`
+	OutputTokens int    `json:"output_tokens,omitempty"`
+	Content      any    `json:"content"`
+}
+
+type compactUserTextBlock struct {
+	Text string `json:"text"`
+}
+
+type compactAssistantTextBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type compactAssistantToolUseBlock struct {
+	Type   string                 `json:"type"`
+	ID     string                 `json:"id,omitempty"`
+	Name   string                 `json:"name"`
+	Input  any                    `json:"input"`
+	Result *compactToolResultJSON `json:"result,omitempty"`
+}
+
+type compactToolResultJSON struct {
+	Output string `json:"output"`
+	Status string `json:"status"`
+}
+
+func (a *Agent) CompactTranscript(sessionRef string) (protocol.CompactTranscriptResponse, error) {
+	data, err := os.ReadFile(sessionRef)
+	if err != nil {
+		return protocol.CompactTranscriptResponse{}, fmt.Errorf("failed to read transcript: %w", err)
+	}
+	compacted, err := compactTranscriptBytes(data)
+	if err != nil {
+		return protocol.CompactTranscriptResponse{}, err
+	}
+	return protocol.CompactTranscriptResponse{Transcript: base64.StdEncoding.EncodeToString(compacted)}, nil
+}
+
+func compactTranscriptBytes(data []byte) ([]byte, error) {
+	thread, err := parseAmpThread(data)
+	if err != nil {
+		return nil, err
+	}
+	if len(thread.Messages) == 0 {
+		return nil, errors.New("compact transcript produced no output")
+	}
+
+	cliVersion := compactCLIVersion()
+	var buf bytes.Buffer
+	for _, msg := range thread.Messages {
+		switch msg.Role {
+		case ThreadMessageRoleUser:
+			content := compactUserContent(msg.Content)
+			if len(content) == 0 {
+				continue
+			}
+			if err := writeCompactTranscriptLine(&buf, compactTranscriptLine{
+				V:          1,
+				Agent:      compactTranscriptAgent,
+				CLIVersion: cliVersion,
+				Type:       "user",
+				TS:         threadMessageTimestamp(msg),
+				Content:    content,
+			}); err != nil {
+				return nil, err
+			}
+		case ThreadMessageRoleAssistant:
+			content := compactAssistantContent(msg.Content, thread.Messages)
+			if len(content) == 0 {
+				continue
+			}
+			line := compactTranscriptLine{
+				V:          1,
+				Agent:      compactTranscriptAgent,
+				CLIVersion: cliVersion,
+				Type:       "assistant",
+				TS:         threadMessageTimestamp(msg),
+				ID:         threadMessageIDString(msg.MessageID),
+				Content:    content,
+			}
+			if msg.Usage != nil {
+				line.InputTokens = msg.Usage.InputTokens
+				line.OutputTokens = msg.Usage.OutputTokens
+			}
+			if err := writeCompactTranscriptLine(&buf, line); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if buf.Len() == 0 {
+		return nil, errors.New("compact transcript produced no output")
+	}
+	return buf.Bytes(), nil
+}
+
+func compactUserContent(blocks []ThreadContentBlock) []compactUserTextBlock {
+	out := make([]compactUserTextBlock, 0, len(blocks))
+	for _, block := range blocks {
+		if block.Type == ThreadContentText && block.Text != "" {
+			out = append(out, compactUserTextBlock{Text: block.Text})
+		}
+	}
+	return out
+}
+
+func compactAssistantContent(blocks []ThreadContentBlock, messages []ThreadMessage) []any {
+	results := collectToolResults(messages)
+	out := make([]any, 0, len(blocks))
+	for _, block := range blocks {
+		switch block.Type {
+		case ThreadContentText:
+			if block.Text != "" {
+				out = append(out, compactAssistantTextBlock{Type: "text", Text: block.Text})
+			}
+		case ThreadContentToolUse:
+			tool := compactAssistantToolUseBlock{
+				Type:  "tool_use",
+				ID:    block.ID,
+				Name:  block.Name,
+				Input: decodeToolInput(block.Input),
+			}
+			if result, ok := results[block.ID]; ok {
+				tool.Result = &result
+			}
+			out = append(out, tool)
+		}
+	}
+	return out
+}
+
+func collectToolResults(messages []ThreadMessage) map[string]compactToolResultJSON {
+	results := map[string]compactToolResultJSON{}
+	for _, msg := range messages {
+		for _, block := range msg.Content {
+			if block.Type != ThreadContentToolResult || block.ToolUseID == "" || block.Run == nil {
+				continue
+			}
+			status := "success"
+			if block.Run.Status == "error" || block.Run.Status == "cancelled" || block.Run.Error != nil {
+				status = "error"
+			}
+			results[block.ToolUseID] = compactToolResultJSON{Output: toolRunOutput(block.Run), Status: status}
+		}
+	}
+	return results
+}
+
+func writeCompactTranscriptLine(buf *bytes.Buffer, line compactTranscriptLine) error {
+	encoded, err := json.Marshal(line)
+	if err != nil {
+		return err
+	}
+	buf.Write(encoded)
+	return buf.WriteByte('\n')
+}
+
+func compactCLIVersion() string {
+	if version := strings.TrimSpace(os.Getenv("ENTIRE_CLI_VERSION")); version != "" {
+		return version
+	}
+	return compactTranscriptCLIVersion
+}
+
+func decodeToolInput(input ThreadToolInput) any {
+	if input == nil {
+		return map[string]any{}
+	}
+	decoded := make(map[string]any, len(input))
+	for key, raw := range input {
+		var value any
+		if err := json.Unmarshal(raw, &value); err != nil {
+			decoded[key] = string(raw)
+			continue
+		}
+		decoded[key] = value
+	}
+	return decoded
+}
+
+func toolRunOutput(run *ThreadToolRun) string {
+	if run == nil {
+		return ""
+	}
+	if run.Error != nil && run.Error.Message != "" {
+		return run.Error.Message
+	}
+	if len(run.Result) == 0 {
+		return ""
+	}
+	var common ThreadCommonToolResult
+	if err := json.Unmarshal(run.Result, &common); err == nil {
+		if common.Output != "" {
+			return common.Output
+		}
+		if common.Diff != "" {
+			return common.Diff
+		}
+		if len(common.Content) > 0 {
+			var parts []string
+			for _, block := range common.Content {
+				if block.Text != "" {
+					parts = append(parts, block.Text)
+				}
+			}
+			if len(parts) > 0 {
+				return strings.Join(parts, "\n")
+			}
+		}
+	}
+	var s string
+	if err := json.Unmarshal(run.Result, &s); err == nil {
+		return s
+	}
+	return string(run.Result)
+}

--- a/agents/entire-agent-amp/internal/amp/compact_test.go
+++ b/agents/entire-agent-amp/internal/amp/compact_test.go
@@ -1,0 +1,72 @@
+package amp
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestCompactTranscriptBytes(t *testing.T) {
+	t.Setenv("ENTIRE_CLI_VERSION", "9.9.9")
+	data, err := compactTranscriptBytes([]byte(testPreparedTranscriptJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	for _, want := range []string{
+		`"agent":"amp"`,
+		`"cli_version":"9.9.9"`,
+		`"type":"user"`,
+		`"type":"assistant"`,
+		`"name":"edit_file"`,
+		`"result":{"output":"ok","status":"success"}`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("compact transcript missing %q\n%s", want, got)
+		}
+	}
+}
+
+func TestCompactTranscriptResponse(t *testing.T) {
+	agent := New()
+	path := writePreparedTranscript(t)
+	resp, err := agent.CompactTranscript(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(resp.Transcript)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(decoded), `"agent":"amp"`) {
+		t.Fatalf("decoded = %s", decoded)
+	}
+}
+
+func TestCompactTranscriptBytes_UnpreparedJSONL(t *testing.T) {
+	_, err := compactTranscriptBytes([]byte(testTranscriptJSONL))
+	if err == nil {
+		t.Fatal("expected unprepared transcript error")
+	}
+}
+
+func TestCompactTranscriptBytes_PreparedJSON(t *testing.T) {
+	t.Setenv("ENTIRE_CLI_VERSION", "9.9.9")
+	data, err := compactTranscriptBytes([]byte(testPreparedTranscriptJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	for _, want := range []string{
+		`"agent":"amp"`,
+		`"cli_version":"9.9.9"`,
+		`"type":"user"`,
+		`"type":"assistant"`,
+		`"name":"edit_file"`,
+		`"result":{"output":"ok","status":"success"}`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("compact transcript missing %q\n%s", want, got)
+		}
+	}
+}

--- a/agents/entire-agent-amp/internal/amp/hooks.go
+++ b/agents/entire-agent-amp/internal/amp/hooks.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -64,8 +65,7 @@ func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, e
 		model := latestModelFromSessionRef(sessionRef)
 		if model == "" {
 			// Fallback: ensure we have a prepared transcript so we can populate the model.
-			error := a.exportThread(sessionID, sessionRef)
-			if error == nil {
+			if exportErr := a.exportThread(sessionID, sessionRef); exportErr == nil {
 				model = latestModelFromSessionRef(sessionRef)
 			}
 		}
@@ -79,9 +79,8 @@ func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, e
 		}, nil
 
 	case "agent.end":
-		error := a.exportThread(sessionID, sessionRef)
-		if error != nil {
-			return nil, fmt.Errorf("export thread on agent.end: %w", error)
+		if err := a.exportThread(sessionID, sessionRef); err != nil {
+			return nil, fmt.Errorf("export thread on agent.end: %w", err)
 		}
 		return &protocol.EventJSON{
 			Type:       3,
@@ -102,7 +101,7 @@ func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, e
 // model so events are still emitted.
 func (a *Agent) exportThread(threadID, sessionRef string) error {
 	if strings.TrimSpace(threadID) == "" || strings.TrimSpace(sessionRef) == "" {
-		return fmt.Errorf("thread id and session ref are required")
+		return errors.New("thread id and session ref are required")
 	}
 	runner := a.CommandRunner
 	if runner == nil {
@@ -119,7 +118,7 @@ func (a *Agent) exportThread(threadID, sessionRef string) error {
 
 // latestModelFromSessionRef returns the most recent model string recorded in
 // the prepared transcript at sessionRef. It returns an empty string if the
-// file is missing or not yet a prepared AmpThread JSON.
+// file is missing or not yet a prepared Thread JSON.
 func latestModelFromSessionRef(sessionRef string) string {
 	if strings.TrimSpace(sessionRef) == "" {
 		return ""

--- a/agents/entire-agent-amp/internal/amp/hooks.go
+++ b/agents/entire-agent-amp/internal/amp/hooks.go
@@ -1,6 +1,8 @@
 package amp
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -49,47 +51,88 @@ func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, e
 
 	switch hookName {
 	case "session.start":
+		_ = a.exportThread(sessionID, sessionRef)
 		return &protocol.EventJSON{
 			Type:       1,
 			SessionID:  sessionID,
 			SessionRef: sessionRef,
+			Model:      latestModelFromSessionRef(sessionRef),
 			Timestamp:  now,
 		}, nil
 
 	case "agent.start":
-		if err := appendTranscriptEntry(sessionRef, ampTranscriptEntry{
-			Type:     "agent.start",
-			ThreadID: sessionID,
-			Message:  payload.Message,
-		}); err != nil {
-			return nil, err
+		model := latestModelFromSessionRef(sessionRef)
+		if model == "" {
+			// Fallback: ensure we have a prepared transcript so we can populate the model.
+			error := a.exportThread(sessionID, sessionRef)
+			if error == nil {
+				model = latestModelFromSessionRef(sessionRef)
+			}
 		}
 		return &protocol.EventJSON{
 			Type:       2,
 			SessionID:  sessionID,
 			SessionRef: sessionRef,
 			Prompt:     payload.Message,
+			Model:      model,
 			Timestamp:  now,
 		}, nil
 
 	case "agent.end":
-		if err := appendTranscriptEntry(sessionRef, ampTranscriptEntry{
-			Type:     "agent.end",
-			ThreadID: sessionID,
-			Message:  payload.Message,
-		}); err != nil {
-			return nil, err
+		error := a.exportThread(sessionID, sessionRef)
+		if error != nil {
+			return nil, fmt.Errorf("export thread on agent.end: %w", error)
 		}
 		return &protocol.EventJSON{
 			Type:       3,
 			SessionID:  sessionID,
 			SessionRef: sessionRef,
+			Model:      latestModelFromSessionRef(sessionRef),
 			Timestamp:  now,
 		}, nil
 
 	default:
 		return nil, nil
 	}
+}
+
+// exportThread runs `amp threads export` for the given thread and writes the
+// result to sessionRef. The parent directory is created if needed. Callers
+// generally ignore the returned error and fall back to reporting an empty
+// model so events are still emitted.
+func (a *Agent) exportThread(threadID, sessionRef string) error {
+	if strings.TrimSpace(threadID) == "" || strings.TrimSpace(sessionRef) == "" {
+		return fmt.Errorf("thread id and session ref are required")
+	}
+	runner := a.CommandRunner
+	if runner == nil {
+		runner = &DefaultCommandRunner{}
+	}
+	if err := os.MkdirAll(filepath.Dir(sessionRef), 0o750); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), prepareTranscriptTimeout)
+	defer cancel()
+	_, err := runner.ExportThread(ctx, threadID, sessionRef)
+	return err
+}
+
+// latestModelFromSessionRef returns the most recent model string recorded in
+// the prepared transcript at sessionRef. It returns an empty string if the
+// file is missing or not yet a prepared AmpThread JSON.
+func latestModelFromSessionRef(sessionRef string) string {
+	if strings.TrimSpace(sessionRef) == "" {
+		return ""
+	}
+	data, err := os.ReadFile(sessionRef)
+	if err != nil || len(bytes.TrimSpace(data)) == 0 {
+		return ""
+	}
+	thread, err := parseAmpThread(data)
+	if err != nil {
+		return ""
+	}
+	return latestThreadModel(thread)
 }
 
 func (a *Agent) InstallHooks(_ bool, force bool) (int, error) {

--- a/agents/entire-agent-amp/internal/amp/hooks.go
+++ b/agents/entire-agent-amp/internal/amp/hooks.go
@@ -13,10 +13,9 @@ import (
 )
 
 const (
-	pluginDir         = ".amp/plugins"
-	pluginFile        = ".amp/plugins/entire.ts"
-	transcriptSubdir  = "amp"
-	seenSessionSubdir = "amp/seen"
+	pluginDir        = ".amp/plugins"
+	pluginFile       = ".amp/plugins/entire.ts"
+	transcriptSubdir = "amp"
 )
 
 type ampHookPayload struct {
@@ -50,7 +49,6 @@ func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, e
 
 	switch hookName {
 	case "session.start":
-		markSessionSeen(sessionID)
 		return &protocol.EventJSON{
 			Type:       1,
 			SessionID:  sessionID,
@@ -59,9 +57,6 @@ func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, e
 		}, nil
 
 	case "agent.start":
-		if !sessionSeen(sessionID) {
-			markSessionSeen(sessionID)
-		}
 		if err := appendTranscriptEntry(sessionRef, ampTranscriptEntry{
 			Type:     "agent.start",
 			ThreadID: sessionID,
@@ -133,15 +128,6 @@ func (a *Agent) UninstallHooks() error {
 		_ = os.Remove(ampDir)
 	}
 
-	// Clean up any seen session markers, but leave transcripts in place since they may be useful to the user and are small in size.
-	sessionsDir := protocol.DefaultSessionDir(root)
-	seenDir := filepath.Join(sessionsDir, seenSessionSubdir)
-	if entries, err := os.ReadDir(seenDir); err == nil {
-		for _, entry := range entries {
-			_ = os.Remove(filepath.Join(seenDir, entry.Name()))
-		}
-	}
-
 	return nil
 }
 
@@ -152,12 +138,34 @@ func (a *Agent) AreHooksInstalled() bool {
 }
 
 func generatePlugin() string {
-	return `import type { AgentEndEvent, AgentStartEvent, PluginAPI, ThreadMessage } from "@ampcode/plugin";
+	return `import type {
+  AgentEndEvent,
+  AgentStartEvent,
+  PluginAPI,
+  SessionStartEvent,
+  ThreadMessage,
+} from "@ampcode/plugin";
 import { execFile } from "node:child_process";
 
 // entire-agent-amp: project-local Entire integration for Amp.
 export default function (amp: PluginAPI) {
+  // In-memory session tracking.
+  let currentThreadId: string | null = null;
   const seenThreads = new Set<string>();
+
+  // trackThread records the given thread id and returns true when it is the
+  // first time we have seen it for the current session. When a different
+  // thread id is discovered we clear all tracking — the user has switched to
+  // a new thread, so prior dedupe state no longer applies.
+  function trackThread(threadId: string): boolean {
+    if (threadId !== currentThreadId) {
+      seenThreads.clear();
+      currentThreadId = threadId;
+    }
+    if (seenThreads.has(threadId)) return false;
+    seenThreads.add(threadId);
+    return true;
+  }
 
   function fireHook(hookName: string, data: Record<string, unknown>): Promise<void> {
     return new Promise((resolve) => {
@@ -200,9 +208,21 @@ export default function (amp: PluginAPI) {
     return Array.from(files).sort();
   }
 
+  amp.on("session.start", async (event: SessionStartEvent): Promise<void> => {
+    const threadId = event.thread?.id;
+    if (!threadId) return;
+    if (!trackThread(threadId)) return;
+    await fireHook("session.start", {
+      type: "session.start",
+      cwd: process.cwd(),
+      thread_id: threadId,
+    });
+  });
+
   amp.on("agent.start", async (event: AgentStartEvent): Promise<void> => {
-    if (!seenThreads.has(event.thread.id)) {
-      seenThreads.add(event.thread.id);
+    // Amp's session.start does not always include a thread id, so agent.start
+    // is the fallback point for firing the synthetic session.start hook.
+    if (trackThread(event.thread.id)) {
       await fireHook("session.start", {
         type: "session.start",
         cwd: process.cwd(),
@@ -237,22 +257,6 @@ export default function (amp: PluginAPI) {
 
 func transcriptPath(sessionID string) string {
 	return filepath.Join(protocol.DefaultSessionDir(protocol.RepoRoot()), transcriptSubdir, safeSessionID(sessionID)+".jsonl")
-}
-
-func seenPath(sessionID string) string {
-	return filepath.Join(protocol.DefaultSessionDir(protocol.RepoRoot()), seenSessionSubdir, safeSessionID(sessionID))
-}
-
-func sessionSeen(sessionID string) bool {
-	_, err := os.Stat(seenPath(sessionID))
-	return err == nil
-}
-
-func markSessionSeen(sessionID string) {
-	path := seenPath(sessionID)
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err == nil {
-		_ = os.WriteFile(path, []byte(sessionID), 0o600)
-	}
 }
 
 func safeSessionID(sessionID string) string {

--- a/agents/entire-agent-amp/internal/amp/hooks.go
+++ b/agents/entire-agent-amp/internal/amp/hooks.go
@@ -1,0 +1,264 @@
+package amp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/entireio/external-agents/agents/entire-agent-amp/internal/protocol"
+)
+
+const (
+	pluginDir         = ".amp/plugins"
+	pluginFile        = ".amp/plugins/entire.ts"
+	transcriptSubdir  = "amp"
+	seenSessionSubdir = "amp/seen"
+)
+
+type ampHookPayload struct {
+	Type          string            `json:"type"`
+	Cwd           string            `json:"cwd,omitempty"`
+	ThreadID      string            `json:"thread_id,omitempty"`
+	MessageID     string            `json:"message_id,omitempty"`
+	Message       string            `json:"message,omitempty"`
+	Status        string            `json:"status,omitempty"`
+	Messages      []json.RawMessage `json:"messages,omitempty"`
+	ModifiedFiles []string          `json:"modified_files,omitempty"`
+}
+
+func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, error) {
+	if len(input) == 0 {
+		return nil, nil
+	}
+
+	var payload ampHookPayload
+	if err := json.Unmarshal(input, &payload); err != nil {
+		return nil, fmt.Errorf("parse hook payload: %w", err)
+	}
+
+	sessionID := payload.ThreadID
+	if sessionID == "" {
+		return nil, nil
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	sessionRef := transcriptPath(sessionID)
+
+	switch hookName {
+	case "session.start":
+		markSessionSeen(sessionID)
+		return &protocol.EventJSON{
+			Type:       1,
+			SessionID:  sessionID,
+			SessionRef: sessionRef,
+			Timestamp:  now,
+		}, nil
+
+	case "agent.start":
+		if !sessionSeen(sessionID) {
+			markSessionSeen(sessionID)
+		}
+		if err := appendTranscriptEntry(sessionRef, ampTranscriptEntry{
+			Type:     "agent.start",
+			ThreadID: sessionID,
+			Message:  payload.Message,
+		}); err != nil {
+			return nil, err
+		}
+		return &protocol.EventJSON{
+			Type:       2,
+			SessionID:  sessionID,
+			SessionRef: sessionRef,
+			Prompt:     payload.Message,
+			Timestamp:  now,
+		}, nil
+
+	case "agent.end":
+		if err := appendTranscriptEntry(sessionRef, ampTranscriptEntry{
+			Type:     "agent.end",
+			ThreadID: sessionID,
+			Message:  payload.Message,
+		}); err != nil {
+			return nil, err
+		}
+		return &protocol.EventJSON{
+			Type:       3,
+			SessionID:  sessionID,
+			SessionRef: sessionRef,
+			Timestamp:  now,
+		}, nil
+
+	default:
+		return nil, nil
+	}
+}
+
+func (a *Agent) InstallHooks(_ bool, force bool) (int, error) {
+	root := protocol.RepoRoot()
+	if !force && a.AreHooksInstalled() {
+		return 0, nil
+	}
+
+	dir := filepath.Join(root, pluginDir)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return 0, fmt.Errorf("create plugin dir: %w", err)
+	}
+
+	path := filepath.Join(root, pluginFile)
+	if err := os.WriteFile(path, []byte(generatePlugin()), 0o600); err != nil {
+		return 0, fmt.Errorf("write plugin: %w", err)
+	}
+
+	return 3, nil
+}
+
+func (a *Agent) UninstallHooks() error {
+	root := protocol.RepoRoot()
+	path := filepath.Join(root, pluginFile)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	// If the plugin directory is empty after removing the plugin file, remove it as well.
+	dir := filepath.Join(root, pluginDir)
+	if entries, err := os.ReadDir(dir); err == nil && len(entries) == 0 {
+		_ = os.Remove(dir)
+	}
+	// If .amp is empty after removing the plugin directory, remove it as well.
+	ampDir := filepath.Join(root, ".amp")
+	if entries, err := os.ReadDir(ampDir); err == nil && len(entries) == 0 {
+		_ = os.Remove(ampDir)
+	}
+
+	// Clean up any seen session markers, but leave transcripts in place since they may be useful to the user and are small in size.
+	sessionsDir := protocol.DefaultSessionDir(root)
+	seenDir := filepath.Join(sessionsDir, seenSessionSubdir)
+	if entries, err := os.ReadDir(seenDir); err == nil {
+		for _, entry := range entries {
+			_ = os.Remove(filepath.Join(seenDir, entry.Name()))
+		}
+	}
+
+	return nil
+}
+
+func (a *Agent) AreHooksInstalled() bool {
+	root := protocol.RepoRoot()
+	data, err := os.ReadFile(filepath.Join(root, pluginFile))
+	return err == nil && strings.Contains(string(data), "entire-agent-amp")
+}
+
+func generatePlugin() string {
+	return `import type { AgentEndEvent, AgentStartEvent, PluginAPI, ThreadMessage } from "@ampcode/plugin";
+import { execFile } from "node:child_process";
+
+// entire-agent-amp: project-local Entire integration for Amp.
+export default function (amp: PluginAPI) {
+  const seenThreads = new Set<string>();
+
+  function fireHook(hookName: string, data: Record<string, unknown>): Promise<void> {
+    return new Promise((resolve) => {
+      let body: string;
+      try {
+        body = JSON.stringify(data);
+      } catch (err) {
+        amp.logger.log("entire hook stringify failed", hookName, err);
+        resolve();
+        return;
+      }
+
+      // NOTE: we await this from request handlers (agent.start/agent.end) on
+      // purpose — Entire's transcript ordering depends on hooks completing in
+      // sequence. Do not convert to fire-and-forget.
+      const child = execFile(
+        "entire",
+        ["hooks", "amp", hookName],
+        { timeout: 10_000, windowsHide: true, maxBuffer: Infinity },
+        (err, _stdout, stderr) => {
+          if (err) {
+            amp.logger.log("entire hook failed", hookName, err.message, stderr);
+          }
+          resolve();
+        },
+      );
+      child.stdin?.end(body);
+    });
+  }
+
+  function modifiedFiles(messages: ThreadMessage[]): string[] {
+    const files = new Set<string>();
+    for (const item of amp.helpers.toolCallsInMessages(messages)) {
+      for (const event of [item.call, item.result]) {
+        const modified = amp.helpers.filesModifiedByToolCall(event);
+        if (!modified) continue;
+        for (const file of modified) files.add(amp.helpers.filePathFromURI(file));
+      }
+    }
+    return Array.from(files).sort();
+  }
+
+  amp.on("agent.start", async (event: AgentStartEvent): Promise<void> => {
+    if (!seenThreads.has(event.thread.id)) {
+      seenThreads.add(event.thread.id);
+      await fireHook("session.start", {
+        type: "session.start",
+        cwd: process.cwd(),
+        thread_id: event.thread.id,
+      });
+    }
+
+    await fireHook("agent.start", {
+      type: "agent.start",
+      cwd: process.cwd(),
+      thread_id: event.thread.id,
+      message_id: String(event.id),
+      message: event.message,
+    });
+  });
+
+  amp.on("agent.end", async (event: AgentEndEvent): Promise<void> => {
+    await fireHook("agent.end", {
+      type: "agent.end",
+      cwd: process.cwd(),
+      thread_id: event.thread.id,
+      message_id: String(event.id),
+      message: event.message,
+      status: event.status,
+      messages: event.messages,
+      modified_files: modifiedFiles(event.messages),
+    });
+  });
+}
+`
+}
+
+func transcriptPath(sessionID string) string {
+	return filepath.Join(protocol.DefaultSessionDir(protocol.RepoRoot()), transcriptSubdir, safeSessionID(sessionID)+".jsonl")
+}
+
+func seenPath(sessionID string) string {
+	return filepath.Join(protocol.DefaultSessionDir(protocol.RepoRoot()), seenSessionSubdir, safeSessionID(sessionID))
+}
+
+func sessionSeen(sessionID string) bool {
+	_, err := os.Stat(seenPath(sessionID))
+	return err == nil
+}
+
+func markSessionSeen(sessionID string) {
+	path := seenPath(sessionID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err == nil {
+		_ = os.WriteFile(path, []byte(sessionID), 0o600)
+	}
+}
+
+func safeSessionID(sessionID string) string {
+	if sessionID == "" {
+		return "unknown"
+	}
+	re := regexp.MustCompile(`[^A-Za-z0-9_.-]+`)
+	return re.ReplaceAllString(sessionID, "_")
+}

--- a/agents/entire-agent-amp/internal/amp/hooks_test.go
+++ b/agents/entire-agent-amp/internal/amp/hooks_test.go
@@ -1,0 +1,131 @@
+package amp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/external-agents/agents/entire-agent-amp/internal/protocol"
+)
+
+func TestInfo(t *testing.T) {
+	agent := New()
+	info := agent.Info()
+	if info.ProtocolVersion != protocol.ProtocolVersion {
+		t.Fatalf("ProtocolVersion = %d, want %d", info.ProtocolVersion, protocol.ProtocolVersion)
+	}
+	if info.Name != "amp" {
+		t.Fatalf("Name = %q, want amp", info.Name)
+	}
+	if !info.Capabilities.Hooks || !info.Capabilities.TranscriptAnalyzer || !info.Capabilities.CompactTranscript {
+		t.Fatalf("unexpected capabilities: %+v", info.Capabilities)
+	}
+	if !info.Capabilities.TranscriptPreparer {
+		t.Fatalf("expected transcript_preparer capability")
+	}
+	if !info.Capabilities.TokenCalculator {
+		t.Fatalf("expected token_calculator capability")
+	}
+}
+
+func TestParseHookSessionStart(t *testing.T) {
+	t.Setenv("ENTIRE_REPO_ROOT", t.TempDir())
+	agent := New()
+	event, err := agent.ParseHook("session.start", []byte(`{"type":"session.start","thread_id":"T-123"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event == nil || event.Type != 1 || event.SessionID != "T-123" {
+		t.Fatalf("event = %+v", event)
+	}
+}
+
+func TestParseHookAgentStartWritesTranscript(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", root)
+	agent := New()
+	event, err := agent.ParseHook("agent.start", []byte(`{"type":"agent.start","thread_id":"T-123","message":"hello"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event == nil || event.Type != 2 || event.Prompt != "hello" {
+		t.Fatalf("event = %+v", event)
+	}
+	data, err := os.ReadFile(filepath.Join(root, ".entire", "tmp", "amp", "T-123.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"message":"hello"`) {
+		t.Fatalf("transcript = %s", data)
+	}
+}
+
+func TestParseHookAgentEndWritesTranscript(t *testing.T) {
+	t.Setenv("ENTIRE_REPO_ROOT", t.TempDir())
+	agent := New()
+	payload := `{"type":"agent.end","thread_id":"T-123","status":"done","messages":[{"role":"assistant","id":"a1","content":[{"type":"text","text":"done"}]}],"modified_files":["hello.txt"]}`
+	event, err := agent.ParseHook("agent.end", []byte(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event == nil || event.Type != 3 || event.SessionID != "T-123" || event.SessionRef == "" {
+		t.Fatalf("event = %+v", event)
+	}
+}
+
+func TestGeneratePlugin(t *testing.T) {
+	plugin := generatePlugin()
+	for _, snippet := range []string{
+		`PluginAPI`,
+		`from "@ampcode/plugin"`,
+		`amp.on("agent.start"`,
+		`amp.on("agent.end"`,
+		`["hooks", "amp", hookName]`,
+		`toolCallsInMessages`,
+		`amp.logger.log`,
+		`maxBuffer: Infinity`,
+	} {
+		if !strings.Contains(plugin, snippet) {
+			t.Fatalf("plugin missing %q\n%s", snippet, plugin)
+		}
+	}
+}
+
+func TestInstallAndUninstallHooks(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", root)
+	agent := New()
+	if agent.AreHooksInstalled() {
+		t.Fatal("hooks should not be installed")
+	}
+	count, err := agent.InstallHooks(false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 3 {
+		t.Fatalf("count = %d, want 3", count)
+	}
+	if !agent.AreHooksInstalled() {
+		t.Fatal("hooks should be installed")
+	}
+	count, err = agent.InstallHooks(false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("idempotent count = %d, want 0", count)
+	}
+	if err := agent.UninstallHooks(); err != nil {
+		t.Fatal(err)
+	}
+	if agent.AreHooksInstalled() {
+		t.Fatal("hooks should not be installed")
+	}
+}
+
+func TestSafeSessionID(t *testing.T) {
+	if got := safeSessionID("T/foo:bar"); got != "T_foo_bar" {
+		t.Fatalf("safeSessionID = %q", got)
+	}
+}

--- a/agents/entire-agent-amp/internal/amp/hooks_test.go
+++ b/agents/entire-agent-amp/internal/amp/hooks_test.go
@@ -30,8 +30,10 @@ func TestInfo(t *testing.T) {
 }
 
 func TestParseHookSessionStart(t *testing.T) {
-	t.Setenv("ENTIRE_REPO_ROOT", t.TempDir())
-	agent := New()
+	root := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", root)
+	runner := &fakeCommandRunner{}
+	agent := &Agent{CommandRunner: runner}
 	event, err := agent.ParseHook("session.start", []byte(`{"type":"session.start","thread_id":"T-123"}`))
 	if err != nil {
 		t.Fatal(err)
@@ -39,12 +41,17 @@ func TestParseHookSessionStart(t *testing.T) {
 	if event == nil || event.Type != 1 || event.SessionID != "T-123" {
 		t.Fatalf("event = %+v", event)
 	}
+	if event.Model != "claude" {
+		t.Fatalf("Model = %q, want claude", event.Model)
+	}
+	assertExportedThread(t, runner, root)
 }
 
-func TestParseHookAgentStartWritesTranscript(t *testing.T) {
+func TestParseHookAgentStartFallbackExports(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("ENTIRE_REPO_ROOT", root)
-	agent := New()
+	runner := &fakeCommandRunner{}
+	agent := &Agent{CommandRunner: runner}
 	event, err := agent.ParseHook("agent.start", []byte(`{"type":"agent.start","thread_id":"T-123","message":"hello"}`))
 	if err != nil {
 		t.Fatal(err)
@@ -52,18 +59,41 @@ func TestParseHookAgentStartWritesTranscript(t *testing.T) {
 	if event == nil || event.Type != 2 || event.Prompt != "hello" {
 		t.Fatalf("event = %+v", event)
 	}
-	data, err := os.ReadFile(filepath.Join(root, ".entire", "tmp", "amp", "T-123.jsonl"))
+	if event.Model != "claude" {
+		t.Fatalf("Model = %q, want claude", event.Model)
+	}
+	assertExportedThread(t, runner, root)
+}
+
+func TestParseHookAgentStartSkipsExportWhenPrepared(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", root)
+	path := filepath.Join(root, ".entire", "tmp", "amp", "T-123.jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(testPreparedTranscriptJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runner := &fakeCommandRunner{}
+	agent := &Agent{CommandRunner: runner}
+	event, err := agent.ParseHook("agent.start", []byte(`{"type":"agent.start","thread_id":"T-123","message":"hello"}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(data), `"message":"hello"`) {
-		t.Fatalf("transcript = %s", data)
+	if event == nil || event.Model != "claude" || event.Prompt != "hello" {
+		t.Fatalf("event = %+v", event)
+	}
+	if runner.threadID != "" {
+		t.Fatalf("expected no export, got threadID = %q", runner.threadID)
 	}
 }
 
 func TestParseHookAgentEndWritesTranscript(t *testing.T) {
-	t.Setenv("ENTIRE_REPO_ROOT", t.TempDir())
-	agent := New()
+	root := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", root)
+	runner := &fakeCommandRunner{}
+	agent := &Agent{CommandRunner: runner}
 	payload := `{"type":"agent.end","thread_id":"T-123","status":"done","messages":[{"role":"assistant","id":"a1","content":[{"type":"text","text":"done"}]}],"modified_files":["hello.txt"]}`
 	event, err := agent.ParseHook("agent.end", []byte(payload))
 	if err != nil {
@@ -71,6 +101,52 @@ func TestParseHookAgentEndWritesTranscript(t *testing.T) {
 	}
 	if event == nil || event.Type != 3 || event.SessionID != "T-123" || event.SessionRef == "" {
 		t.Fatalf("event = %+v", event)
+	}
+	if event.Model != "claude" {
+		t.Fatalf("Model = %q, want claude", event.Model)
+	}
+	assertExportedThread(t, runner, root)
+}
+
+func TestParseHookUsesSessionRefExportedThreadModel(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", root)
+	path := filepath.Join(root, ".entire", "tmp", "amp", "T-123.jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(testPreparedTranscriptJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runner := &fakeCommandRunner{}
+	agent := &Agent{CommandRunner: runner}
+	event, err := agent.ParseHook("session.start", []byte(`{"type":"session.start","thread_id":"T-123"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event == nil || event.Model != "claude" {
+		t.Fatalf("event = %+v", event)
+	}
+	if runner.threadID != "T-123" {
+		t.Fatalf("export threadID = %q, want T-123", runner.threadID)
+	}
+}
+
+func assertExportedThread(t *testing.T, runner *fakeCommandRunner, root string) {
+	t.Helper()
+	if runner.threadID != "T-123" {
+		t.Fatalf("threadID = %q, want T-123", runner.threadID)
+	}
+	wantPath := filepath.Join(root, ".entire", "tmp", "amp", "T-123.jsonl")
+	if runner.outputPath != wantPath {
+		t.Fatalf("outputPath = %q, want %q", runner.outputPath, wantPath)
+	}
+	data, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != testPreparedTranscriptJSON {
+		t.Fatalf("exported data = %s", data)
 	}
 }
 

--- a/agents/entire-agent-amp/internal/amp/paths.go
+++ b/agents/entire-agent-amp/internal/amp/paths.go
@@ -1,0 +1,11 @@
+package amp
+
+import "github.com/entireio/external-agents/agents/entire-agent-amp/internal/protocol"
+
+func (a *Agent) GetSessionDir(repoPath string) (string, error) {
+	return protocol.DefaultSessionDir(repoPath), nil
+}
+
+func (a *Agent) ResolveSessionFile(sessionDir, sessionID string) string {
+	return protocol.ResolveSessionFile(sessionDir, sessionID)
+}

--- a/agents/entire-agent-amp/internal/amp/transcript.go
+++ b/agents/entire-agent-amp/internal/amp/transcript.go
@@ -20,7 +20,7 @@ const prepareTranscriptTimeout = 30 * time.Second
 func parseAmpThread(data []byte) (*Thread, error) {
 	trimmed := bytes.TrimSpace(data)
 	if len(trimmed) == 0 {
-		return nil, errors.New("empty amp thread transcript")
+		return &Thread{}, nil
 	}
 	if trimmed[0] != '{' {
 		return nil, errors.New("amp transcript is not prepared: run prepare-transcript first")
@@ -29,37 +29,7 @@ func parseAmpThread(data []byte) (*Thread, error) {
 	if err := json.Unmarshal(trimmed, &thread); err != nil {
 		return nil, fmt.Errorf("parse amp thread transcript: %w", err)
 	}
-	if thread.ID == "" {
-		return nil, errors.New("prepared amp thread transcript missing id")
-	}
 	return &thread, nil
-}
-
-func parseAmpThreadOrPlaceholder(data []byte) (*Thread, bool, error) {
-	trimmed := bytes.TrimSpace(data)
-	if len(trimmed) == 0 {
-		return &Thread{}, false, nil
-	}
-	if trimmed[0] != '{' {
-		return nil, false, errors.New("amp transcript is not prepared: run prepare-transcript first")
-	}
-	var thread Thread
-	if err := json.Unmarshal(trimmed, &thread); err != nil {
-		return nil, false, fmt.Errorf("parse amp thread transcript: %w", err)
-	}
-	return &thread, thread.ID != "", nil
-}
-
-func readAmpThread(path string) (*Thread, []byte, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, nil, err
-	}
-	thread, err := parseAmpThread(data)
-	if err != nil {
-		return nil, data, err
-	}
-	return thread, data, nil
 }
 
 func threadIDFromTranscriptData(data []byte) (string, error) {
@@ -68,7 +38,7 @@ func threadIDFromTranscriptData(data []byte) (string, error) {
 		return "", errors.New("empty amp transcript")
 	}
 
-	if thread, err := parseAmpThread(trimmed); err == nil {
+	if thread, err := parseAmpThread(trimmed); err == nil && thread.ID != "" {
 		return thread.ID, nil
 	}
 
@@ -114,11 +84,11 @@ func (a *Agent) ReadSession(input *protocol.HookInputJSON) (protocol.AgentSessio
 	if err != nil {
 		return protocol.AgentSessionJSON{}, err
 	}
-	thread, prepared, err := parseAmpThreadOrPlaceholder(data)
+	thread, err := parseAmpThread(data)
 	if err != nil {
 		return protocol.AgentSessionJSON{}, err
 	}
-	if !prepared {
+	if thread.ID == "" {
 		if sessionID == "" {
 			sessionID = strings.TrimSuffix(filepath.Base(sessionRef), filepath.Ext(sessionRef))
 		}
@@ -231,7 +201,7 @@ func (a *Agent) GetTranscriptPosition(path string) (int, error) {
 		}
 		return 0, err
 	}
-	thread, _, err := parseAmpThreadOrPlaceholder(data)
+	thread, err := parseAmpThread(data)
 	if err != nil {
 		return 0, err
 	}
@@ -243,7 +213,7 @@ func (a *Agent) ExtractModifiedFiles(path string, offset int) ([]string, int, er
 	if err != nil {
 		return nil, 0, err
 	}
-	thread, _, err := parseAmpThreadOrPlaceholder(data)
+	thread, err := parseAmpThread(data)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -255,7 +225,7 @@ func (a *Agent) ExtractPrompts(sessionRef string, offset int) ([]string, error) 
 	if err != nil {
 		return nil, err
 	}
-	thread, _, err := parseAmpThreadOrPlaceholder(data)
+	thread, err := parseAmpThread(data)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +246,7 @@ func (a *Agent) ExtractSummary(sessionRef string) (string, bool, error) {
 	if err != nil {
 		return "", false, err
 	}
-	thread, _, err := parseAmpThreadOrPlaceholder(data)
+	thread, err := parseAmpThread(data)
 	if err != nil {
 		return "", false, err
 	}
@@ -293,7 +263,7 @@ func (a *Agent) ExtractSummary(sessionRef string) (string, bool, error) {
 }
 
 func (a *Agent) CalculateTokens(data []byte, offset int) (protocol.TokenUsageResponse, error) {
-	thread, _, err := parseAmpThreadOrPlaceholder(data)
+	thread, err := parseAmpThread(data)
 	if err != nil {
 		return protocol.TokenUsageResponse{}, err
 	}

--- a/agents/entire-agent-amp/internal/amp/transcript.go
+++ b/agents/entire-agent-amp/internal/amp/transcript.go
@@ -17,7 +17,7 @@ import (
 
 const prepareTranscriptTimeout = 30 * time.Second
 
-func parseAmpThread(data []byte) (*AmpThread, error) {
+func parseAmpThread(data []byte) (*Thread, error) {
 	trimmed := bytes.TrimSpace(data)
 	if len(trimmed) == 0 {
 		return nil, errors.New("empty amp thread transcript")
@@ -25,7 +25,7 @@ func parseAmpThread(data []byte) (*AmpThread, error) {
 	if trimmed[0] != '{' {
 		return nil, errors.New("amp transcript is not prepared: run prepare-transcript first")
 	}
-	var thread AmpThread
+	var thread Thread
 	if err := json.Unmarshal(trimmed, &thread); err != nil {
 		return nil, fmt.Errorf("parse amp thread transcript: %w", err)
 	}
@@ -35,7 +35,7 @@ func parseAmpThread(data []byte) (*AmpThread, error) {
 	return &thread, nil
 }
 
-func readAmpThread(path string) (*AmpThread, []byte, error) {
+func readAmpThread(path string) (*Thread, []byte, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, nil, err
@@ -249,7 +249,7 @@ func (a *Agent) CalculateTokens(data []byte, offset int) (protocol.TokenUsageRes
 	return usage, nil
 }
 
-func threadMessagesFromOffset(thread *AmpThread, offset int) []ThreadMessage {
+func threadMessagesFromOffset(thread *Thread, offset int) []ThreadMessage {
 	if thread == nil || len(thread.Messages) == 0 {
 		return nil
 	}
@@ -262,7 +262,7 @@ func threadMessagesFromOffset(thread *AmpThread, offset int) []ThreadMessage {
 	return thread.Messages[offset:]
 }
 
-func latestThreadModel(thread *AmpThread) string {
+func latestThreadModel(thread *Thread) string {
 	if thread == nil {
 		return ""
 	}
@@ -275,7 +275,7 @@ func latestThreadModel(thread *AmpThread) string {
 	return ""
 }
 
-func modifiedFilesFromThread(thread *AmpThread) []string {
+func modifiedFilesFromThread(thread *Thread) []string {
 	if thread == nil {
 		return nil
 	}

--- a/agents/entire-agent-amp/internal/amp/transcript.go
+++ b/agents/entire-agent-amp/internal/amp/transcript.go
@@ -35,6 +35,21 @@ func parseAmpThread(data []byte) (*Thread, error) {
 	return &thread, nil
 }
 
+func parseAmpThreadOrPlaceholder(data []byte) (*Thread, bool, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return &Thread{}, false, nil
+	}
+	if trimmed[0] != '{' {
+		return nil, false, errors.New("amp transcript is not prepared: run prepare-transcript first")
+	}
+	var thread Thread
+	if err := json.Unmarshal(trimmed, &thread); err != nil {
+		return nil, false, fmt.Errorf("parse amp thread transcript: %w", err)
+	}
+	return &thread, thread.ID != "", nil
+}
+
 func readAmpThread(path string) (*Thread, []byte, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -71,21 +86,53 @@ func threadIDFromTranscriptData(data []byte) (string, error) {
 		}
 	}
 
+	if trimmed[0] == '{' {
+		var payload map[string]json.RawMessage
+		if err := json.Unmarshal(trimmed, &payload); err == nil && len(payload) == 0 {
+			return "", nil
+		}
+	}
+
 	return "", errors.New("cannot prepare transcript: missing amp thread_id")
 }
 
 func (a *Agent) ReadSession(input *protocol.HookInputJSON) (protocol.AgentSessionJSON, error) {
-	sessionRef := input.SessionRef
-	if sessionRef == "" && input.SessionID != "" {
-		sessionRef = transcriptPath(input.SessionID)
+	var sessionID string
+	var sessionRef string
+	if input != nil {
+		sessionID = input.SessionID
+		sessionRef = input.SessionRef
+		if sessionRef == "" && sessionID != "" {
+			sessionRef = transcriptPath(sessionID)
+		}
 	}
 	if sessionRef == "" {
 		return protocol.AgentSessionJSON{}, errors.New("session_ref or session_id is required")
 	}
 
-	thread, data, err := readAmpThread(sessionRef)
+	data, err := os.ReadFile(sessionRef)
 	if err != nil {
 		return protocol.AgentSessionJSON{}, err
+	}
+	thread, prepared, err := parseAmpThreadOrPlaceholder(data)
+	if err != nil {
+		return protocol.AgentSessionJSON{}, err
+	}
+	if !prepared {
+		if sessionID == "" {
+			sessionID = strings.TrimSuffix(filepath.Base(sessionRef), filepath.Ext(sessionRef))
+		}
+		return protocol.AgentSessionJSON{
+			SessionID:     sessionID,
+			AgentName:     "amp",
+			RepoPath:      protocol.RepoRoot(),
+			SessionRef:    sessionRef,
+			StartTime:     time.Now().UTC().Format(time.RFC3339),
+			NativeData:    data,
+			ModifiedFiles: []string{},
+			NewFiles:      []string{},
+			DeletedFiles:  []string{},
+		}, nil
 	}
 
 	startTime := thread.Created.Time()
@@ -120,6 +167,9 @@ func (a *Agent) PrepareTranscript(sessionRef string) error {
 	threadID, err := threadIDFromTranscriptData(data)
 	if err != nil {
 		return err
+	}
+	if threadID == "" {
+		return nil
 	}
 	runner := a.CommandRunner
 	if runner == nil {
@@ -181,7 +231,7 @@ func (a *Agent) GetTranscriptPosition(path string) (int, error) {
 		}
 		return 0, err
 	}
-	thread, err := parseAmpThread(data)
+	thread, _, err := parseAmpThreadOrPlaceholder(data)
 	if err != nil {
 		return 0, err
 	}
@@ -189,7 +239,11 @@ func (a *Agent) GetTranscriptPosition(path string) (int, error) {
 }
 
 func (a *Agent) ExtractModifiedFiles(path string, offset int) ([]string, int, error) {
-	thread, _, err := readAmpThread(path)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	thread, _, err := parseAmpThreadOrPlaceholder(data)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -197,7 +251,11 @@ func (a *Agent) ExtractModifiedFiles(path string, offset int) ([]string, int, er
 }
 
 func (a *Agent) ExtractPrompts(sessionRef string, offset int) ([]string, error) {
-	thread, _, err := readAmpThread(sessionRef)
+	data, err := os.ReadFile(sessionRef)
+	if err != nil {
+		return nil, err
+	}
+	thread, _, err := parseAmpThreadOrPlaceholder(data)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +272,11 @@ func (a *Agent) ExtractPrompts(sessionRef string, offset int) ([]string, error) 
 }
 
 func (a *Agent) ExtractSummary(sessionRef string) (string, bool, error) {
-	thread, _, err := readAmpThread(sessionRef)
+	data, err := os.ReadFile(sessionRef)
+	if err != nil {
+		return "", false, err
+	}
+	thread, _, err := parseAmpThreadOrPlaceholder(data)
 	if err != nil {
 		return "", false, err
 	}
@@ -231,7 +293,7 @@ func (a *Agent) ExtractSummary(sessionRef string) (string, bool, error) {
 }
 
 func (a *Agent) CalculateTokens(data []byte, offset int) (protocol.TokenUsageResponse, error) {
-	thread, err := parseAmpThread(data)
+	thread, _, err := parseAmpThreadOrPlaceholder(data)
 	if err != nil {
 		return protocol.TokenUsageResponse{}, err
 	}

--- a/agents/entire-agent-amp/internal/amp/transcript.go
+++ b/agents/entire-agent-amp/internal/amp/transcript.go
@@ -47,6 +47,33 @@ func readAmpThread(path string) (*AmpThread, []byte, error) {
 	return thread, data, nil
 }
 
+func threadIDFromTranscriptData(data []byte) (string, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return "", errors.New("empty amp transcript")
+	}
+
+	if thread, err := parseAmpThread(trimmed); err == nil {
+		return thread.ID, nil
+	}
+
+	for line := range bytes.SplitSeq(trimmed, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var payload ampHookPayload
+		if err := json.Unmarshal(line, &payload); err != nil {
+			continue
+		}
+		if strings.TrimSpace(payload.ThreadID) != "" {
+			return strings.TrimSpace(payload.ThreadID), nil
+		}
+	}
+
+	return "", errors.New("cannot prepare transcript: missing amp thread_id")
+}
+
 func (a *Agent) ReadSession(input *protocol.HookInputJSON) (protocol.AgentSessionJSON, error) {
 	sessionRef := input.SessionRef
 	if sessionRef == "" && input.SessionID != "" {
@@ -90,13 +117,9 @@ func (a *Agent) PrepareTranscript(sessionRef string) error {
 	if err != nil {
 		return fmt.Errorf("read transcript for prepare: %w", err)
 	}
-	thread, err := parseAmpThread(data)
+	threadID, err := threadIDFromTranscriptData(data)
 	if err != nil {
 		return err
-	}
-	threadID := thread.ID
-	if threadID == "" {
-		return errors.New("cannot prepare transcript: missing amp thread_id")
 	}
 	runner := a.CommandRunner
 	if runner == nil {
@@ -158,27 +181,28 @@ func (a *Agent) GetTranscriptPosition(path string) (int, error) {
 		}
 		return 0, err
 	}
-	if _, err := parseAmpThread(data); err != nil {
+	thread, err := parseAmpThread(data)
+	if err != nil {
 		return 0, err
 	}
-	return len(data), nil
+	return len(thread.Messages), nil
 }
 
-func (a *Agent) ExtractModifiedFiles(path string, _ int) ([]string, int, error) {
-	thread, data, err := readAmpThread(path)
+func (a *Agent) ExtractModifiedFiles(path string, offset int) ([]string, int, error) {
+	thread, _, err := readAmpThread(path)
 	if err != nil {
 		return nil, 0, err
 	}
-	return modifiedFilesFromThread(thread), len(data), nil
+	return modifiedFilesFromMessages(threadMessagesFromOffset(thread, offset)), len(thread.Messages), nil
 }
 
-func (a *Agent) ExtractPrompts(sessionRef string, _ int) ([]string, error) {
+func (a *Agent) ExtractPrompts(sessionRef string, offset int) ([]string, error) {
 	thread, _, err := readAmpThread(sessionRef)
 	if err != nil {
 		return nil, err
 	}
 	var prompts []string
-	for _, msg := range thread.Messages {
+	for _, msg := range threadMessagesFromOffset(thread, offset) {
 		if msg.Role != ThreadMessageRoleUser {
 			continue
 		}
@@ -206,13 +230,13 @@ func (a *Agent) ExtractSummary(sessionRef string) (string, bool, error) {
 	return "", false, nil
 }
 
-func (a *Agent) CalculateTokens(data []byte, _ int) (protocol.TokenUsageResponse, error) {
+func (a *Agent) CalculateTokens(data []byte, offset int) (protocol.TokenUsageResponse, error) {
 	thread, err := parseAmpThread(data)
 	if err != nil {
 		return protocol.TokenUsageResponse{}, err
 	}
 	var usage protocol.TokenUsageResponse
-	for _, msg := range thread.Messages {
+	for _, msg := range threadMessagesFromOffset(thread, offset) {
 		if msg.Usage == nil {
 			continue
 		}
@@ -223,6 +247,19 @@ func (a *Agent) CalculateTokens(data []byte, _ int) (protocol.TokenUsageResponse
 		usage.APICallCount++
 	}
 	return usage, nil
+}
+
+func threadMessagesFromOffset(thread *AmpThread, offset int) []ThreadMessage {
+	if thread == nil || len(thread.Messages) == 0 {
+		return nil
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(thread.Messages) {
+		return nil
+	}
+	return thread.Messages[offset:]
 }
 
 func latestThreadModel(thread *AmpThread) string {
@@ -239,8 +276,15 @@ func latestThreadModel(thread *AmpThread) string {
 }
 
 func modifiedFilesFromThread(thread *AmpThread) []string {
+	if thread == nil {
+		return nil
+	}
+	return modifiedFilesFromMessages(thread.Messages)
+}
+
+func modifiedFilesFromMessages(messages []ThreadMessage) []string {
 	seen := map[string]bool{}
-	for _, msg := range thread.Messages {
+	for _, msg := range messages {
 		for _, file := range modifiedFilesFromMessage(msg) {
 			if file != "" {
 				seen[file] = true

--- a/agents/entire-agent-amp/internal/amp/transcript.go
+++ b/agents/entire-agent-amp/internal/amp/transcript.go
@@ -1,0 +1,387 @@
+package amp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/entireio/external-agents/agents/entire-agent-amp/internal/protocol"
+)
+
+const maxScannerLine = 4 << 20
+
+const prepareTranscriptTimeout = 30 * time.Second
+
+type ampTranscriptEntry struct {
+	Type     string `json:"type"`
+	ThreadID string `json:"thread_id"`
+	Message  string `json:"message,omitempty"`
+}
+
+func newJSONLScanner(data []byte) *bufio.Scanner {
+	s := bufio.NewScanner(bytes.NewReader(data))
+	s.Buffer(make([]byte, 0, 64*1024), maxScannerLine)
+	return s
+}
+
+func appendTranscriptEntry(path string, entry ampTranscriptEntry) error {
+	if path == "" {
+		return errors.New("transcript path is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	line, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	_, err = f.Write(append(line, '\n'))
+	return err
+}
+
+func readBootstrapEntries(data []byte) []ampTranscriptEntry {
+	var entries []ampTranscriptEntry
+	scanner := newJSONLScanner(data)
+	for scanner.Scan() {
+		var entry ampTranscriptEntry
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err == nil && entry.Type != "" {
+			entries = append(entries, entry)
+		}
+	}
+	return entries
+}
+
+func bootstrapThreadID(data []byte) string {
+	for _, entry := range readBootstrapEntries(data) {
+		if entry.ThreadID != "" {
+			return entry.ThreadID
+		}
+	}
+	return ""
+}
+
+func parseAmpThread(data []byte) (*AmpThread, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil, errors.New("empty amp thread transcript")
+	}
+	if trimmed[0] != '{' {
+		return nil, errors.New("amp transcript is not prepared: run prepare-transcript first")
+	}
+	var thread AmpThread
+	if err := json.Unmarshal(trimmed, &thread); err != nil {
+		return nil, fmt.Errorf("parse amp thread transcript: %w", err)
+	}
+	if thread.ID == "" {
+		return nil, errors.New("prepared amp thread transcript missing id")
+	}
+	return &thread, nil
+}
+
+func readAmpThread(path string) (*AmpThread, []byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	thread, err := parseAmpThread(data)
+	if err != nil {
+		return nil, data, err
+	}
+	return thread, data, nil
+}
+
+func (a *Agent) ReadSession(input *protocol.HookInputJSON) (protocol.AgentSessionJSON, error) {
+	sessionRef := input.SessionRef
+	if sessionRef == "" && input.SessionID != "" {
+		sessionRef = transcriptPath(input.SessionID)
+	}
+	if sessionRef == "" {
+		return protocol.AgentSessionJSON{}, errors.New("session_ref or session_id is required")
+	}
+
+	thread, data, err := readAmpThread(sessionRef)
+	if err != nil {
+		return protocol.AgentSessionJSON{}, err
+	}
+
+	startTime := thread.Created.Time()
+	if startTime.IsZero() && !thread.UpdatedAt.IsZero() {
+		startTime = thread.UpdatedAt.UTC()
+	}
+	if startTime.IsZero() {
+		startTime = time.Now().UTC()
+	}
+
+	return protocol.AgentSessionJSON{
+		SessionID:     thread.ID,
+		AgentName:     "amp",
+		RepoPath:      protocol.RepoRoot(),
+		SessionRef:    sessionRef,
+		StartTime:     startTime.Format(time.RFC3339),
+		NativeData:    data,
+		ModifiedFiles: modifiedFilesFromThread(thread),
+		NewFiles:      []string{},
+		DeletedFiles:  []string{},
+	}, nil
+}
+
+func (a *Agent) PrepareTranscript(sessionRef string) error {
+	if strings.TrimSpace(sessionRef) == "" {
+		return errors.New("session_ref is required")
+	}
+	data, err := os.ReadFile(sessionRef)
+	if err != nil {
+		return fmt.Errorf("read transcript for prepare: %w", err)
+	}
+	threadID := bootstrapThreadID(data)
+	if threadID == "" {
+		if thread, err := parseAmpThread(data); err == nil {
+			threadID = thread.ID
+		}
+	}
+	if threadID == "" {
+		return errors.New("cannot prepare transcript: missing amp thread_id")
+	}
+	runner := a.CommandRunner
+	if runner == nil {
+		runner = &DefaultCommandRunner{}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), prepareTranscriptTimeout)
+	defer cancel()
+	_, err = runner.ExportThread(ctx, threadID, sessionRef)
+	return err
+}
+
+func (a *Agent) WriteSession(session protocol.AgentSessionJSON) error {
+	if session.SessionRef == "" {
+		return errors.New("session_ref is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(session.SessionRef), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(session.SessionRef, session.NativeData, 0o600)
+}
+
+func (a *Agent) ReadTranscript(sessionRef string) ([]byte, error) {
+	data, err := os.ReadFile(sessionRef)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := parseAmpThread(data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (a *Agent) ChunkTranscript(content []byte, maxSize int) ([][]byte, error) {
+	if maxSize <= 0 {
+		return nil, fmt.Errorf("max-size must be positive, got %d", maxSize)
+	}
+	var chunks [][]byte
+	for len(content) > 0 {
+		end := min(maxSize, len(content))
+		chunks = append(chunks, content[:end])
+		content = content[end:]
+	}
+	return chunks, nil
+}
+
+func (a *Agent) ReassembleTranscript(chunks [][]byte) ([]byte, error) {
+	var data []byte
+	for _, chunk := range chunks {
+		data = append(data, chunk...)
+	}
+	return data, nil
+}
+
+func (a *Agent) GetTranscriptPosition(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	if _, err := parseAmpThread(data); err != nil {
+		return 0, err
+	}
+	return len(data), nil
+}
+
+func (a *Agent) ExtractModifiedFiles(path string, _ int) ([]string, int, error) {
+	thread, data, err := readAmpThread(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	return modifiedFilesFromThread(thread), len(data), nil
+}
+
+func (a *Agent) ExtractPrompts(sessionRef string, _ int) ([]string, error) {
+	thread, _, err := readAmpThread(sessionRef)
+	if err != nil {
+		return nil, err
+	}
+	var prompts []string
+	for _, msg := range thread.Messages {
+		if msg.Role != ThreadMessageRoleUser {
+			continue
+		}
+		if text := threadMessageText(msg); text != "" {
+			prompts = append(prompts, text)
+		}
+	}
+	return prompts, nil
+}
+
+func (a *Agent) ExtractSummary(sessionRef string) (string, bool, error) {
+	thread, _, err := readAmpThread(sessionRef)
+	if err != nil {
+		return "", false, err
+	}
+	for i := len(thread.Messages) - 1; i >= 0; i-- {
+		msg := thread.Messages[i]
+		if msg.Role != ThreadMessageRoleAssistant {
+			continue
+		}
+		if text := threadMessageText(msg); text != "" {
+			return text, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func (a *Agent) CalculateTokens(data []byte, _ int) (protocol.TokenUsageResponse, error) {
+	thread, err := parseAmpThread(data)
+	if err != nil {
+		return protocol.TokenUsageResponse{}, err
+	}
+	var usage protocol.TokenUsageResponse
+	for _, msg := range thread.Messages {
+		if msg.Usage == nil {
+			continue
+		}
+		usage.InputTokens += msg.Usage.InputTokens
+		usage.OutputTokens += msg.Usage.OutputTokens
+		usage.CacheReadTokens += msg.Usage.CacheReadInputTokens
+		usage.CacheCreationTokens += msg.Usage.CacheCreationInputTokens
+		usage.APICallCount++
+	}
+	return usage, nil
+}
+
+func modifiedFilesFromThread(thread *AmpThread) []string {
+	seen := map[string]bool{}
+	for _, msg := range thread.Messages {
+		for _, file := range modifiedFilesFromMessage(msg) {
+			if file != "" {
+				seen[file] = true
+			}
+		}
+	}
+	files := make([]string, 0, len(seen))
+	for file := range seen {
+		files = append(files, file)
+	}
+	sort.Strings(files)
+	return files
+}
+
+func modifiedFilesFromMessage(msg ThreadMessage) []string {
+	var files []string
+	for _, block := range msg.Content {
+		files = append(files, filesFromContentBlock(block)...)
+	}
+	for _, input := range msg.OriginalToolUseInput {
+		files = append(files, filesFromToolInput(input)...)
+	}
+	return files
+}
+
+func filesFromContentBlock(block ThreadContentBlock) []string {
+	var files []string
+	files = append(files, filesFromToolInput(block.Input)...)
+	if block.Run != nil {
+		files = append(files, block.Run.TrackFiles...)
+		var result ThreadCommonToolResult
+		if len(block.Run.Result) > 0 && json.Unmarshal(block.Run.Result, &result) == nil {
+			if strings.TrimSpace(result.AbsolutePath) != "" {
+				files = append(files, strings.TrimSpace(result.AbsolutePath))
+			}
+		}
+	}
+	return cleanFiles(files)
+}
+
+func filesFromToolInput(input ThreadToolInput) []string {
+	var files []string
+	for _, key := range []string{"path", "filePath", "filepath", "file", "absolutePath"} {
+		files = append(files, stringValues(input[key])...)
+	}
+	for _, key := range []string{"paths", "files"} {
+		files = append(files, stringValues(input[key])...)
+	}
+	return cleanFiles(files)
+}
+
+func stringValues(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return []string{s}
+	}
+	var arr []string
+	if err := json.Unmarshal(raw, &arr); err == nil {
+		return arr
+	}
+	return nil
+}
+
+func cleanFiles(files []string) []string {
+	out := files[:0]
+	for _, file := range files {
+		file = strings.TrimSpace(file)
+		if file != "" {
+			out = append(out, file)
+		}
+	}
+	return out
+}
+
+func threadMessageText(msg ThreadMessage) string {
+	var parts []string
+	for _, block := range msg.Content {
+		if block.Type == ThreadContentText && block.Text != "" {
+			parts = append(parts, block.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func threadMessageIDString(id ThreadMessageID) string {
+	return string(id)
+}
+
+func threadMessageTimestamp(msg ThreadMessage) string {
+	if msg.Meta == nil {
+		return ""
+	}
+	if ts := msg.Meta.SentAt.Time(); !ts.IsZero() {
+		return ts.Format(time.RFC3339)
+	}
+	return ""
+}

--- a/agents/entire-agent-amp/internal/amp/transcript.go
+++ b/agents/entire-agent-amp/internal/amp/transcript.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -217,7 +218,7 @@ func (a *Agent) ExtractModifiedFiles(path string, offset int) ([]string, int, er
 	if err != nil {
 		return nil, 0, err
 	}
-	return modifiedFilesFromMessages(threadMessagesFromOffset(thread, offset)), len(thread.Messages), nil
+	return modifiedFilesFromThreadFromOffset(thread, offset), len(thread.Messages), nil
 }
 
 func (a *Agent) ExtractPrompts(sessionRef string, offset int) ([]string, error) {
@@ -311,13 +312,21 @@ func modifiedFilesFromThread(thread *Thread) []string {
 	if thread == nil {
 		return nil
 	}
-	return modifiedFilesFromMessages(thread.Messages)
+	return modifiedFilesFromMessagesWithContext(thread.Messages, thread.Messages)
 }
 
-func modifiedFilesFromMessages(messages []ThreadMessage) []string {
+func modifiedFilesFromThreadFromOffset(thread *Thread, offset int) []string {
+	if thread == nil {
+		return nil
+	}
+	return modifiedFilesFromMessagesWithContext(threadMessagesFromOffset(thread, offset), thread.Messages)
+}
+
+func modifiedFilesFromMessagesWithContext(messages []ThreadMessage, contextMessages []ThreadMessage) []string {
 	seen := map[string]bool{}
+	toolNamesByID := toolNamesByIDFromMessages(contextMessages)
 	for _, msg := range messages {
-		for _, file := range modifiedFilesFromMessage(msg) {
+		for _, file := range modifiedFilesFromMessage(msg, toolNamesByID) {
 			if file != "" {
 				seen[file] = true
 			}
@@ -331,30 +340,82 @@ func modifiedFilesFromMessages(messages []ThreadMessage) []string {
 	return files
 }
 
-func modifiedFilesFromMessage(msg ThreadMessage) []string {
+func toolNamesByIDFromMessages(messages []ThreadMessage) map[string]string {
+	toolNamesByID := map[string]string{}
+	for _, msg := range messages {
+		for _, block := range msg.Content {
+			if strings.TrimSpace(block.ID) != "" && strings.TrimSpace(block.Name) != "" {
+				toolNamesByID[strings.TrimSpace(block.ID)] = strings.TrimSpace(block.Name)
+			}
+		}
+	}
+	return toolNamesByID
+}
+
+func modifiedFilesFromMessage(msg ThreadMessage, toolNamesByID map[string]string) []string {
 	var files []string
 	for _, block := range msg.Content {
-		files = append(files, filesFromContentBlock(block)...)
+		files = append(files, filesFromContentBlockForTool(block, toolNameForContentBlock(block, toolNamesByID))...)
 	}
-	for _, input := range msg.OriginalToolUseInput {
-		files = append(files, filesFromToolInput(input)...)
+	for idOrName, input := range msg.OriginalToolUseInput {
+		if isMutatingToolName(idOrName) || isMutatingToolName(toolNamesByID[strings.TrimSpace(idOrName)]) {
+			files = append(files, filesFromToolInput(input)...)
+		}
 	}
 	return files
 }
 
-func filesFromContentBlock(block ThreadContentBlock) []string {
+func filesFromContentBlockForTool(block ThreadContentBlock, toolName string) []string {
 	var files []string
-	files = append(files, filesFromToolInput(block.Input)...)
+	mutatingTool := isMutatingToolName(toolName)
+	if mutatingTool {
+		files = append(files, filesFromToolInput(block.Input)...)
+	}
 	if block.Run != nil {
-		files = append(files, block.Run.TrackFiles...)
+		if mutatingTool {
+			files = append(files, block.Run.TrackFiles...)
+		}
 		var result ThreadCommonToolResult
 		if len(block.Run.Result) > 0 && json.Unmarshal(block.Run.Result, &result) == nil {
-			if strings.TrimSpace(result.AbsolutePath) != "" {
+			if mutatingTool && strings.TrimSpace(result.AbsolutePath) != "" {
 				files = append(files, strings.TrimSpace(result.AbsolutePath))
 			}
 		}
 	}
 	return cleanFiles(files)
+}
+
+func toolNameForContentBlock(block ThreadContentBlock, toolNamesByID map[string]string) string {
+	if strings.TrimSpace(block.Name) != "" {
+		return strings.TrimSpace(block.Name)
+	}
+	if toolNamesByID == nil || strings.TrimSpace(block.ToolUseID) == "" {
+		return ""
+	}
+	return toolNamesByID[strings.TrimSpace(block.ToolUseID)]
+}
+
+func isMutatingToolName(name string) bool {
+	switch normalizeToolName(name) {
+	case "create", "create_file",
+		"delete", "delete_file",
+		"edit", "edit_file",
+		"move", "move_file",
+		"multi_edit",
+		"patch",
+		"rename", "rename_file",
+		"replace",
+		"str_replace_based_edit_tool",
+		"str_replace_editor",
+		"write", "write_file":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeToolName(name string) string {
+	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(name)), "-", "_")
 }
 
 func filesFromToolInput(input ThreadToolInput) []string {
@@ -386,12 +447,26 @@ func stringValues(raw json.RawMessage) []string {
 func cleanFiles(files []string) []string {
 	out := files[:0]
 	for _, file := range files {
-		file = strings.TrimSpace(file)
+		file = cleanFile(file)
 		if file != "" {
 			out = append(out, file)
 		}
 	}
 	return out
+}
+
+func cleanFile(file string) string {
+	file = strings.TrimSpace(file)
+	if file == "" {
+		return ""
+	}
+	if u, err := url.Parse(file); err == nil && u.Scheme == "file" {
+		file = u.Path
+		if unescaped, err := url.PathUnescape(file); err == nil {
+			file = unescaped
+		}
+	}
+	return file
 }
 
 func threadMessageText(msg ThreadMessage) string {

--- a/agents/entire-agent-amp/internal/amp/transcript.go
+++ b/agents/entire-agent-amp/internal/amp/transcript.go
@@ -1,7 +1,6 @@
 package amp
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -16,62 +15,7 @@ import (
 	"github.com/entireio/external-agents/agents/entire-agent-amp/internal/protocol"
 )
 
-const maxScannerLine = 4 << 20
-
 const prepareTranscriptTimeout = 30 * time.Second
-
-type ampTranscriptEntry struct {
-	Type     string `json:"type"`
-	ThreadID string `json:"thread_id"`
-	Message  string `json:"message,omitempty"`
-}
-
-func newJSONLScanner(data []byte) *bufio.Scanner {
-	s := bufio.NewScanner(bytes.NewReader(data))
-	s.Buffer(make([]byte, 0, 64*1024), maxScannerLine)
-	return s
-}
-
-func appendTranscriptEntry(path string, entry ampTranscriptEntry) error {
-	if path == "" {
-		return errors.New("transcript path is required")
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-		return err
-	}
-	line, err := json.Marshal(entry)
-	if err != nil {
-		return err
-	}
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = f.Close() }()
-	_, err = f.Write(append(line, '\n'))
-	return err
-}
-
-func readBootstrapEntries(data []byte) []ampTranscriptEntry {
-	var entries []ampTranscriptEntry
-	scanner := newJSONLScanner(data)
-	for scanner.Scan() {
-		var entry ampTranscriptEntry
-		if err := json.Unmarshal(scanner.Bytes(), &entry); err == nil && entry.Type != "" {
-			entries = append(entries, entry)
-		}
-	}
-	return entries
-}
-
-func bootstrapThreadID(data []byte) string {
-	for _, entry := range readBootstrapEntries(data) {
-		if entry.ThreadID != "" {
-			return entry.ThreadID
-		}
-	}
-	return ""
-}
 
 func parseAmpThread(data []byte) (*AmpThread, error) {
 	trimmed := bytes.TrimSpace(data)
@@ -146,12 +90,11 @@ func (a *Agent) PrepareTranscript(sessionRef string) error {
 	if err != nil {
 		return fmt.Errorf("read transcript for prepare: %w", err)
 	}
-	threadID := bootstrapThreadID(data)
-	if threadID == "" {
-		if thread, err := parseAmpThread(data); err == nil {
-			threadID = thread.ID
-		}
+	thread, err := parseAmpThread(data)
+	if err != nil {
+		return err
 	}
+	threadID := thread.ID
 	if threadID == "" {
 		return errors.New("cannot prepare transcript: missing amp thread_id")
 	}
@@ -280,6 +223,19 @@ func (a *Agent) CalculateTokens(data []byte, _ int) (protocol.TokenUsageResponse
 		usage.APICallCount++
 	}
 	return usage, nil
+}
+
+func latestThreadModel(thread *AmpThread) string {
+	if thread == nil {
+		return ""
+	}
+	for i := len(thread.Messages) - 1; i >= 0; i-- {
+		usage := thread.Messages[i].Usage
+		if usage != nil && strings.TrimSpace(usage.Model) != "" {
+			return strings.TrimSpace(usage.Model)
+		}
+	}
+	return ""
 }
 
 func modifiedFilesFromThread(thread *AmpThread) []string {

--- a/agents/entire-agent-amp/internal/amp/transcript_test.go
+++ b/agents/entire-agent-amp/internal/amp/transcript_test.go
@@ -85,6 +85,46 @@ func TestExtractModifiedFiles_PreparedJSON(t *testing.T) {
 	}
 }
 
+func TestTranscriptAnalyzer_PlaceholderTranscript(t *testing.T) {
+	agent := New()
+	path := filepath.Join(t.TempDir(), "amp.json")
+	if err := os.WriteFile(path, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	pos, err := agent.GetTranscriptPosition(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pos != 0 {
+		t.Fatalf("position = %d, want 0", pos)
+	}
+
+	files, currentPosition, err := agent.ExtractModifiedFiles(path, 999)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 || currentPosition != 0 {
+		t.Fatalf("files = %v currentPosition = %d, want no files at position 0", files, currentPosition)
+	}
+
+	prompts, err := agent.ExtractPrompts(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prompts) != 0 {
+		t.Fatalf("prompts = %v, want none", prompts)
+	}
+
+	summary, hasSummary, err := agent.ExtractSummary(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasSummary || summary != "" {
+		t.Fatalf("summary = %q hasSummary = %v, want no summary", summary, hasSummary)
+	}
+}
+
 func TestExtractPrompts(t *testing.T) {
 	agent := New()
 	if _, err := agent.ExtractPrompts(writeTestTranscript(t), 0); err == nil {
@@ -164,6 +204,27 @@ func TestReadSession_PreparedJSON(t *testing.T) {
 	}
 }
 
+func TestReadSession_PlaceholderTranscript(t *testing.T) {
+	t.Setenv("ENTIRE_REPO_ROOT", t.TempDir())
+	path := filepath.Join(t.TempDir(), "test-roundtrip-session.json")
+	if err := os.WriteFile(path, []byte(`{"test":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	session, err := New().ReadSession(&protocol.HookInputJSON{
+		SessionID:  "test-roundtrip-session",
+		SessionRef: path,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.SessionID != "test-roundtrip-session" || session.AgentName != "amp" || string(session.NativeData) != `{"test":true}` {
+		t.Fatalf("session = %+v", session)
+	}
+	if session.ModifiedFiles == nil || session.NewFiles == nil || session.DeletedFiles == nil {
+		t.Fatalf("session file slices must be initialized: %+v", session)
+	}
+}
+
 func TestCalculateTokens_PreparedJSON(t *testing.T) {
 	agent := New()
 	usage, err := agent.CalculateTokens([]byte(testPreparedTranscriptJSON), 0)
@@ -179,6 +240,16 @@ func TestCalculateTokens_PreparedJSON(t *testing.T) {
 	}
 	if usage.APICallCount != 0 || usage.InputTokens != 0 || usage.OutputTokens != 0 || usage.CacheReadTokens != 0 || usage.CacheCreationTokens != 0 {
 		t.Fatalf("offset usage = %+v, want zero usage", usage)
+	}
+}
+
+func TestCalculateTokens_PlaceholderTranscript(t *testing.T) {
+	usage, err := New().CalculateTokens([]byte(`{}`), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage != (protocol.TokenUsageResponse{}) {
+		t.Fatalf("usage = %+v, want zero", usage)
 	}
 }
 
@@ -213,6 +284,20 @@ func TestPrepareTranscript(t *testing.T) {
 	}
 	if string(data) != testPreparedTranscriptJSON {
 		t.Fatalf("prepared data = %s", data)
+	}
+}
+
+func TestPrepareTranscript_PlaceholderTranscript(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "amp.json")
+	if err := os.WriteFile(path, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runner := &fakeCommandRunner{}
+	if err := (&Agent{CommandRunner: runner}).PrepareTranscript(path); err != nil {
+		t.Fatal(err)
+	}
+	if runner.threadID != "" {
+		t.Fatalf("runner unexpectedly invoked with threadID = %q", runner.threadID)
 	}
 }
 

--- a/agents/entire-agent-amp/internal/amp/transcript_test.go
+++ b/agents/entire-agent-amp/internal/amp/transcript_test.go
@@ -1,0 +1,231 @@
+package amp
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/external-agents/agents/entire-agent-amp/internal/protocol"
+)
+
+const testTranscriptJSONL = `{"type":"agent.start","thread_id":"T-123","message":"Create hello.txt","timestamp":"2026-05-07T12:00:00Z"}
+{"type":"agent.end","thread_id":"T-123","status":"done","modified_files":["hello.txt"],"timestamp":"2026-05-07T12:00:03Z","messages":[{"role":"user","id":1,"content":[{"type":"text","text":"Create hello.txt"}]},{"role":"assistant","id":"a1","content":[{"type":"tool_use","id":"tool1","name":"edit_file","input":{"path":"hello.txt"}},{"type":"text","text":"Created hello.txt"}]},{"role":"user","id":2,"content":[{"type":"tool_result","toolUseID":"tool1","status":"done","output":"ok"}]}]}
+`
+
+const testPreparedTranscriptJSON = `{"v":1,"id":"T-123","created":1778155200000,"updatedAt":"2026-05-07T12:00:05Z","messages":[{"role":"user","messageId":1,"meta":{"sentAt":1778155200000},"content":[{"type":"text","text":"Create hello.txt"}]},{"role":"assistant","messageId":"a1","meta":{"sentAt":1778155201000},"usage":{"model":"claude","timestamp":"2026-05-07T12:00:01Z","inputTokens":100,"outputTokens":25,"cacheReadInputTokens":7,"cacheCreationInputTokens":3},"content":[{"type":"tool_use","id":"tool1","name":"edit_file","input":{"path":"hello.txt"}},{"type":"text","text":"Created hello.txt"}]},{"role":"user","messageId":2,"meta":{"sentAt":1778155202000},"content":[{"type":"tool_result","toolUseID":"tool1","run":{"status":"done","trackFiles":["hello.txt"],"result":{"output":"ok"}}}]}]}`
+
+type fakeCommandRunner struct {
+	threadID   string
+	outputPath string
+	err        error
+}
+
+func (r *fakeCommandRunner) ExportThread(_ context.Context, threadID string, outputPath string) (string, error) {
+	r.threadID = threadID
+	r.outputPath = outputPath
+	if r.err != nil {
+		return "", r.err
+	}
+	if err := os.WriteFile(outputPath, []byte(testPreparedTranscriptJSON), 0o600); err != nil {
+		return "", err
+	}
+	return outputPath, nil
+}
+
+func writeTestTranscript(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "amp.jsonl")
+	if err := os.WriteFile(path, []byte(testTranscriptJSONL), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writePreparedTranscript(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "amp.json")
+	if err := os.WriteFile(path, []byte(testPreparedTranscriptJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestExtractModifiedFiles(t *testing.T) {
+	agent := New()
+	path := writeTestTranscript(t)
+	if _, _, err := agent.ExtractModifiedFiles(path, 0); err == nil {
+		t.Fatal("expected unprepared transcript error")
+	}
+}
+
+func TestExtractModifiedFiles_PreparedJSON(t *testing.T) {
+	agent := New()
+	path := filepath.Join(t.TempDir(), "amp.json")
+	if err := os.WriteFile(path, []byte(testPreparedTranscriptJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	files, _, err := agent.ExtractModifiedFiles(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 || files[0] != "hello.txt" {
+		t.Fatalf("files = %v", files)
+	}
+}
+
+func TestExtractPrompts(t *testing.T) {
+	agent := New()
+	if _, err := agent.ExtractPrompts(writeTestTranscript(t), 0); err == nil {
+		t.Fatal("expected unprepared transcript error")
+	}
+}
+
+func TestExtractPrompts_PreparedJSON(t *testing.T) {
+	agent := New()
+	path := filepath.Join(t.TempDir(), "amp.json")
+	if err := os.WriteFile(path, []byte(testPreparedTranscriptJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	prompts, err := agent.ExtractPrompts(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prompts) != 1 || prompts[0] != "Create hello.txt" {
+		t.Fatalf("prompts = %v", prompts)
+	}
+}
+
+func TestExtractSummary(t *testing.T) {
+	agent := New()
+	if _, _, err := agent.ExtractSummary(writeTestTranscript(t)); err == nil {
+		t.Fatal("expected unprepared transcript error")
+	}
+}
+
+func TestExtractSummary_PreparedJSON(t *testing.T) {
+	agent := New()
+	path := filepath.Join(t.TempDir(), "amp.json")
+	if err := os.WriteFile(path, []byte(testPreparedTranscriptJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	summary, has, err := agent.ExtractSummary(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !has || summary != "Created hello.txt" {
+		t.Fatalf("summary = %q has=%v", summary, has)
+	}
+}
+
+func TestReadSession(t *testing.T) {
+	t.Setenv("ENTIRE_REPO_ROOT", t.TempDir())
+	path := writeTestTranscript(t)
+	agent := New()
+	if _, err := agent.ReadSession(&protocol.HookInputJSON{SessionRef: path}); err == nil {
+		t.Fatal("expected unprepared transcript error")
+	}
+}
+
+func TestReadSession_PreparedJSON(t *testing.T) {
+	t.Setenv("ENTIRE_REPO_ROOT", t.TempDir())
+	path := filepath.Join(t.TempDir(), "amp.json")
+	if err := os.WriteFile(path, []byte(testPreparedTranscriptJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	agent := New()
+	session, err := agent.ReadSession(&protocol.HookInputJSON{SessionRef: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.SessionID != "T-123" || session.AgentName != "amp" || len(session.NativeData) == 0 {
+		t.Fatalf("session = %+v", session)
+	}
+	if len(session.ModifiedFiles) != 1 || session.ModifiedFiles[0] != "hello.txt" {
+		t.Fatalf("modified files = %v", session.ModifiedFiles)
+	}
+}
+
+func TestCalculateTokens_PreparedJSON(t *testing.T) {
+	agent := New()
+	usage, err := agent.CalculateTokens([]byte(testPreparedTranscriptJSON), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage.InputTokens != 100 || usage.OutputTokens != 25 || usage.CacheReadTokens != 7 || usage.CacheCreationTokens != 3 || usage.APICallCount != 1 {
+		t.Fatalf("usage = %+v", usage)
+	}
+}
+
+func TestPrepareTranscript(t *testing.T) {
+	path := writeTestTranscript(t)
+	runner := &fakeCommandRunner{}
+	agent := &Agent{CommandRunner: runner}
+	if err := agent.PrepareTranscript(path); err != nil {
+		t.Fatal(err)
+	}
+	if runner.threadID != "T-123" {
+		t.Fatalf("threadID = %q", runner.threadID)
+	}
+	if runner.outputPath != path {
+		t.Fatalf("outputPath = %q", runner.outputPath)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != testPreparedTranscriptJSON {
+		t.Fatalf("prepared data = %s", data)
+	}
+}
+
+func TestPrepareTranscript_MissingThreadID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "amp.jsonl")
+	if err := os.WriteFile(path, []byte("{\"type\":\"agent.start\",\"message\":\"hello\"}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := (&Agent{CommandRunner: &fakeCommandRunner{}}).PrepareTranscript(path)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestPrepareTranscript_RunnerError(t *testing.T) {
+	path := writeTestTranscript(t)
+	wantErr := errors.New("boom")
+	err := (&Agent{CommandRunner: &fakeCommandRunner{err: wantErr}}).PrepareTranscript(path)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+}
+
+func TestChunkAndReassemble(t *testing.T) {
+	agent := New()
+	chunks, err := agent.ChunkTranscript([]byte("hello world"), 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := agent.ReassembleTranscript(chunks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello world" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestWriteSession(t *testing.T) {
+	agent := New()
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := agent.WriteSession(protocol.AgentSessionJSON{SessionRef: path, NativeData: []byte("x")}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "x" {
+		t.Fatalf("data = %q", data)
+	}
+}

--- a/agents/entire-agent-amp/internal/amp/transcript_test.go
+++ b/agents/entire-agent-amp/internal/amp/transcript_test.go
@@ -66,12 +66,22 @@ func TestExtractModifiedFiles_PreparedJSON(t *testing.T) {
 	if err := os.WriteFile(path, []byte(testPreparedTranscriptJSON), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	files, _, err := agent.ExtractModifiedFiles(path, 0)
+	files, pos, err := agent.ExtractModifiedFiles(path, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(files) != 1 || files[0] != "hello.txt" {
 		t.Fatalf("files = %v", files)
+	}
+	if pos != 3 {
+		t.Fatalf("position = %d, want 3", pos)
+	}
+	files, pos, err = agent.ExtractModifiedFiles(path, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 || pos != 3 {
+		t.Fatalf("offset files = %v position = %d, want no files at position 3", files, pos)
 	}
 }
 
@@ -94,6 +104,13 @@ func TestExtractPrompts_PreparedJSON(t *testing.T) {
 	}
 	if len(prompts) != 1 || prompts[0] != "Create hello.txt" {
 		t.Fatalf("prompts = %v", prompts)
+	}
+	prompts, err = agent.ExtractPrompts(path, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prompts) != 0 {
+		t.Fatalf("offset prompts = %v, want none", prompts)
 	}
 }
 
@@ -156,6 +173,25 @@ func TestCalculateTokens_PreparedJSON(t *testing.T) {
 	if usage.InputTokens != 100 || usage.OutputTokens != 25 || usage.CacheReadTokens != 7 || usage.CacheCreationTokens != 3 || usage.APICallCount != 1 {
 		t.Fatalf("usage = %+v", usage)
 	}
+	usage, err = agent.CalculateTokens([]byte(testPreparedTranscriptJSON), 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage.APICallCount != 0 || usage.InputTokens != 0 || usage.OutputTokens != 0 || usage.CacheReadTokens != 0 || usage.CacheCreationTokens != 0 {
+		t.Fatalf("offset usage = %+v, want zero usage", usage)
+	}
+}
+
+func TestGetTranscriptPosition_PreparedJSON(t *testing.T) {
+	agent := New()
+	path := writePreparedTranscript(t)
+	pos, err := agent.GetTranscriptPosition(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pos != 3 {
+		t.Fatalf("position = %d, want 3", pos)
+	}
 }
 
 func TestPrepareTranscript(t *testing.T) {
@@ -181,6 +217,21 @@ func TestPrepareTranscript(t *testing.T) {
 }
 
 func TestPrepareTranscript_UnpreparedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "amp.jsonl")
+	if err := os.WriteFile(path, []byte(testTranscriptJSONL), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runner := &fakeCommandRunner{}
+	err := (&Agent{CommandRunner: runner}).PrepareTranscript(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runner.threadID != "T-123" {
+		t.Fatalf("threadID = %q, want T-123", runner.threadID)
+	}
+}
+
+func TestPrepareTranscript_UnpreparedFileMissingThreadID(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "amp.jsonl")
 	if err := os.WriteFile(path, []byte("{\"type\":\"agent.start\",\"message\":\"hello\"}\n"), 0o600); err != nil {
 		t.Fatal(err)

--- a/agents/entire-agent-amp/internal/amp/transcript_test.go
+++ b/agents/entire-agent-amp/internal/amp/transcript_test.go
@@ -159,7 +159,7 @@ func TestCalculateTokens_PreparedJSON(t *testing.T) {
 }
 
 func TestPrepareTranscript(t *testing.T) {
-	path := writeTestTranscript(t)
+	path := writePreparedTranscript(t)
 	runner := &fakeCommandRunner{}
 	agent := &Agent{CommandRunner: runner}
 	if err := agent.PrepareTranscript(path); err != nil {
@@ -180,19 +180,23 @@ func TestPrepareTranscript(t *testing.T) {
 	}
 }
 
-func TestPrepareTranscript_MissingThreadID(t *testing.T) {
+func TestPrepareTranscript_UnpreparedFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "amp.jsonl")
 	if err := os.WriteFile(path, []byte("{\"type\":\"agent.start\",\"message\":\"hello\"}\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	err := (&Agent{CommandRunner: &fakeCommandRunner{}}).PrepareTranscript(path)
+	runner := &fakeCommandRunner{}
+	err := (&Agent{CommandRunner: runner}).PrepareTranscript(path)
 	if err == nil {
 		t.Fatal("expected error")
+	}
+	if runner.threadID != "" {
+		t.Fatalf("runner unexpectedly invoked with threadID = %q", runner.threadID)
 	}
 }
 
 func TestPrepareTranscript_RunnerError(t *testing.T) {
-	path := writeTestTranscript(t)
+	path := writePreparedTranscript(t)
 	wantErr := errors.New("boom")
 	err := (&Agent{CommandRunner: &fakeCommandRunner{err: wantErr}}).PrepareTranscript(path)
 	if !errors.Is(err, wantErr) {

--- a/agents/entire-agent-amp/internal/amp/transcript_test.go
+++ b/agents/entire-agent-amp/internal/amp/transcript_test.go
@@ -85,6 +85,103 @@ func TestExtractModifiedFiles_PreparedJSON(t *testing.T) {
 	}
 }
 
+func TestExtractModifiedFiles_IgnoresReadOnlyToolPaths(t *testing.T) {
+	t.Setenv("ENTIRE_REPO_ROOT", t.TempDir())
+	transcript := `{"v":1,"id":"T-read","created":1778155200000,"messages":[{"role":"assistant","messageId":"a1","content":[{"type":"tool_use","id":"read1","name":"read_file","input":{"path":"inspected.go"}},{"type":"tool_result","toolUseID":"read1","run":{"status":"done","trackFiles":["file:///tmp/inspected.go"],"result":{"absolutePath":"inspected.go","output":"package main"}}}],"originalToolUseInput":{"read1":{"path":"inspected.go"},"read_file":{"path":"also-inspected.go"}}}]}`
+	path := filepath.Join(t.TempDir(), "amp.json")
+	if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	files, pos, err := New().ExtractModifiedFiles(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("files = %v, want no modified files", files)
+	}
+	if pos != 1 {
+		t.Fatalf("position = %d, want 1", pos)
+	}
+
+	session, err := New().ReadSession(&protocol.HookInputJSON{SessionRef: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(session.ModifiedFiles) != 0 {
+		t.Fatalf("session modified files = %v, want none", session.ModifiedFiles)
+	}
+}
+
+func TestExtractModifiedFiles_NormalizesFileURIs(t *testing.T) {
+	transcript := `{"v":1,"id":"T-write","created":1778155200000,"messages":[{"role":"assistant","messageId":"a1","content":[{"type":"tool_use","id":"edit1","name":"edit_file","input":{"path":"/tmp/space dir/changed.go"}}]},{"role":"user","messageId":2,"content":[{"type":"tool_result","toolUseID":"edit1","run":{"status":"done","trackFiles":["file:///tmp/space%20dir/changed.go"],"result":{"output":"ok"}}}]}]}`
+	path := filepath.Join(t.TempDir(), "amp.json")
+	if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	files, _, err := New().ExtractModifiedFiles(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"/tmp/space dir/changed.go"}
+	if len(files) != len(want) {
+		t.Fatalf("files = %v, want %v", files, want)
+	}
+	for i := range want {
+		if files[i] != want[i] {
+			t.Fatalf("files = %v, want %v", files, want)
+		}
+	}
+}
+
+func TestExtractModifiedFiles_OffsetResolvesPriorToolUse(t *testing.T) {
+	transcript := `{"v":1,"id":"T-write","created":1778155200000,"messages":[{"role":"assistant","messageId":"a1","content":[{"type":"tool_use","id":"edit1","name":"edit_file","input":{"path":"changed.go"}}]},{"role":"user","messageId":2,"content":[{"type":"tool_result","toolUseID":"edit1","run":{"status":"done","trackFiles":["also-changed.go"],"result":{"absolutePath":"result-changed.go","output":"ok"}}}]}]}`
+	path := filepath.Join(t.TempDir(), "amp.json")
+	if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	files, pos, err := New().ExtractModifiedFiles(path, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"also-changed.go", "result-changed.go"}
+	if len(files) != len(want) {
+		t.Fatalf("files = %v, want %v", files, want)
+	}
+	for i := range want {
+		if files[i] != want[i] {
+			t.Fatalf("files = %v, want %v", files, want)
+		}
+	}
+	if pos != 2 {
+		t.Fatalf("position = %d, want 2", pos)
+	}
+}
+
+func TestExtractModifiedFiles_IncludesMutatingToolInput(t *testing.T) {
+	transcript := `{"v":1,"id":"T-write","created":1778155200000,"messages":[{"role":"assistant","messageId":"a1","content":[{"type":"tool_use","id":"edit1","name":"edit_file","input":{"path":"changed.go"}}],"originalToolUseInput":{"edit1":{"path":"also-changed.go"}}}]}`
+	path := filepath.Join(t.TempDir(), "amp.json")
+	if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	files, _, err := New().ExtractModifiedFiles(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"also-changed.go", "changed.go"}
+	if len(files) != len(want) {
+		t.Fatalf("files = %v, want %v", files, want)
+	}
+	for i := range want {
+		if files[i] != want[i] {
+			t.Fatalf("files = %v, want %v", files, want)
+		}
+	}
+}
+
 func TestTranscriptAnalyzer_PlaceholderTranscript(t *testing.T) {
 	agent := New()
 	path := filepath.Join(t.TempDir(), "amp.json")

--- a/agents/entire-agent-amp/internal/amp/types.go
+++ b/agents/entire-agent-amp/internal/amp/types.go
@@ -1,0 +1,325 @@
+package amp
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ThreadUnixMillis is an epoch timestamp encoded as milliseconds.
+type ThreadUnixMillis int64
+
+func (m ThreadUnixMillis) Time() time.Time {
+	if m == 0 {
+		return time.Time{}
+	}
+	return time.UnixMilli(int64(m)).UTC()
+}
+
+// AmpThread is the top-level Amp thread transcript document.
+type AmpThread struct {
+	Version         int                    `json:"v"`
+	ID              string                 `json:"id"`
+	Env             ThreadEnvironment      `json:"env"`
+	Meta            ThreadMeta             `json:"meta"`
+	Title           string                 `json:"title"`
+	Created         ThreadUnixMillis       `json:"created"`
+	Messages        []ThreadMessage        `json:"messages"`
+	AgentMode       string                 `json:"agentMode"`
+	UpdatedAt       time.Time              `json:"updatedAt"`
+	CreatorUserID   string                 `json:"creatorUserID"`
+	NextMessageID   int                    `json:"nextMessageId"`
+	ActivatedSkills []ThreadActivatedSkill `json:"activatedSkills,omitempty"`
+}
+
+// ThreadEnvironment describes the editor, workspace, and platform state captured for
+// the transcript.
+type ThreadEnvironment struct {
+	Initial ThreadInitialEnvironment `json:"initial"`
+}
+
+type ThreadInitialEnvironment struct {
+	Tags     []string              `json:"tags,omitempty"`
+	Trees    []ThreadWorkspaceTree `json:"trees,omitempty"`
+	Platform ThreadPlatform        `json:"platform"`
+}
+
+type ThreadWorkspaceTree struct {
+	URI         string           `json:"uri"`
+	Repository  ThreadRepository `json:"repository"`
+	DisplayName string           `json:"displayName"`
+}
+
+type ThreadRepository struct {
+	Ref  string `json:"ref"`
+	SHA  string `json:"sha"`
+	URL  string `json:"url"`
+	Type string `json:"type"`
+}
+
+type ThreadPlatform struct {
+	OS                string `json:"os"`
+	Client            string `json:"client"`
+	OSVersion         string `json:"osVersion"`
+	ClientType        string `json:"clientType"`
+	WebBrowser        bool   `json:"webBrowser"`
+	ClientVersion     string `json:"clientVersion"`
+	InstallationID    string `json:"installationID"`
+	CPUArchitecture   string `json:"cpuArchitecture"`
+	DeviceFingerprint string `json:"deviceFingerprint"`
+}
+
+// ThreadMeta contains transcript-level metadata and execution traces.
+type ThreadMeta struct {
+	Traces          []ThreadTrace `json:"traces,omitempty"`
+	Deleted         bool          `json:"deleted"`
+	UsesDtw         bool          `json:"usesDtw"`
+	AgentMode       string        `json:"agentMode"`
+	ProjectID       *string       `json:"projectID"`
+	Visibility      string        `json:"visibility"`
+	WorkspaceID     *string       `json:"workspaceID"`
+	SharedGroupIDs  []string      `json:"sharedGroupIDs,omitempty"`
+	CreatedOnServer bool          `json:"createdOnServer"`
+	LastUserMessage time.Time     `json:"lastUserMessageAt"`
+}
+
+type ThreadTrace struct {
+	ID         string                 `json:"id"`
+	Name       string                 `json:"name"`
+	Label      string                 `json:"label,omitempty"`
+	Parent     string                 `json:"parent,omitempty"`
+	Context    ThreadTraceContext     `json:"context"`
+	StartTime  time.Time              `json:"startTime"`
+	EndTime    time.Time              `json:"endTime"`
+	Events     []ThreadTraceEvent     `json:"events,omitempty"`
+	Attributes *ThreadTraceAttributes `json:"attributes,omitempty"`
+}
+
+type ThreadTraceContext struct {
+	MessageID *ThreadMessageID `json:"messageId,omitempty"`
+}
+
+type ThreadTraceEvent struct {
+	Message   string    `json:"message,omitempty"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+type ThreadTraceAttributes struct {
+	Plugin *ThreadPluginTraceAttributes `json:"plugin,omitempty"`
+}
+
+type ThreadPluginTraceAttributes struct {
+	Hook       string `json:"hook"`
+	PluginName string `json:"pluginName"`
+}
+
+type ThreadActivatedSkill struct {
+	Name string `json:"name"`
+}
+
+// ThreadMessageID is documented by Amp's plugin API as number|string. Exported
+// transcripts observed so far use numbers, but accepting both keeps the parser
+// aligned with the public ThreadMessage contract.
+type ThreadMessageID string
+
+func (id *ThreadMessageID) UnmarshalJSON(data []byte) error {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" || trimmed == "null" {
+		*id = ""
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		*id = ThreadMessageID(s)
+		return nil
+	}
+	var n json.Number
+	if err := json.Unmarshal(data, &n); err == nil {
+		*id = ThreadMessageID(n.String())
+		return nil
+	}
+	return fmt.Errorf("invalid thread message id: %s", trimmed)
+}
+
+func (id ThreadMessageID) MarshalJSON() ([]byte, error) {
+	if id == "" {
+		return []byte("null"), nil
+	}
+	if _, err := strconv.Atoi(string(id)); err == nil {
+		return []byte(string(id)), nil
+	}
+	return json.Marshal(string(id))
+}
+
+// ThreadMessageRole is an Amp transcript message role.
+type ThreadMessageRole string
+
+const (
+	ThreadMessageRoleAssistant ThreadMessageRole = "assistant"
+	ThreadMessageRoleInfo      ThreadMessageRole = "info"
+	ThreadMessageRoleUser      ThreadMessageRole = "user"
+)
+
+// ThreadMessage is a user, assistant, or informational entry in the transcript.
+type ThreadMessage struct {
+	Meta                 *ThreadMessageMeta         `json:"meta,omitempty"`
+	Role                 ThreadMessageRole          `json:"role"`
+	Content              []ThreadContentBlock       `json:"content,omitempty"`
+	AgentMode            string                     `json:"agentMode,omitempty"`
+	MessageID            ThreadMessageID            `json:"messageId"`
+	UserState            *ThreadUserState           `json:"userState,omitempty"`
+	FileMentions         *ThreadFileMentions        `json:"fileMentions,omitempty"`
+	State                *ThreadAssistantState      `json:"state,omitempty"`
+	Usage                *ThreadUsage               `json:"usage,omitempty"`
+	TurnElapsedMillis    int64                      `json:"turnElapsedMs,omitempty"`
+	Interrupted          *bool                      `json:"interrupted,omitempty"`
+	NativeMessage        json.RawMessage            `json:"nativeMessage,omitempty"`
+	OriginalToolUseInput map[string]ThreadToolInput `json:"originalToolUseInput,omitempty"`
+}
+
+type ThreadMessageMeta struct {
+	SentAt ThreadUnixMillis `json:"sentAt"`
+}
+
+type ThreadUserState struct {
+	ActiveEditor          string                `json:"activeEditor,omitempty"`
+	CursorLocation        *ThreadCursorLocation `json:"cursorLocation,omitempty"`
+	CursorLocationLine    string                `json:"cursorLocationLine,omitempty"`
+	CurrentlyVisibleFiles []string              `json:"currentlyVisibleFiles,omitempty"`
+	SelectionRange        *ThreadSelectionRange `json:"selectionRange,omitempty"`
+}
+
+type ThreadCursorLocation struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}
+
+type ThreadFileMentions struct {
+	Files    []ThreadMentionedFile `json:"files,omitempty"`
+	Mentions []ThreadFileMention   `json:"mentions,omitempty"`
+}
+
+type ThreadMentionedFile struct {
+	URI     string `json:"uri"`
+	Path    string `json:"path,omitempty"`
+	Content string `json:"content"`
+	IsImage bool   `json:"isImage"`
+}
+
+type ThreadFileMention struct {
+	URI  string `json:"uri,omitempty"`
+	Path string `json:"path,omitempty"`
+}
+
+type ThreadSelectionRange struct {
+	Content string             `json:"content,omitempty"`
+	Start   ThreadTextPosition `json:"start"`
+	End     ThreadTextPosition `json:"end"`
+}
+
+type ThreadTextPosition struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}
+
+type ThreadAssistantState struct {
+	Type       string `json:"type"`
+	StopReason string `json:"stopReason"`
+}
+
+type ThreadUsage struct {
+	Model                    string    `json:"model"`
+	Timestamp                time.Time `json:"timestamp"`
+	InputTokens              int       `json:"inputTokens"`
+	OutputTokens             int       `json:"outputTokens"`
+	MaxInputTokens           int       `json:"maxInputTokens"`
+	TotalInputTokens         int       `json:"totalInputTokens"`
+	CacheReadInputTokens     int       `json:"cacheReadInputTokens"`
+	CacheCreationInputTokens int       `json:"cacheCreationInputTokens"`
+	Credits                  float64   `json:"credits,omitempty"`
+	CreditsSinceLastUser     float64   `json:"creditsSinceLastUserMessage,omitempty"`
+}
+
+// ThreadContentType is the discriminator for ThreadMessage.Content items.
+type ThreadContentType string
+
+const (
+	ThreadContentText             ThreadContentType = "text"
+	ThreadContentThinking         ThreadContentType = "thinking"
+	ThreadContentImage            ThreadContentType = "image"
+	ThreadContentToolUse          ThreadContentType = "tool_use"
+	ThreadContentToolResult       ThreadContentType = "tool_result"
+	ThreadContentServerToolUse    ThreadContentType = "server_tool_use"
+	ThreadContentToolSearchResult ThreadContentType = "tool_search_tool_result"
+)
+
+// ThreadContentBlock represents one item in a message content array.
+//
+// Text and thinking blocks use Text/Thinking. Tool-use blocks use ID, Name,
+// Input, Complete, StartTime, and FinalTime. Tool-result blocks use ToolUseID
+// and Run. Input is raw because its schema depends on the tool name.
+type ThreadContentBlock struct {
+	Type      ThreadContentType `json:"type"`
+	Text      string            `json:"text,omitempty"`
+	Provider  string            `json:"provider,omitempty"`
+	Thinking  string            `json:"thinking,omitempty"`
+	Signature string            `json:"signature,omitempty"`
+	Source    *ThreadSource     `json:"source,omitempty"`
+	UserInput *ThreadUserInput  `json:"userInput,omitempty"`
+
+	ID       string          `json:"id,omitempty"`
+	Name     string          `json:"name,omitempty"`
+	Input    ThreadToolInput `json:"input,omitempty"`
+	Complete *bool           `json:"complete,omitempty"`
+
+	ToolUseID string         `json:"toolUseID,omitempty"`
+	Run       *ThreadToolRun `json:"run,omitempty"`
+
+	StartTime ThreadUnixMillis `json:"startTime,omitempty"`
+	FinalTime ThreadUnixMillis `json:"finalTime,omitempty"`
+}
+
+type ThreadSource struct {
+	Type string `json:"type"`
+	URL  string `json:"url,omitempty"`
+}
+
+type ThreadUserInput struct {
+	Accepted bool `json:"accepted"`
+}
+
+// ThreadToolInput is a tool-specific input object keyed by argument name.
+type ThreadToolInput map[string]json.RawMessage
+
+type ThreadToolRun struct {
+	Status     string              `json:"status"`
+	Result     json.RawMessage     `json:"result,omitempty"`
+	Error      *ThreadToolRunError `json:"error,omitempty"`
+	Progress   json.RawMessage     `json:"progress,omitempty"`
+	TrackFiles []string            `json:"trackFiles,omitempty"`
+	Debug      json.RawMessage     `json:"~debug,omitempty"`
+}
+
+type ThreadToolRunError struct {
+	Message string `json:"message"`
+}
+
+// ThreadCommonToolResult captures fields shared by many Amp tool results. Use
+// ThreadToolRun.DecodeResult for stricter tool-specific structs.
+type ThreadCommonToolResult struct {
+	Output           string                  `json:"output,omitempty"`
+	ExitCode         int                     `json:"exitCode,omitempty"`
+	Diff             string                  `json:"diff,omitempty"`
+	LineRange        []int                   `json:"lineRange,omitempty"`
+	AbsolutePath     string                  `json:"absolutePath,omitempty"`
+	DirectoryEntries []string                `json:"directoryEntries,omitempty"`
+	IsDirectory      *bool                   `json:"isDirectory,omitempty"`
+	Content          []ThreadEmbeddedContent `json:"content,omitempty"`
+}
+
+type ThreadEmbeddedContent struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}

--- a/agents/entire-agent-amp/internal/amp/types.go
+++ b/agents/entire-agent-amp/internal/amp/types.go
@@ -119,9 +119,6 @@ type ThreadActivatedSkill struct {
 	Name string `json:"name"`
 }
 
-// ThreadMessageID is documented by Amp's plugin API as number|string. Exported
-// transcripts observed so far use numbers, but accepting both keeps the parser
-// aligned with the public ThreadMessage contract.
 type ThreadMessageID string
 
 func (id *ThreadMessageID) UnmarshalJSON(data []byte) error {

--- a/agents/entire-agent-amp/internal/amp/types.go
+++ b/agents/entire-agent-amp/internal/amp/types.go
@@ -18,8 +18,8 @@ func (m ThreadUnixMillis) Time() time.Time {
 	return time.UnixMilli(int64(m)).UTC()
 }
 
-// AmpThread is the top-level Amp thread transcript document.
-type AmpThread struct {
+// Thread is the top-level Amp thread transcript document.
+type Thread struct {
 	Version         int                    `json:"v"`
 	ID              string                 `json:"id"`
 	Env             ThreadEnvironment      `json:"env"`

--- a/agents/entire-agent-amp/internal/protocol/handlers_test.go
+++ b/agents/entire-agent-amp/internal/protocol/handlers_test.go
@@ -1,0 +1,50 @@
+package protocol
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+type testTranscriptCompactor struct {
+	response CompactTranscriptResponse
+	err      error
+}
+
+type testTranscriptPreparer struct {
+	sessionRef string
+	err        error
+}
+
+func (c testTranscriptCompactor) CompactTranscript(_ string) (CompactTranscriptResponse, error) {
+	return c.response, c.err
+}
+
+func (p *testTranscriptPreparer) PrepareTranscript(sessionRef string) error {
+	p.sessionRef = sessionRef
+	return p.err
+}
+
+func TestHandleCompactTranscript(t *testing.T) {
+	var stdout bytes.Buffer
+	err := HandleCompactTranscript([]string{"--session-ref", "/tmp/repo/.entire/tmp/abc123.json"}, &stdout, testTranscriptCompactor{
+		response: CompactTranscriptResponse{Transcript: "eyJ2IjoxfQo="},
+	})
+	if err != nil {
+		t.Fatalf("HandleCompactTranscript() error = %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, `"transcript":"eyJ2IjoxfQo="`) {
+		t.Fatalf("stdout = %s", got)
+	}
+}
+
+func TestHandlePrepareTranscript(t *testing.T) {
+	preparer := &testTranscriptPreparer{}
+	err := HandlePrepareTranscript([]string{"--session-ref", "/tmp/repo/.entire/tmp/amp/T-123.json"}, preparer)
+	if err != nil {
+		t.Fatalf("HandlePrepareTranscript() error = %v", err)
+	}
+	if preparer.sessionRef != "/tmp/repo/.entire/tmp/amp/T-123.json" {
+		t.Fatalf("sessionRef = %q", preparer.sessionRef)
+	}
+}

--- a/agents/entire-agent-amp/internal/protocol/protocol.go
+++ b/agents/entire-agent-amp/internal/protocol/protocol.go
@@ -1,0 +1,363 @@
+package protocol
+
+import (
+	"encoding/json"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type sessionDirResolver interface {
+	GetSessionDir(repoPath string) (string, error)
+}
+
+type sessionFileResolver interface {
+	ResolveSessionFile(sessionDir, sessionID string) string
+}
+
+type sessionIDProvider interface {
+	GetSessionID(*HookInputJSON) string
+}
+
+type sessionReader interface {
+	ReadSession(*HookInputJSON) (AgentSessionJSON, error)
+}
+
+type sessionWriter interface {
+	WriteSession(AgentSessionJSON) error
+}
+
+type transcriptReader interface {
+	ReadTranscript(sessionRef string) ([]byte, error)
+}
+
+type transcriptChunker interface {
+	ChunkTranscript(content []byte, maxSize int) ([][]byte, error)
+	ReassembleTranscript(chunks [][]byte) ([]byte, error)
+}
+
+type transcriptCompactor interface {
+	CompactTranscript(sessionRef string) (CompactTranscriptResponse, error)
+}
+
+type transcriptPreparer interface {
+	PrepareTranscript(sessionRef string) error
+}
+
+type resumeFormatter interface {
+	FormatResumeCommand(sessionID string) string
+}
+
+type hookParser interface {
+	ParseHook(hookName string, input []byte) (*EventJSON, error)
+	InstallHooks(localDev bool, force bool) (int, error)
+	UninstallHooks() error
+	AreHooksInstalled() bool
+}
+
+type transcriptAnalyzer interface {
+	GetTranscriptPosition(path string) (int, error)
+	ExtractModifiedFiles(path string, offset int) ([]string, int, error)
+	ExtractPrompts(sessionRef string, offset int) ([]string, error)
+	ExtractSummary(sessionRef string) (string, bool, error)
+}
+
+type tokenCalculator interface {
+	CalculateTokens(data []byte, offset int) (TokenUsageResponse, error)
+}
+
+func WriteJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(v)
+}
+
+func ReadJSON[T any](r io.Reader) (*T, error) {
+	var value T
+	if err := json.NewDecoder(r).Decode(&value); err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
+func RepoRoot() string {
+	if root := os.Getenv("ENTIRE_REPO_ROOT"); root != "" {
+		return root
+	}
+	root, _ := os.Getwd()
+	return root
+}
+
+func HandleGetSessionID(stdin io.Reader, stdout io.Writer, provider sessionIDProvider) error {
+	input, err := ReadJSON[HookInputJSON](stdin)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionIDResponse{SessionID: provider.GetSessionID(input)})
+}
+
+func HandleGetSessionDir(args []string, stdout io.Writer, resolver sessionDirResolver) error {
+	fs := flag.NewFlagSet("get-session-dir", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	repoPath := fs.String("repo-path", "", "repo path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	sessionDir, err := resolver.GetSessionDir(*repoPath)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionDirResponse{SessionDir: sessionDir})
+}
+
+func HandleResolveSessionFile(args []string, stdout io.Writer, resolver sessionFileResolver) error {
+	fs := flag.NewFlagSet("resolve-session-file", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionDir := fs.String("session-dir", "", "session dir")
+	sessionID := fs.String("session-id", "", "session id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionFileResponse{SessionFile: resolver.ResolveSessionFile(*sessionDir, *sessionID)})
+}
+
+func HandleReadSession(stdin io.Reader, stdout io.Writer, reader sessionReader) error {
+	input, err := ReadJSON[HookInputJSON](stdin)
+	if err != nil {
+		return err
+	}
+	session, err := reader.ReadSession(input)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, session)
+}
+
+func HandleWriteSession(stdin io.Reader, writer sessionWriter) error {
+	session, err := ReadJSON[AgentSessionJSON](stdin)
+	if err != nil {
+		return err
+	}
+	return writer.WriteSession(*session)
+}
+
+func HandleReadTranscript(args []string, stdout io.Writer, reader transcriptReader) error {
+	fs := flag.NewFlagSet("read-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	data, err := reader.ReadTranscript(*sessionRef)
+	if err != nil {
+		return err
+	}
+	_, err = stdout.Write(data)
+	return err
+}
+
+func HandleChunkTranscript(args []string, stdin io.Reader, stdout io.Writer, chunker transcriptChunker) error {
+	fs := flag.NewFlagSet("chunk-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	maxSize := fs.Int("max-size", 0, "max size")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	content, err := io.ReadAll(stdin)
+	if err != nil {
+		return err
+	}
+	chunks, err := chunker.ChunkTranscript(content, *maxSize)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ChunkResponse{Chunks: chunks})
+}
+
+func HandleReassembleTranscript(stdin io.Reader, stdout io.Writer, chunker transcriptChunker) error {
+	input, err := ReadJSON[ChunkResponse](stdin)
+	if err != nil {
+		return err
+	}
+	data, err := chunker.ReassembleTranscript(input.Chunks)
+	if err != nil {
+		return err
+	}
+	_, err = stdout.Write(data)
+	return err
+}
+
+func HandleCompactTranscript(args []string, stdout io.Writer, compactor transcriptCompactor) error {
+	fs := flag.NewFlagSet("compact-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	compacted, err := compactor.CompactTranscript(*sessionRef)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, compacted)
+}
+
+func HandlePrepareTranscript(args []string, preparer transcriptPreparer) error {
+	fs := flag.NewFlagSet("prepare-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return preparer.PrepareTranscript(*sessionRef)
+}
+
+func HandleFormatResumeCommand(args []string, stdout io.Writer, formatter resumeFormatter) error {
+	fs := flag.NewFlagSet("format-resume-command", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionID := fs.String("session-id", "", "session id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ResumeCommandResponse{Command: formatter.FormatResumeCommand(*sessionID)})
+}
+
+func readStdinWithTimeout(r io.Reader, timeout time.Duration) ([]byte, error) {
+	type result struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		data, err := io.ReadAll(r)
+		ch <- result{data, err}
+	}()
+	select {
+	case res := <-ch:
+		return res.data, res.err
+	case <-time.After(timeout):
+		return nil, nil
+	}
+}
+
+func HandleParseHook(args []string, stdin io.Reader, stdout io.Writer, parser hookParser) error {
+	fs := flag.NewFlagSet("parse-hook", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	hook := fs.String("hook", "", "hook name")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	input, err := readStdinWithTimeout(stdin, 100*time.Millisecond)
+	if err != nil {
+		return err
+	}
+	event, err := parser.ParseHook(*hook, input)
+	if err != nil {
+		return err
+	}
+	if event == nil {
+		_, err = io.WriteString(stdout, "null\n")
+		return err
+	}
+	return WriteJSON(stdout, event)
+}
+
+func HandleInstallHooks(args []string, stdout io.Writer, parser hookParser) error {
+	fs := flag.NewFlagSet("install-hooks", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	localDev := fs.Bool("local-dev", false, "local dev")
+	force := fs.Bool("force", false, "force")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	count, err := parser.InstallHooks(*localDev, *force)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, HooksInstalledCountResponse{HooksInstalled: count})
+}
+
+func HandleGetTranscriptPosition(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("get-transcript-position", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	path := fs.String("path", "", "path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	position, err := analyzer.GetTranscriptPosition(*path)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, TranscriptPositionResponse{Position: position})
+}
+
+func HandleExtractModifiedFiles(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-modified-files", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	path := fs.String("path", "", "path")
+	offset := fs.Int("offset", 0, "offset")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	files, currentPosition, err := analyzer.ExtractModifiedFiles(*path, *offset)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractFilesResponse{Files: files, CurrentPosition: currentPosition})
+}
+
+func HandleExtractPrompts(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-prompts", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	offset := fs.Int("offset", 0, "offset")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	prompts, err := analyzer.ExtractPrompts(*sessionRef, *offset)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractPromptsResponse{Prompts: prompts})
+}
+
+func HandleExtractSummary(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-summary", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	summary, hasSummary, err := analyzer.ExtractSummary(*sessionRef)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractSummaryResponse{Summary: summary, HasSummary: hasSummary})
+}
+
+func HandleCalculateTokens(args []string, stdin io.Reader, stdout io.Writer, calculator tokenCalculator) error {
+	fs := flag.NewFlagSet("calculate-tokens", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	offset := fs.Int("offset", 0, "offset")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	data, err := io.ReadAll(stdin)
+	if err != nil {
+		return err
+	}
+	usage, err := calculator.CalculateTokens(data, *offset)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, usage)
+}
+
+func DefaultSessionDir(repoPath string) string {
+	return filepath.Join(repoPath, ".entire", "tmp")
+}
+
+func ResolveSessionFile(sessionDir, sessionID string) string {
+	return filepath.Join(sessionDir, sessionID+".json")
+}

--- a/agents/entire-agent-amp/internal/protocol/types.go
+++ b/agents/entire-agent-amp/internal/protocol/types.go
@@ -1,0 +1,139 @@
+package protocol
+
+import "encoding/json"
+
+const ProtocolVersion = 1
+
+type DeclaredCapabilities struct {
+	Hooks                  bool `json:"hooks"`
+	TranscriptAnalyzer     bool `json:"transcript_analyzer"`
+	TranscriptPreparer     bool `json:"transcript_preparer"`
+	TokenCalculator        bool `json:"token_calculator"`
+	CompactTranscript      bool `json:"compact_transcript"`
+	TextGenerator          bool `json:"text_generator"`
+	HookResponseWriter     bool `json:"hook_response_writer"`
+	SubagentAwareExtractor bool `json:"subagent_aware_extractor"`
+	UsesTerminal           bool `json:"uses_terminal"`
+}
+
+type InfoResponse struct {
+	ProtocolVersion int                  `json:"protocol_version"`
+	Name            string               `json:"name"`
+	Type            string               `json:"type"`
+	Description     string               `json:"description"`
+	IsPreview       bool                 `json:"is_preview"`
+	ProtectedDirs   []string             `json:"protected_dirs"`
+	ProtectedFiles  []string             `json:"protected_files,omitempty"`
+	HookNames       []string             `json:"hook_names"`
+	Capabilities    DeclaredCapabilities `json:"capabilities"`
+}
+
+type DetectResponse struct {
+	Present bool `json:"present"`
+}
+
+type SessionIDResponse struct {
+	SessionID string `json:"session_id"`
+}
+
+type SessionDirResponse struct {
+	SessionDir string `json:"session_dir"`
+}
+
+type SessionFileResponse struct {
+	SessionFile string `json:"session_file"`
+}
+
+type ChunkResponse struct {
+	Chunks [][]byte `json:"chunks"`
+}
+
+type ResumeCommandResponse struct {
+	Command string `json:"command"`
+}
+
+type HooksInstalledCountResponse struct {
+	HooksInstalled int `json:"hooks_installed"`
+}
+
+type AreHooksInstalledResponse struct {
+	Installed bool `json:"installed"`
+}
+
+type TranscriptPositionResponse struct {
+	Position int `json:"position"`
+}
+
+type ExtractFilesResponse struct {
+	Files           []string `json:"files"`
+	CurrentPosition int      `json:"current_position"`
+}
+
+type ExtractPromptsResponse struct {
+	Prompts []string `json:"prompts"`
+}
+
+type ExtractSummaryResponse struct {
+	Summary    string `json:"summary"`
+	HasSummary bool   `json:"has_summary"`
+}
+
+type TokenUsageResponse struct {
+	InputTokens         int `json:"input_tokens"`
+	CacheCreationTokens int `json:"cache_creation_tokens"`
+	CacheReadTokens     int `json:"cache_read_tokens"`
+	OutputTokens        int `json:"output_tokens"`
+	APICallCount        int `json:"api_call_count"`
+}
+
+type CompactTranscriptResponse struct {
+	Transcript string                       `json:"transcript"`
+	Assets     []CompactTranscriptAssetJSON `json:"assets,omitempty"`
+}
+
+type CompactTranscriptAssetJSON struct {
+	Name      string `json:"name"`
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
+}
+
+type AgentSessionJSON struct {
+	SessionID     string   `json:"session_id"`
+	AgentName     string   `json:"agent_name"`
+	RepoPath      string   `json:"repo_path"`
+	SessionRef    string   `json:"session_ref"`
+	StartTime     string   `json:"start_time"`
+	NativeData    []byte   `json:"native_data"`
+	ModifiedFiles []string `json:"modified_files"`
+	NewFiles      []string `json:"new_files"`
+	DeletedFiles  []string `json:"deleted_files"`
+}
+
+type HookInputJSON struct {
+	HookType   string                 `json:"hook_type"`
+	SessionID  string                 `json:"session_id"`
+	SessionRef string                 `json:"session_ref"`
+	Timestamp  string                 `json:"timestamp"`
+	UserPrompt string                 `json:"user_prompt,omitempty"`
+	ToolName   string                 `json:"tool_name,omitempty"`
+	ToolUseID  string                 `json:"tool_use_id,omitempty"`
+	ToolInput  json.RawMessage        `json:"tool_input,omitempty"`
+	RawData    map[string]interface{} `json:"raw_data,omitempty"`
+}
+
+type EventJSON struct {
+	Type              int               `json:"type"`
+	SessionID         string            `json:"session_id"`
+	PreviousSessionID string            `json:"previous_session_id,omitempty"`
+	SessionRef        string            `json:"session_ref,omitempty"`
+	Prompt            string            `json:"prompt,omitempty"`
+	Model             string            `json:"model,omitempty"`
+	Timestamp         string            `json:"timestamp,omitempty"`
+	ToolUseID         string            `json:"tool_use_id,omitempty"`
+	SubagentID        string            `json:"subagent_id,omitempty"`
+	ToolInput         json.RawMessage   `json:"tool_input,omitempty"`
+	SubagentType      string            `json:"subagent_type,omitempty"`
+	TaskDescription   string            `json:"task_description,omitempty"`
+	ResponseMessage   string            `json:"response_message,omitempty"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+}

--- a/agents/entire-agent-amp/mise.toml
+++ b/agents/entire-agent-amp/mise.toml
@@ -1,0 +1,10 @@
+[tools]
+go = "1.26.0"
+
+[tasks.build]
+description = "Build the entire-agent-amp binary"
+run = "go build -o entire-agent-amp ./cmd/entire-agent-amp"
+
+[tasks.test]
+description = "Run unit tests"
+run = "go test ./..."

--- a/agents/entire-agent-amp/scripts/verify-amp.sh
+++ b/agents/entire-agent-amp/scripts/verify-amp.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AGENT_NAME="Amp"
+AGENT_SLUG="amp"
+AGENT_BIN="amp"
+PROBE_DIR="$(cd "$(dirname "$0")/.." && pwd)/.probe-${AGENT_SLUG}-$(date +%s)"
+CAPTURE_DIR="$PROBE_DIR/captures"
+MODE=""
+RUN_CMD=""
+
+usage() {
+  echo "Usage: $0 [--run-cmd '<cmd>'] [--manual-live]"
+  echo "  --run-cmd '<cmd>'   Automated: launch Amp with a non-interactive prompt"
+  echo "  --manual-live       Interactive: run PLUGINS=all amp manually, then press Enter"
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run-cmd) RUN_CMD="$2"; MODE="auto"; shift 2 ;;
+    --manual-live) MODE="manual"; shift ;;
+    *) usage ;;
+  esac
+done
+
+mkdir -p "$CAPTURE_DIR"
+
+echo "=== Static Checks ==="
+if command -v "$AGENT_BIN" >/dev/null 2>&1; then
+  echo "  Binary present: PASS ($(command -v "$AGENT_BIN"))"
+else
+  echo "  Binary present: FAIL"
+  exit 1
+fi
+echo "  Version: $($AGENT_BIN --version 2>/dev/null || true)"
+
+TEST_REPO="$PROBE_DIR/test-repo"
+mkdir -p "$TEST_REPO/.amp/plugins"
+git -C "$TEST_REPO" init -q
+git -C "$TEST_REPO" config user.name "Amp Probe"
+git -C "$TEST_REPO" config user.email "amp-probe@example.invalid"
+touch "$TEST_REPO/README.md"
+git -C "$TEST_REPO" add README.md
+git -C "$TEST_REPO" commit -q -m "init"
+
+PLUGIN="$TEST_REPO/.amp/plugins/entire-probe.ts"
+cat > "$PLUGIN" <<'PLUGIN_EOF'
+import type { PluginAPI, ThreadMessage, ToolCallEvent } from "@ampcode/plugin";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+export default function (amp: PluginAPI) {
+  const captureDir = process.env.ENTIRE_PROBE_CAPTURE_DIR;
+  const modified = new Map<string, Set<string>>();
+  function capture(eventName: string, data: Record<string, unknown>) {
+    if (!captureDir) return;
+    mkdirSync(captureDir, { recursive: true });
+    const ts = new Date().toISOString().replace(/[:.]/g, "-");
+    writeFileSync(join(captureDir, `${eventName}-${ts}.json`), JSON.stringify(data, null, 2));
+  }
+  function filesFor(event: ToolCallEvent): Set<string> {
+    let files = modified.get(event.thread.id);
+    if (!files) {
+      files = new Set<string>();
+      modified.set(event.thread.id, files);
+    }
+    return files;
+  }
+  amp.on("tool.call", async (event) => {
+    const files = amp.helpers.filesModifiedByToolCall(event);
+    if (files) for (const file of files) filesFor(event).add(amp.helpers.filePathFromURI(file));
+    capture("tool.call", { thread_id: event.thread.id, tool: event.tool, input: event.input });
+    return { action: "allow" };
+  });
+  amp.on("agent.start", (event) => {
+    capture("agent.start", { thread_id: event.thread.id, message_id: String(event.id), message: event.message, cwd: process.cwd() });
+  });
+  amp.on("agent.end", (event) => {
+    capture("agent.end", {
+      thread_id: event.thread.id,
+      message_id: String(event.id),
+      message: event.message,
+      status: event.status,
+      messages: event.messages as ThreadMessage[],
+      modified_files: Array.from(modified.get(event.thread.id) ?? []).sort(),
+      cwd: process.cwd(),
+    });
+  });
+}
+PLUGIN_EOF
+
+echo "=== Hook Wiring ==="
+echo "  Probe plugin: $PLUGIN"
+
+if [[ "$MODE" == "auto" ]]; then
+  echo "=== Automated Run ==="
+  (cd "$TEST_REPO" && ENTIRE_PROBE_CAPTURE_DIR="$CAPTURE_DIR" PLUGINS=all eval "$RUN_CMD") || true
+elif [[ "$MODE" == "manual" ]]; then
+  echo "=== Manual Live Mode ==="
+  echo "  Run: cd $TEST_REPO && ENTIRE_PROBE_CAPTURE_DIR=$CAPTURE_DIR PLUGINS=all amp"
+  read -r
+else
+  echo "=== Skipping run ==="
+  echo "  Use --run-cmd 'amp --dangerously-allow-all --no-notifications --no-ide -x ...' or --manual-live"
+fi
+
+echo "=== Captured Payloads ==="
+count=0
+for file in "$CAPTURE_DIR"/*.json; do
+  [[ -f "$file" ]] || continue
+  count=$((count + 1))
+  echo "--- $(basename "$file") ---"
+  python3 -m json.tool "$file" 2>/dev/null || true
+done
+[[ $count -gt 0 ]] || echo "  (no captures found)"
+
+echo "Probe directory: $PROBE_DIR"

--- a/e2e/agents/amp.go
+++ b/e2e/agents/amp.go
@@ -1,0 +1,115 @@
+package agents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func init() {
+	if env := os.Getenv("E2E_AGENT"); env != "" && env != "amp" {
+		return
+	}
+	Register(&Amp{})
+	RegisterGate("amp", 2)
+}
+
+type Amp struct{}
+
+func (a *Amp) Name() string               { return "amp" }
+func (a *Amp) Binary() string             { return "amp" }
+func (a *Amp) EntireAgent() string        { return "amp" }
+func (a *Amp) PromptPattern() string      { return `>` }
+func (a *Amp) TimeoutMultiplier() float64 { return 1.5 }
+func (a *Amp) IsExternalAgent() bool      { return true }
+
+func (a *Amp) IsTransientError(out Output, _ error) bool {
+	combined := strings.ToLower(out.Stdout + out.Stderr)
+	patterns := []string{
+		"overloaded",
+		"rate limit",
+		"429",
+		"500",
+		"503",
+		"econnreset",
+		"etimedout",
+		"timeout",
+	}
+	for _, pattern := range patterns {
+		if strings.Contains(combined, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *Amp) Bootstrap() error {
+	return nil
+}
+
+func (a *Amp) RunPrompt(ctx context.Context, dir string, prompt string, opts ...Option) (Output, error) {
+	cfg := &runConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	bin, err := exec.LookPath(a.Binary())
+	if err != nil {
+		return Output{}, fmt.Errorf("%s not in PATH: %w", a.Binary(), err)
+	}
+
+	args := []string{"--dangerously-allow-all", "--no-notifications", "--no-ide", "-x", prompt}
+	displayArgs := []string{"--dangerously-allow-all", "--no-notifications", "--no-ide", "-x", fmt.Sprintf("%q", prompt)}
+
+	env := append(filterEnv(os.Environ(), "ENTIRE_TEST_TTY"), "PLUGINS=all")
+
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	cmd.WaitDelay = 5 * time.Second
+
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+	exitCode := 0
+	if err != nil {
+		exitErr := &exec.ExitError{}
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = -1
+		}
+	}
+
+	return Output{
+		Command:  "PLUGINS=all " + a.Binary() + " " + strings.Join(displayArgs, " "),
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+		ExitCode: exitCode,
+	}, err
+}
+
+func (a *Amp) StartSession(ctx context.Context, dir string) (Session, error) {
+	name := fmt.Sprintf("amp-test-%d", time.Now().UnixNano())
+	s, err := NewTmuxSession(name, dir, []string{"ENTIRE_TEST_TTY"}, "env", "PLUGINS=all", a.Binary())
+	if err != nil {
+		return nil, err
+	}
+	if _, err := s.WaitFor(a.PromptPattern(), 30*time.Second); err != nil {
+		_ = s.Close()
+		return nil, fmt.Errorf("waiting for initial prompt: %w", err)
+	}
+	s.stableAtSend = ""
+	return s, nil
+}

--- a/e2e/amp_protocol_test.go
+++ b/e2e/amp_protocol_test.go
@@ -69,7 +69,7 @@ func TestLifecycle_AmpPrepareTranscriptProtocol(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(modified, &modifiedResp))
 	assert.Equal(t, []string{"hello.txt"}, modifiedResp.Files)
-	assert.Equal(t, len(prepared), modifiedResp.CurrentPosition)
+	assert.Equal(t, 3, modifiedResp.CurrentPosition)
 
 	tokens := runAgent(t, binPath, env, prepared, "calculate-tokens", "--offset", "0")
 	assert.JSONEq(t, `{"input_tokens":100,"cache_creation_tokens":3,"cache_read_tokens":7,"output_tokens":25,"api_call_count":1}`, string(tokens))

--- a/e2e/amp_protocol_test.go
+++ b/e2e/amp_protocol_test.go
@@ -1,0 +1,122 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const ampE2EThreadJSON = `{"v":1,"id":"T-e2e-amp","created":1778155200000,"updatedAt":"2026-05-07T12:00:05Z","messages":[{"role":"user","messageId":1,"meta":{"sentAt":1778155200000},"content":[{"type":"text","text":"Create hello.txt"}]},{"role":"assistant","messageId":"a1","meta":{"sentAt":1778155201000},"usage":{"model":"claude","timestamp":"2026-05-07T12:00:01Z","inputTokens":100,"outputTokens":25,"cacheReadInputTokens":7,"cacheCreationInputTokens":3},"content":[{"type":"tool_use","id":"tool1","name":"edit_file","input":{"path":"hello.txt"}},{"type":"text","text":"Created hello.txt"}]},{"role":"user","messageId":2,"meta":{"sentAt":1778155202000},"content":[{"type":"tool_result","toolUseID":"tool1","run":{"status":"done","trackFiles":["hello.txt"],"result":{"output":"ok"}}}]}]}`
+
+func TestLifecycle_AmpPrepareTranscriptProtocol(t *testing.T) {
+	if env := os.Getenv("E2E_AGENT"); env != "" && env != "amp" {
+		t.Skip("amp-specific e2e test")
+	}
+
+	binPath, ok := AgentBinaries["entire-agent-amp"]
+	require.True(t, ok, "entire-agent-amp binary should be built")
+
+	repoRoot := t.TempDir()
+	sessionRef := filepath.Join(repoRoot, ".entire", "tmp", "amp", "T-e2e-amp.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionRef), 0o755))
+	require.NoError(t, os.WriteFile(sessionRef, []byte("{\"type\":\"agent.start\",\"thread_id\":\"T-e2e-amp\",\"message\":\"Create hello.txt\"}\n"), 0o600))
+
+	fakeBinDir := t.TempDir()
+	writeFakeAmp(t, fakeBinDir)
+	env := append(os.Environ(),
+		"ENTIRE_REPO_ROOT="+repoRoot,
+		"PATH="+fakeBinDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+
+	runAgent(t, binPath, env, nil, "prepare-transcript", "--session-ref", sessionRef)
+	prepared := readFile(t, sessionRef)
+	assert.JSONEq(t, ampE2EThreadJSON, string(prepared))
+
+	readTranscript := runAgent(t, binPath, env, nil, "read-transcript", "--session-ref", sessionRef)
+	assert.JSONEq(t, ampE2EThreadJSON, string(readTranscript))
+
+	readSession := runAgent(t, binPath, env, []byte(`{"hook_type":"stop","session_ref":"`+sessionRef+`"}`), "read-session")
+	var session struct {
+		SessionID     string   `json:"session_id"`
+		AgentName     string   `json:"agent_name"`
+		ModifiedFiles []string `json:"modified_files"`
+	}
+	require.NoError(t, json.Unmarshal(readSession, &session))
+	assert.Equal(t, "T-e2e-amp", session.SessionID)
+	assert.Equal(t, "amp", session.AgentName)
+	assert.Equal(t, []string{"hello.txt"}, session.ModifiedFiles)
+
+	prompts := runAgent(t, binPath, env, nil, "extract-prompts", "--session-ref", sessionRef, "--offset", "0")
+	assert.JSONEq(t, `{"prompts":["Create hello.txt"]}`, string(prompts))
+
+	summary := runAgent(t, binPath, env, nil, "extract-summary", "--session-ref", sessionRef)
+	assert.JSONEq(t, `{"summary":"Created hello.txt","has_summary":true}`, string(summary))
+
+	modified := runAgent(t, binPath, env, nil, "extract-modified-files", "--path", sessionRef, "--offset", "0")
+	var modifiedResp struct {
+		Files           []string `json:"files"`
+		CurrentPosition int      `json:"current_position"`
+	}
+	require.NoError(t, json.Unmarshal(modified, &modifiedResp))
+	assert.Equal(t, []string{"hello.txt"}, modifiedResp.Files)
+	assert.Equal(t, len(prepared), modifiedResp.CurrentPosition)
+
+	tokens := runAgent(t, binPath, env, prepared, "calculate-tokens", "--offset", "0")
+	assert.JSONEq(t, `{"input_tokens":100,"cache_creation_tokens":3,"cache_read_tokens":7,"output_tokens":25,"api_call_count":1}`, string(tokens))
+
+	compact := runAgent(t, binPath, env, nil, "compact-transcript", "--session-ref", sessionRef)
+	var compactResp struct {
+		Transcript string `json:"transcript"`
+	}
+	require.NoError(t, json.Unmarshal(compact, &compactResp))
+	decoded, err := base64.StdEncoding.DecodeString(compactResp.Transcript)
+	require.NoError(t, err)
+	assert.Contains(t, string(decoded), `"agent":"amp"`)
+	assert.Contains(t, string(decoded), `"type":"assistant"`)
+	assert.Contains(t, string(decoded), `"input_tokens":100`)
+	assert.Contains(t, string(decoded), `"result":{"output":"ok","status":"success"}`)
+}
+
+func writeFakeAmp(t *testing.T, dir string) {
+	t.Helper()
+	path := filepath.Join(dir, "amp")
+	script := `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "threads" && "$2" == "export" && "$3" == "T-e2e-amp" ]]; then
+  printf '%s' '` + ampE2EThreadJSON + `'
+  exit 0
+fi
+echo "unexpected amp args: $*" >&2
+exit 2
+`
+	require.NoError(t, os.WriteFile(path, []byte(script), 0o755))
+}
+
+func runAgent(t *testing.T, binPath string, env []string, stdin []byte, args ...string) []byte {
+	t.Helper()
+	cmd := exec.Command(binPath, args...)
+	cmd.Env = env
+	if stdin != nil {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "entire-agent-amp %s failed:\n%s", strings.Join(args, " "), out)
+	return out
+}
+
+func readFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return data
+}


### PR DESCRIPTION
This PR adds [Amp](https://ampcode.com) external agent. 


## Notes
- The current stable version of amp only load plugins when user runs `PLUGINS=all amp`. The [Neo version](https://ampcode.com/news/neo) stabilized the plugin API and can be run without setting the env.
- Amp stores authoritative threads server-side, so the threads are exported for transcript passing.  
- After this is merged and released, entire web will need to add the functionality to parse the sessions transcripts. `agents/entire-agent-amp/internal/amp/types.go` can be used as reference. 

 Example of [amp session](https://entire.io/gh/savekirk/entire-test/session/T-019e17cf-3412-72a0-80ad-4764b4836402)

[Amp plugin guide](https://ampcode.com/manual#plugins)
[Amp plugin API](https://ampcode.com/manual/plugin-api)