### PR TITLE
Document Amp agent and external agent opt-in flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,21 @@ External agents communicate with Entire CLI via subcommands that accept and retu
 |-------|-----------|--------|
 | [Kiro](agents/entire-agent-kiro/) | `agents/entire-agent-kiro/` | Implemented — hooks + transcript analysis |
 | [Pi](agents/entire-agent-pi/) | `agents/entire-agent-pi/` | Implemented — hooks + transcript analysis + token calculation + compact transcripts |
+| [Amp](agents/entire-agent-amp/) | `agents/entire-agent-amp/` | Implemented — hooks + transcript analysis + token calculation + compact transcripts |
 
 See each agent's own README for setup and usage instructions.
+
+## Enabling External Agents
+
+External agent discovery is opt-in. Once an `entire-agent-<name>` binary is on your `PATH`, set `external_agents: true` in the repo's `.entire/settings.json` so Entire scans for it:
+
+```json
+{
+  "external_agents": true
+}
+```
+
+Without this flag, Entire ignores external agent binaries even when they're installed.
 
 ## Building a New External Agent
 


### PR DESCRIPTION
## Summary
- Add Amp to the implemented external agents table in the README
- Document the `external_agents: true` opt-in flag in `.entire/settings.json` required for Entire to discover external agent binaries

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Confirm Amp agent link resolves to `agents/entire-agent-amp/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes: adds an Amp entry and explains the `external_agents: true` opt-in setting; no runtime or behavior changes in this repo.
> 
> **Overview**
> **Documentation update for external agent usage.** The README now lists the Amp agent as an implemented external agent.
> 
> It also documents that external agent discovery is *opt-in* and requires setting `external_agents: true` in `.entire/settings.json` even when `entire-agent-<name>` binaries are on `PATH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a95e0ea567d84c357bd0edfcd0ab4253e8462747. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->