### PR TITLE
Add CONTRIBUTING.md and first-time contributors guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,434 @@
+# Contributing to Entire External Agents
+
+Thank you for your interest in contributing! If the
+[Entire CLI](https://github.com/entireio/cli) doesn't already integrate
+with the AI coding agent you use, this is the repository where you can add
+that support. Each integration lives in its own directory under
+[`agents/`](agents/) as a small standalone Go program that lets Entire hook
+into a specific coding tool to capture checkpoints, transcripts, and
+lifecycle events.
+
+**You don't have to build it from scratch.** This repo ships a built-in
+skill that walks an AI coding tool (Claude Code, Codex, Cursor, or
+OpenCode) through researching the target agent, scaffolding tests, and
+implementing the binary. It gets you most of the way to a working
+integration. See [Adding a New External Agent](#adding-a-new-external-agent)
+below for how to invoke it.
+
+Please read the [Entire CLI Code of Conduct](https://github.com/entireio/cli/blob/main/CODE_OF_CONDUCT.md)
+before participating.
+
+> **New to Entire?** See the [First-Time Contributors guide](doc/first-time-contributors.md)
+> for a step-by-step first contribution walkthrough, or the [README](README.md)
+> for setup and architecture documentation.
+
+---
+
+## Before You Code: Discuss First
+
+The fastest way to get a contribution merged is to align with maintainers before
+writing code. Please **open an issue first** describing what you want to change,
+and wait for maintainer feedback before starting implementation. This is
+especially true if you want to add support for a brand-new agent. That work
+is a long-running commitment the maintainers will need to support.
+
+### Contribution Workflow
+
+1. **Open an issue** describing the problem, feature, or new agent
+2. **Wait for maintainer feedback**: we may have relevant context or plans
+3. **Get approval** before starting implementation
+4. **Submit your PR** referencing the approved issue
+5. **Address all feedback** including automated Copilot comments
+6. **Maintainer review and merge**
+
+---
+
+## First-Time Contributors
+
+New to the project? Welcome! Start with the
+[First-Time Contributors guide](doc/first-time-contributors.md). It explains
+how to find a comfortable issue, ask for a scoped starter task, set up the
+repo, use AI responsibly, run the right checks, and open your first pull
+request.
+
+### Starter Contributions
+
+We recommend starting with:
+
+- **A protocol compliance gap**: An existing agent fails a check against
+  [`entireio/external-agents-tests`](https://github.com/entireio/external-agents-tests)
+  on your machine; add a focused fix.
+- **A lifecycle test failure you can reproduce**: The `e2e/` harness flagged
+  something; capture it as a narrower test and a fix.
+- **Confusing output or help text** in an existing agent's CLI.
+- **Documentation friction**: Improve this repo's README, agent READMEs, or
+  contributor docs after you hit a real problem.
+- **An agent unit test** that covers existing behavior without changing it.
+
+Adding support for a brand-new agent is welcome but is not a first-PR
+shape. Open an issue first and expect the work to span multiple PRs.
+
+Browse [GitHub Issues](https://github.com/entireio/external-agents/issues), or
+ask in the `#looking-for-contributors` channel on the
+[Entire Discord](https://discord.gg/jZJs3Tue4S) if you want help finding a
+starter-sized slice.
+
+Using a coding agent while contributing is welcome (this repo is literally
+about coding-agent integration), but you are responsible for the final diff.
+Review AI-generated changes yourself before opening a PR.
+
+---
+
+## Submitting Issues
+
+All feature requests, bug reports, and general issues should be submitted
+through [GitHub Issues](https://github.com/entireio/external-agents/issues).
+Please search for existing issues before opening a new one.
+
+For security-related issues, see the Security section below.
+
+---
+
+## Security
+
+If you discover a security vulnerability, **do not report it through GitHub
+Issues**. Instead, follow the disclosure process described in the
+[Entire CLI SECURITY.md](https://github.com/entireio/cli/blob/main/SECURITY.md).
+All security reports are kept confidential.
+
+---
+
+## Communication
+
+Contributions and communications are expected to occur through:
+
+- [GitHub Issues](https://github.com/entireio/external-agents/issues): Bug
+  reports and feature requests
+- [Discord](https://discord.gg/jZJs3Tue4S): Questions, general conversation,
+  and real-time support
+
+Please represent the project and community respectfully in all public and
+private interactions.
+
+---
+
+## How to Contribute
+
+There are many ways to contribute:
+
+- **Fix or extend an existing agent** under [`agents/`](agents/)
+- **Improve the lifecycle harness**: The shared `e2e/` tests that exercise
+  every agent
+- **Add a new external agent**: Discuss in an issue first; the
+  [external agent builder skill](.claude/skills/entire-external-agent/) walks
+  you through the full pipeline
+- **Documentation**: Improve READMEs, agent docs, contributor instructions
+- **Community**: Help others on Discord, answer questions, share knowledge
+
+---
+
+## Reporting Bugs
+
+Good bug reports help us fix issues quickly. When reporting a bug, please
+include:
+
+### Required Information
+
+1. **Affected agent**: which directory under `agents/`, or "the `e2e/`
+   harness"
+2. **Entire CLI version**: run `entire version`
+3. **Operating system**
+4. **Go version**: run `go version`
+5. **mise version**: run `mise --version`
+
+### What to Include
+
+1. **What did you do?**: Include the exact commands you ran
+2. **What did you expect to happen?**
+3. **What actually happened?**: Include the full error message or unexpected
+   output (especially the JSON returned by the agent if a protocol check
+   failed)
+4. **Can you reproduce it?**: Does it happen every time or intermittently?
+5. **Any additional context?**: Logs, lifecycle artifacts from
+   `e2e/artifacts/`, related issues
+
+---
+
+## Local Setup
+
+### Prerequisites
+
+- **Go 1.26.x**: mise will install the pinned version
+- **mise**: Task runner and version manager. Install with
+  `curl https://mise.run | sh`
+- **The target agent's own CLI** if you plan to run lifecycle tests against
+  it. Each agent's README under [`agents/`](agents/) lists what it expects.
+
+### Clone and Install
+
+```bash
+# Clone the repository
+git clone https://github.com/entireio/external-agents.git
+cd external-agents
+
+# Trust the mise configuration (required on first setup)
+mise trust
+
+# Install pinned tools (Go, golangci-lint, license_finder, ...)
+mise install
+
+# Build every agent binary into ./bin
+mise run build
+
+# Verify setup by running unit tests across all agents
+mise run test
+```
+
+See the [README](README.md) for the wider repository layout and the testing
+split between protocol compliance, lifecycle integration, and unit tests.
+
+---
+
+## Making Changes
+
+1. **Create a branch** for your changes:
+
+   ```bash
+   git checkout -b fix/short-description
+   ```
+
+2. **Make your changes**: follow the [Code Style](#code-style) guidelines
+   and keep the change narrow.
+
+3. **Test your changes**: see [Testing](#testing).
+
+4. **Commit** with clear, descriptive messages:
+
+   ```bash
+   git commit -m "kiro: clarify missing-config error"
+   ```
+
+   When a commit touches a single agent, prefix the subject with the agent
+   name (e.g. `kiro:`). Cross-cutting changes (the lifecycle harness, shared
+   docs, CI) can omit the prefix.
+
+---
+
+## Code Style
+
+Follow standard Go idioms and conventions.
+
+### Key Points
+
+- **Error handling**: Handle all errors explicitly. Don't leave them
+  unchecked.
+- **Formatting**: Code must pass `gofmt` (run `mise run fmt`).
+- **Linting**: Code must pass `golangci-lint`. The config lives at
+  [.golangci.yaml](.golangci.yaml).
+- **Naming**: Use meaningful, descriptive names following Go conventions.
+- **Protocol surface**: When changing a subcommand's JSON output, keep it
+  compatible with the [external agent protocol spec](https://github.com/entireio/cli/blob/main/docs/architecture/external-agent-protocol.md).
+  Add or update protocol-compliance coverage in
+  [`entireio/external-agents-tests`](https://github.com/entireio/external-agents-tests)
+  in the same PR cycle.
+
+---
+
+## Testing
+
+Testing is intentionally split into three layers (see [README](README.md) for
+the full picture):
+
+| Layer | Where it lives | When to run |
+|-------|----------------|-------------|
+| Protocol compliance | `entireio/external-agents-tests` (run in CI via [protocol-compliance.yml](.github/workflows/protocol-compliance.yml)) | When you change subcommand JSON, exit codes, or protocol surface |
+| Lifecycle integration | `e2e/` in this repo | When you change anything that interacts with `entire enable`, hooks, checkpoints, or rewind |
+| Unit | `agents/entire-agent-*/` | Always, before pushing |
+
+```bash
+# Unit tests across all agents (default suite)
+mise run test
+
+# Lifecycle integration tests against every registered agent
+mise run test:e2e
+
+# Same as test:e2e, kept as the explicit name
+mise run test:e2e:lifecycle
+
+# Limit lifecycle runs to one agent while iterating
+E2E_AGENT=kiro mise run test:e2e
+```
+
+CI also runs the protocol compliance suite against every built binary. You do
+not normally need to run that locally, but you can mirror it with:
+
+```bash
+# After mise run build, run the shared compliance suite against one binary
+external-agents-tests --binary-path ./bin/entire-agent-kiro
+```
+
+The lifecycle harness calls the real agent CLIs, so the corresponding tool
+must be on your PATH. See each agent's README for setup hints, and use
+`E2E_KEEP_REPOS=1` if you need to inspect a failed run's temp repo.
+
+---
+
+## Adding a New External Agent
+
+This is a substantial change. Please open an issue first and expect to split
+the work across multiple PRs. When you are ready to start, the repo ships a
+skill that walks through the full pipeline:
+
+| Command | Skill file | Description |
+|---------|-----------|-------------|
+| Full pipeline | [`.claude/skills/entire-external-agent/SKILL.md`](.claude/skills/entire-external-agent/SKILL.md) | Run all three phases sequentially |
+| Research | [`.claude/skills/entire-external-agent/research.md`](.claude/skills/entire-external-agent/research.md) | Analyze the target agent and map to the protocol |
+| Write tests | [`.claude/skills/entire-external-agent/write-tests.md`](.claude/skills/entire-external-agent/write-tests.md) | Scaffold the binary, wire protocol + lifecycle coverage |
+| Implement | [`.claude/skills/entire-external-agent/implement.md`](.claude/skills/entire-external-agent/implement.md) | Build the binary using protocol compliance first, lifecycle second, unit tests last |
+
+The skill auto-discovers per AI tool:
+
+| Tool | How it discovers | What to say |
+|------|------------------|-------------|
+| Claude Code | `.claude/skills/` | `/entire-external-agent` |
+| Codex | `AGENTS.md` | "Build an external agent" |
+| Cursor | `.cursor/rules/` | "Build an external agent" |
+| OpenCode | `.opencode/plugins/` | "Build an external agent" |
+
+For a newly added agent to be picked up automatically by local tasks and CI,
+make sure your `agents/entire-agent-<name>/mise.toml` defines `build` and
+`test` tasks. The shared runner falls back to Go defaults when only `go.mod`
+exists, but the `mise` tasks are the contract for anything non-standard.
+
+---
+
+## Submitting a Pull Request
+
+### Before You Submit
+
+- **Related issue exists and is approved**: Your PR references an issue
+  where a maintainer has acknowledged the approach. (Exceptions: typo
+  corrections, wording-only updates, and maintainer-scoped starter tasks.)
+- **Formatting passes**: `mise run fmt` leaves the tree clean.
+- **Linting passes**: `golangci-lint` clean.
+- **Tests pass**: `mise run test` for unit tests; `mise run test:e2e` if
+  your change is lifecycle-relevant.
+- **Tests included**: New Go code and protocol behavior should ship with
+  accompanying tests at the right layer.
+- **Entire checkpoint trailers included**: See
+  [Using Entire While Contributing](#using-entire-while-contributing).
+
+PRs that skip these steps are likely to be closed without merge.
+
+### Submitting
+
+1. **Push** your branch to your fork.
+2. **Open a PR** against the `main` branch.
+3. **Describe your changes**: Link the related issue, name which agent(s)
+   are affected, summarize what changed and what testing you did.
+4. **Address Copilot feedback**: See [Responding to Automated Review](#responding-to-automated-review).
+5. **Wait for maintainer review.**
+
+---
+
+## Responding to Automated Review
+
+A Copilot reviewer comments on every PR with feedback on code quality,
+potential bugs, and project conventions.
+
+**Read and respond to every Copilot comment.** PRs with unaddressed Copilot
+feedback will not move to maintainer review.
+
+- **Fixed**: Push a commit addressing the issue.
+- **Disagree**: Reply explaining your reasoning. Copilot isn't always right.
+- **Question**: Ask for clarification.
+
+Addressing Copilot feedback upfront is the fastest path to maintainer review.
+
+---
+
+## Using Entire While Contributing
+
+We use Entire on Entire. When contributing to this repo, install the Entire
+CLI and let it capture your coding sessions. This gives us valuable
+dogfooding data and helps improve the tool.
+
+### Setup
+
+Install the latest version of the Entire CLI (see
+[installation docs](https://docs.entire.io/cli/installation)) and verify with
+`entire version`. Entire is already configured in this repository, so there is
+no need to run `entire enable`.
+
+### Checkpoint Trailers
+
+All commits should include `Entire-Checkpoint` trailers from your sessions.
+These are added automatically by the `prepare-commit-msg` hook when Entire is
+enabled. The trailers link your commits to session metadata on the
+`entire/checkpoints/v1` branch.
+
+### Sessions Branch
+
+When you push your PR branch, Entire can automatically push the
+`entire/checkpoints/v1` branch alongside it (if `push_sessions` is enabled in
+your settings). Including it lets maintainers see the session context behind
+your changes.
+
+---
+
+## Troubleshooting
+
+### Common Setup Issues
+
+**`mise install` fails**
+
+```bash
+# Ensure mise is properly installed
+curl https://mise.run | sh
+
+# Reload your shell
+source ~/.zshrc  # or ~/.bashrc
+```
+
+**`go mod download` fails with timeout**
+
+```bash
+# Try using direct mode
+GOPROXY=direct go mod download
+```
+
+**Lifecycle test cannot find the agent CLI**
+
+The lifecycle harness invokes the real agent CLI. Make sure the tool is
+installed and on your PATH, or set the corresponding override described in
+the agent's README.
+
+**Lifecycle test passes locally but fails in CI (or vice versa)**
+
+Set `E2E_KEEP_REPOS=1` and re-run with `E2E_AGENT=<name>` to capture the temp
+repo for inspection. Lifecycle artifacts are written under `e2e/artifacts/`;
+attach the relevant ones to the issue or PR.
+
+---
+
+## Community
+
+Join the Entire community:
+
+- **Discord**: [Join our server][discord] for discussions and support
+
+[discord]: https://discord.gg/jZJs3Tue4S
+
+---
+
+## Additional Resources
+
+- [README](README.md): Setup, architecture, and the testing split
+- [AGENTS.md](AGENTS.md): Agent-builder skill entry point (Codex/Cursor/OpenCode)
+- [External agent protocol spec](https://github.com/entireio/cli/blob/main/docs/architecture/external-agent-protocol.md): The contract every agent binary implements
+- [Entire CLI Code of Conduct](https://github.com/entireio/cli/blob/main/CODE_OF_CONDUCT.md): Community guidelines
+- [Entire CLI Security Policy](https://github.com/entireio/cli/blob/main/SECURITY.md): Reporting security vulnerabilities
+
+---
+
+Thank you for contributing!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ implementing the binary. It gets you most of the way to a working
 integration. See [Adding a New External Agent](#adding-a-new-external-agent)
 below for how to invoke it.
 
-Please read the [Entire CLI Code of Conduct](https://github.com/entireio/cli/blob/main/CODE_OF_CONDUCT.md)
+Please read the [Code of Conduct](https://github.com/entireio/cli/blob/main/CODE_OF_CONDUCT.md)
 before participating.
 
 > **New to Entire?** See the [First-Time Contributors guide](doc/first-time-contributors.md)
@@ -93,7 +93,7 @@ For security-related issues, see the Security section below.
 
 If you discover a security vulnerability, **do not report it through GitHub
 Issues**. Instead, follow the disclosure process described in the
-[Entire CLI SECURITY.md](https://github.com/entireio/cli/blob/main/SECURITY.md).
+[Security Policy](https://github.com/entireio/cli/blob/main/SECURITY.md).
 All security reports are kept confidential.
 
 ---
@@ -426,8 +426,8 @@ Join the Entire community:
 - [README](README.md): Setup, architecture, and the testing split
 - [AGENTS.md](AGENTS.md): Agent-builder skill entry point (Codex/Cursor/OpenCode)
 - [External agent protocol spec](https://github.com/entireio/cli/blob/main/docs/architecture/external-agent-protocol.md): The contract every agent binary implements
-- [Entire CLI Code of Conduct](https://github.com/entireio/cli/blob/main/CODE_OF_CONDUCT.md): Community guidelines
-- [Entire CLI Security Policy](https://github.com/entireio/cli/blob/main/SECURITY.md): Reporting security vulnerabilities
+- [Code of Conduct](https://github.com/entireio/cli/blob/main/CODE_OF_CONDUCT.md): Community guidelines
+- [Security Policy](https://github.com/entireio/cli/blob/main/SECURITY.md): Reporting security vulnerabilities
 
 ---
 

--- a/doc/first-time-contributors.md
+++ b/doc/first-time-contributors.md
@@ -1,0 +1,342 @@
+# First-Time Contributors
+
+Welcome. This guide is for people who are new to Entire, new to open source,
+or just want a careful path through their first contribution to this
+repository.
+
+If the [Entire CLI](https://github.com/entireio/cli) doesn't already work
+with the AI coding agent you use, this repo is where you can add that
+support. The [README](../README.md) goes into more detail on what that
+involves. You can still pick up a small task here without understanding the
+whole system first.
+
+Good to know up front: this repo ships a built-in skill that walks an AI
+coding tool (Claude Code, Codex, Cursor, or OpenCode) through scaffolding
+a new agent. It gets you most of the way to a working integration. Adding
+a brand-new agent still isn't a first-PR shape (the work tends to span
+multiple pull requests), but it's useful to know the skill exists. See
+[Adding a New External Agent](../CONTRIBUTING.md#adding-a-new-external-agent)
+in CONTRIBUTING.md.
+
+The main contribution rules live in [CONTRIBUTING.md](../CONTRIBUTING.md).
+Treat that file as the source of truth. This page slows the process down and
+explains where to start, what to say, what to run, and what to expect after
+you open a pull request.
+
+## Who This Is For
+
+Start here if any of these are true:
+
+- You have never opened a pull request before.
+- You have contributed to other projects, but not to Entire.
+- You want help finding a contribution that is small enough to finish.
+- You are unsure how to ask maintainers for the right amount of context.
+
+If you are already comfortable with this repo, use the shorter workflow in
+[CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Choose a First Contribution
+
+Start by browsing
+[GitHub Issues](https://github.com/entireio/external-agents/issues) for issues
+that describe behavior you can reproduce, mention a command or workflow you
+can try locally, or feel concrete enough that you can explain the problem
+back in your own words. You can also check the `#looking-for-contributors`
+channel in [Discord](https://discord.gg/jZJs3Tue4S). You do not need to
+understand the whole project before asking about an issue.
+
+Good first contributions are small, clear, and easy to review. For this repo,
+that usually means one of these:
+
+- Reproducing a bug in one of the existing agents under [`agents/`](../agents/)
+  and adding the missing test.
+- Clarifying a confusing message in an agent's CLI output.
+- Adding a focused test around existing protocol or lifecycle behavior.
+- Tightening a lifecycle assertion in `e2e/` that is currently lax.
+- Improving README, agent README, or contributor instructions after you hit
+  real friction.
+
+When looking at an issue, favor ones where you can explain the problem back
+in your own words. It is okay if you do not know the fix yet. If an issue is
+broad, comment with the part you think you can tackle and ask whether that
+slice would be useful.
+
+If you do not already have a specific problem in mind, ask in
+`#looking-for-contributors` and mention what you are comfortable with, such
+as Go tests, CLI output, protocol JSON, lifecycle assertions, or README
+wording. A maintainer can usually point you toward a safer slice than
+browsing alone can.
+
+**Not a first-PR shape:** adding support for a brand-new agent. That work is
+long-running, involves protocol design choices, and almost always spans
+multiple pull requests. If that is what you ultimately want to do, get
+comfortable with the repo on something smaller first, then open an issue to
+scope the new agent.
+
+Also avoid, for a first PR: changes to the lifecycle harness's `TestMain` /
+agent discovery, changes to the protocol-compliance workflow, and anything
+that changes how checkpoints or hooks are installed, unless a maintainer
+has already helped define the scope.
+
+## Comment Before You Start
+
+Before starting non-trivial code work, leave a short comment on the issue or
+start a new issue. This helps avoid duplicated effort and gives maintainers
+a chance to redirect you before you spend time on the wrong approach.
+
+A good first comment is specific:
+
+```text
+Hi, I am new to Entire external agents and would like to work on this.
+
+I was able to reproduce the issue by running:
+
+  E2E_AGENT=kiro mise run test:e2e
+
+My plan is to <describe the change> in
+agents/entire-agent-kiro/<file or area> and add a focused test for the
+behavior. Does that sound like the right direction?
+```
+
+If you are not starting from an existing issue, open one with the smallest
+concrete problem you can describe:
+
+```text
+I hit confusing behavior while running `entire-agent-kiro <subcommand>` on
+macOS.
+
+Expected: <what you thought would happen>
+Actual: <what actually happened, with the JSON output if relevant>
+
+I can reproduce this locally. Would a small PR that fixes the message and
+adds a focused unit test be useful?
+```
+
+You do not need a perfect plan. Showing what you have tried and where you are
+headed is usually enough.
+
+## Set Up the Repository
+
+Fork the repository on GitHub, then clone your fork:
+
+```bash
+git clone git@github.com:YOUR-USERNAME/external-agents.git
+cd external-agents
+```
+
+Add the upstream repository so you can pull in maintainer changes later:
+
+```bash
+git remote add upstream git@github.com:entireio/external-agents.git
+git fetch upstream
+```
+
+Install the local toolchain:
+
+```bash
+mise trust
+mise install
+mise run build
+```
+
+`mise run build` builds every agent binary into `./bin`. Verify the setup
+with the unit test suite:
+
+```bash
+mise run test
+```
+
+If you plan to touch the lifecycle harness, also install the relevant
+agent's own CLI so the harness can drive it. Each agent's README under
+[`agents/`](../agents/) lists its requirements.
+
+If setup fails, include the command you ran, the full error text, your OS,
+and the output of `go version` and `mise --version` when asking for help.
+
+## Create a Branch
+
+Create a branch from the latest `main`:
+
+```bash
+git switch main
+git pull upstream main
+git switch -c fix/short-description
+```
+
+Use a branch name that describes the change. Examples:
+
+- `fix/kiro-clearer-missing-config-error`
+- `test/pi-transcript-token-edge-case`
+- `docs/lifecycle-setup-troubleshooting`
+
+## Make a Small Change
+
+Keep your first pull request narrow. A focused PR is easier to review and
+easier to finish.
+
+Good first PR shapes for this repo:
+
+- One failing behavior in a single agent, plus its test.
+- One small CLI message improvement in a single agent.
+- One test-only clarification or assertion tightening.
+- One README or setup clarification based on a real problem you hit.
+
+Avoid bundling unrelated cleanup with your first PR. If you notice extra
+things while working, leave yourself a note and open a follow-up issue or PR
+later.
+
+If you find yourself touching more than one agent, or both the agent and the
+shared lifecycle harness, pause and ask whether the change should be split.
+
+## Use AI Carefully
+
+This repository is, in part, about coding-agent integration, so it is
+completely normal to use a coding agent while contributing here. There is no
+need to tell us that you used AI.
+
+Use whatever agent and workflow you like. The important rule is that you are
+responsible for the final code, tests, and docs. Before submitting a PR,
+review the diff yourself. PRs that look generated, unreviewed, or "vibe
+coded" without a human pass may be closed.
+
+Quick responsible-AI tips:
+
+- **Think first.** Agents tend to jump straight to code. Ask the agent to
+  explore the codebase first, explain the relevant architecture (especially
+  the [external agent protocol spec](https://github.com/entireio/cli/blob/main/docs/architecture/external-agent-protocol.md)),
+  and propose an approach before it edits files.
+- **Push back on shortcuts.** Watch for trivial tests, overly wide types,
+  optional fields added just to satisfy the compiler, swallowed errors, and
+  patterns copied from one agent into another that do not actually fit.
+- **Notice uncertainty.** If the agent keeps declaring it understands the
+  issue but the patches are not converging, stop and reframe. Use what you
+  learned to start a smaller attempt.
+- **Cut the bloat.** Remove redundant comments, just-in-case logging,
+  over-defensive branches, and tests that only check implementation details
+  instead of user-visible or protocol-visible behavior.
+
+## Run the Right Checks
+
+For wording-only changes, run a lightweight sanity check:
+
+```bash
+git diff --check
+```
+
+For Go code changes in a single agent, run:
+
+```bash
+mise run fmt
+mise run test
+```
+
+For changes that touch the shared lifecycle harness or protocol surface, also
+run:
+
+```bash
+mise run test:e2e
+```
+
+You can narrow lifecycle runs while iterating:
+
+```bash
+E2E_AGENT=kiro mise run test:e2e
+```
+
+Protocol compliance runs in CI against every built binary, so you do not
+normally need to run it locally. If you want to mirror it, build first
+(`mise run build`) and then run `external-agents-tests --binary-path
+./bin/entire-agent-<name>` against the binary you care about.
+
+Do not assume tests passing locally is enough on its own. The GitHub Actions
+workflow runs the protocol compliance suite against every agent on every PR,
+so watch the PR checks after you push.
+
+## Commit Your Work
+
+Commit with a short, descriptive message. When your change touches a single
+agent, prefix the subject with the agent name:
+
+```bash
+git add <files you changed>
+git commit -m "kiro: clarify error when config is missing"
+```
+
+Cross-cutting changes (the lifecycle harness, shared docs, CI) can omit the
+prefix.
+
+Entire is used to dogfood Entire. If you have the Entire CLI installed and
+enabled in this repository, the git hook may add an `Entire-Checkpoint`
+trailer to your commit message automatically. That is expected. See
+[Using Entire While Contributing](../CONTRIBUTING.md#using-entire-while-contributing)
+for the full details.
+
+## Open a Pull Request
+
+Push your branch to your fork:
+
+```bash
+git push -u origin fix/short-description
+```
+
+Then open a pull request against `entireio/external-agents` on GitHub.
+
+In the PR description, include:
+
+- The issue it addresses, if there is one.
+- Which agent(s) are affected (e.g. `entire-agent-kiro`) or "shared
+  lifecycle harness".
+- A short summary of what changed.
+- The checks you ran, such as `mise run test`, `mise run test:e2e`, or
+  `git diff --check`.
+- Anything you want reviewers to pay special attention to.
+
+If your PR is not ready for final review yet, open it as a draft. Draft PRs
+are useful when you want early feedback on direction.
+
+## Respond to Review
+
+Review is part of the contribution, not a sign that you did something wrong.
+PRs here may receive automated Copilot comments and maintainer comments.
+
+For each review comment:
+
+- If it is right, push a follow-up commit that addresses it.
+- If you are unsure, ask a question on the PR.
+- If you disagree, explain your reasoning briefly and respectfully.
+
+After pushing updates, leave a short comment saying what changed. GitHub does
+not always make it obvious which comments were addressed by a new commit.
+
+## If You Get Stuck
+
+Ask early, and include context. Good help requests include:
+
+- What you are trying to do.
+- The command you ran (and `E2E_AGENT=...` if relevant).
+- The exact error or output, including the raw JSON line if a protocol check
+  failed.
+- What you already checked.
+- Your OS, Go version, and `mise --version` when setup or tests are
+  involved.
+
+Useful places to ask:
+
+- The GitHub issue you are working on.
+- The pull request, if one is already open.
+- [Discord](https://discord.gg/jZJs3Tue4S) for general questions.
+
+## Quick Checklist
+
+Before opening your first PR:
+
+- You picked a small, focused change in a single area.
+- You asked for maintainer scope before non-trivial code work.
+- You created a branch from current `main`.
+- You ran the checks that match your change (`mise run test`, and
+  `mise run test:e2e` if lifecycle-relevant).
+- Your PR description names the affected agent(s) and explains what changed
+  and how you tested it.
+
+Thank you for taking the time to contribute. Small, careful improvements
+make the project easier for the next person too.


### PR DESCRIPTION
## Summary

Adds two new contributor docs, modeled on the cli repo's [`CONTRIBUTING.md`](https://github.com/entireio/cli/blob/main/CONTRIBUTING.md) and [`docs/first-time-contributors.md`](https://github.com/entireio/cli/blob/main/docs/first-time-contributors.md) (PR [entireio/cli#1189](https://github.com/entireio/cli/pull/1189)), but adapted to this repo's specifics:

- **[CONTRIBUTING.md](./CONTRIBUTING.md)** at the root: workflow, starter tasks, local setup (`mise install` / `mise run build` / `mise run test`), the three-layer test split (protocol compliance / lifecycle / unit), how to add a new external agent via the built-in skill, PR submission, Copilot review handling, dogfooding Entire while contributing, and troubleshooting.
- **[doc/first-time-contributors.md](./doc/first-time-contributors.md)**: a slower walkthrough for first-time / new-to-the-project contributors, covering issue discovery, scoping with maintainers, fork/clone/branch, AI usage tips, the right local checks for the change shape, commit/PR workflow, and what to expect during review.

## Notable framing choices

- **Entry-point framing:** both intros lead with "if the Entire CLI doesn't already work with the AI coding agent you use, this repo is where you add that support" rather than "this repo hosts standalone Go binaries called `entire-agent-<name>`." Implementation detail moved out of the welcome paragraph.
- **Skill is front-loaded** in both docs: readers learn up front that the `entire-external-agent` skill (Claude Code / Codex / Cursor / OpenCode) gets them most of the way to a working integration, so they don't assume new-agent work means starting from scratch.
- **Adding a brand-new agent is explicitly flagged as not a first-PR shape** in the first-time guide, while still pointing at the skill so the reader knows the path exists.
- **Specific agents are not enumerated** in prose; concrete agent names appear only as illustrative examples in commands, branch names, and commit prefixes (so the doc doesn't go stale when an agent is added or removed).
- **Code of Conduct and Security policy** link to the cli repo's canonical versions since this repo doesn't ship its own.
- **Commit subject prefix convention** introduced (e.g. `kiro:`) because this repo has multiple agents and the prefix keeps history scannable.

## Test plan

- [ ] Render both files on GitHub and confirm headings, code blocks, and tables look correct.
- [ ] Confirm intra-doc anchors resolve: `CONTRIBUTING.md#adding-a-new-external-agent`, `CONTRIBUTING.md#using-entire-while-contributing`, `CONTRIBUTING.md#responding-to-automated-review`.
- [ ] Confirm cross-doc links resolve: `CONTRIBUTING.md` → `doc/first-time-contributors.md`, and back.
- [ ] Spot-check external links to the cli repo's CODE_OF_CONDUCT.md and SECURITY.md, and to the external agent protocol spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)