### PR TITLE
Add Qwen Code external agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ External agents communicate with Entire CLI via subcommands that accept and retu
 |-------|-----------|--------|
 | [Kiro](agents/entire-agent-kiro/) | `agents/entire-agent-kiro/` | Implemented — hooks + transcript analysis |
 | [Amp](agents/entire-agent-amp/) | `agents/entire-agent-amp/` | Implemented — hooks + transcript analysis + token calculation + compact transcripts |
+| [Qwen Code](agents/entire-agent-qwen/) | `agents/entire-agent-qwen/` | Implemented — hooks + transcript analysis + compact transcripts |
 
 See each agent's own README for setup and usage instructions.
 
@@ -32,6 +33,22 @@ External agent discovery is opt-in. Once an `entire-agent-<name>` binary is on y
 ```
 
 Without this flag, Entire ignores external agent binaries even when they're installed.
+
+### Qwen Code
+
+Qwen support targets the terminal `qwen` coding agent:
+
+```bash
+cd agents/entire-agent-qwen
+mise run build
+cp entire-agent-qwen /usr/local/bin/
+
+cd /path/to/your/repo
+entire enable --agent qwen --telemetry=false
+qwen -p "Create hello.txt with hello world" --yolo
+```
+
+The adapter installs Qwen command hooks in `.qwen/settings.json` and stores a stable Entire sidecar transcript in `.entire/tmp/qwen/`.
 
 ## Building a New External Agent
 
@@ -104,6 +121,7 @@ The lifecycle harness auto-discovers and builds all agents in `agents/` via `Tes
 | `E2E_ARTIFACT_DIR` | Override lifecycle artifact output directory |
 | `E2E_KEEP_REPOS` | Preserve temp repos for debugging |
 | `E2E_CONCURRENT_TEST_LIMIT` | Override the per-agent lifecycle concurrency limit |
+| `QWEN_E2E` | Set to `1` with `E2E_AGENT=qwen` to run live Qwen Code lifecycle tests |
 
 ## Repository Layout
 
@@ -111,6 +129,7 @@ The lifecycle harness auto-discovers and builds all agents in `agents/` via `Tes
 agents/                          # Standalone external agent projects
   entire-agent-kiro/             # Kiro agent (Go binary)
   entire-agent-amp/              # Amp agent (Go binary)
+  entire-agent-qwen/             # Qwen Code agent (Go binary)
 e2e/                             # Lifecycle integration harness
 .github/workflows/               # CI, including protocol compliance via external-agents-tests
 .claude/skills/entire-external-agent/  # Skill files (research, test-writer, implementer)

--- a/agents/entire-agent-qwen/.gitignore
+++ b/agents/entire-agent-qwen/.gitignore
@@ -1,0 +1,1 @@
+entire-agent-qwen

--- a/agents/entire-agent-qwen/AGENT.md
+++ b/agents/entire-agent-qwen/AGENT.md
@@ -1,0 +1,56 @@
+# Qwen Code — External Agent Research
+
+## Verdict: Compatible
+
+Qwen Code exposes command hooks in `.qwen/settings.json` and stores project-scoped JSONL sessions under the Qwen runtime directory. The first integration uses Qwen hooks as the lifecycle source of truth and writes an Entire-owned sidecar transcript under `.entire/tmp/qwen/` so Entire can read stable session data even if Qwen's native transcript evolves.
+
+## Static Checks
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| Binary present | Optional | `qwen` on `PATH`; protocol commands still run without it |
+| Help available | PASS | Qwen Code documents `qwen -p`, `--continue`, and `--resume` |
+| Hooks available | PASS | `SessionStart`, `UserPromptSubmit`, `Stop`, `StopFailure`, `SessionEnd`, `PreCompact`, `PostToolUse`, `PostToolUseFailure` |
+| Config directory | PASS | Workspace `.qwen/settings.json` |
+| Session storage | PASS | Native JSONL under Qwen runtime; Entire sidecar in `.entire/tmp/qwen/` |
+
+## Protocol Mapping
+
+| Protocol | Qwen Concept | Implementation |
+|----------|--------------|----------------|
+| `info` | Static metadata | Name `qwen`, type `Qwen Code`, preview |
+| `detect` | CLI availability | Checks `qwen` on `PATH` |
+| `get-session-id` | Hook `session_id` | Returns input session ID or stub |
+| `get-session-dir` | Entire sidecar dir | `.entire/tmp/qwen` |
+| `resolve-session-file` | Entire sidecar file | `<session_id>.jsonl` |
+| `read-session` | Sidecar JSONL | Returns native bytes and computed modified files |
+| `write-session` | Sidecar JSONL | Writes `native_data` to `session_ref` |
+| `read-transcript` | Sidecar JSONL | Reads bytes directly |
+| `chunk-transcript` | Raw bytes | Fixed-size byte chunks |
+| `reassemble-transcript` | Raw bytes | Concatenates chunks |
+| `format-resume-command` | Qwen resume | `qwen --resume <session_id>` |
+| `parse-hook` | Qwen hooks | Maps lifecycle hooks to Entire event objects |
+| `install-hooks` | `.qwen/settings.json` | Read-modify-write command hooks |
+| `are-hooks-installed` | `.qwen/settings.json` | Requires all Entire Qwen hooks |
+| `uninstall-hooks` | `.qwen/settings.json` | Removes only Entire hook entries |
+| `extract-modified-files` | Tool inputs | Reads path fields and simple shell write patterns |
+| `extract-prompts` | `UserPromptSubmit` | Reads sidecar prompt records |
+| `extract-summary` | `Stop`/failure | Reads final assistant/error message |
+| `compact-transcript` | Sidecar JSONL | Emits base64 Entire Transcript Format JSONL |
+
+## Lifecycle Mapping
+
+| Qwen Hook | Entire Hook Verb | Entire Event |
+|-----------|------------------|--------------|
+| `SessionStart` | `session-start` | `SessionStart` |
+| `UserPromptSubmit` | `user-prompt-submit` | `TurnStart` |
+| `Stop` | `stop` | `TurnEnd` |
+| `StopFailure` | `stop-failure` | `TurnEnd` with error metadata |
+| `SessionEnd` | `session-end` | `SessionEnd` |
+| `PreCompact` | `pre-compact` | `Compaction` |
+| `PostToolUse` | `post-tool-use` | sidecar metadata only |
+| `PostToolUseFailure` | `post-tool-use-failure` | sidecar metadata only |
+
+## Test Notes
+
+Default CI does not require Qwen credentials. Real lifecycle testing is gated with `QWEN_E2E=1 E2E_AGENT=qwen`.

--- a/agents/entire-agent-qwen/README.md
+++ b/agents/entire-agent-qwen/README.md
@@ -1,0 +1,64 @@
+# entire-agent-qwen
+
+External agent binary that teaches the Entire CLI how to work with Qwen Code.
+
+## Capabilities
+
+| Capability | Status |
+|------------|--------|
+| hooks | Yes, command hooks in `.qwen/settings.json` |
+| transcript_analyzer | Yes, via Entire sidecar JSONL |
+| compact_transcript | Yes, emits Entire compact transcript JSONL |
+| transcript_preparer | No |
+| token_calculator | No |
+
+## Installation
+
+```bash
+cd agents/entire-agent-qwen
+mise run build
+cp entire-agent-qwen /usr/local/bin/
+```
+
+Qwen Code itself must also be installed as `qwen` for real sessions:
+
+```bash
+npm install -g @qwen-code/qwen-code
+```
+
+## Enable In A Repo
+
+```bash
+cd /path/to/repo
+entire enable --agent qwen --telemetry=false
+```
+
+This writes command hooks to `.qwen/settings.json`. Hooks call:
+
+```bash
+entire hooks qwen <hook-name>
+```
+
+The hook commands are wrapped so a missing `entire` binary never breaks a Qwen session.
+
+## Usage
+
+```bash
+qwen -p "Create hello.txt with hello world" --yolo
+git add .
+git commit -m "qwen checkpoint test"
+entire checkpoint list
+```
+
+Entire stores Qwen session metadata in `.entire/tmp/qwen/<session_id>.jsonl`, preserving Qwen's native `transcript_path` as metadata.
+
+## Development
+
+```bash
+mise run build
+mise run test
+external-agents-tests verify ./entire-agent-qwen
+
+cd ../../
+QWEN_E2E=1 E2E_AGENT=qwen mise run test:e2e:lifecycle
+```

--- a/agents/entire-agent-qwen/go.mod
+++ b/agents/entire-agent-qwen/go.mod
@@ -1,0 +1,3 @@
+module github.com/entireio/external-agents/agents/entire-agent-qwen
+
+go 1.26.0

--- a/agents/entire-agent-qwen/internal/protocol/protocol.go
+++ b/agents/entire-agent-qwen/internal/protocol/protocol.go
@@ -1,0 +1,330 @@
+package protocol
+
+import (
+	"encoding/json"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type sessionDirResolver interface {
+	GetSessionDir(repoPath string) (string, error)
+}
+
+type sessionFileResolver interface {
+	ResolveSessionFile(sessionDir, sessionID string) string
+}
+
+type sessionIDProvider interface {
+	GetSessionID(*HookInputJSON) string
+}
+
+type sessionReader interface {
+	ReadSession(*HookInputJSON) (AgentSessionJSON, error)
+}
+
+type sessionWriter interface {
+	WriteSession(AgentSessionJSON) error
+}
+
+type transcriptReader interface {
+	ReadTranscript(sessionRef string) ([]byte, error)
+}
+
+type transcriptChunker interface {
+	ChunkTranscript(content []byte, maxSize int) ([][]byte, error)
+	ReassembleTranscript(chunks [][]byte) ([]byte, error)
+}
+
+type transcriptCompactor interface {
+	CompactTranscript(sessionRef string) (CompactTranscriptResponse, error)
+}
+
+type resumeFormatter interface {
+	FormatResumeCommand(sessionID string) string
+}
+
+type hookParser interface {
+	ParseHook(hookName string, input []byte) (*EventJSON, error)
+	InstallHooks(localDev bool, force bool) (int, error)
+	UninstallHooks() error
+	AreHooksInstalled() bool
+}
+
+type transcriptAnalyzer interface {
+	GetTranscriptPosition(path string) (int, error)
+	ExtractModifiedFiles(path string, offset int) ([]string, int, error)
+	ExtractPrompts(sessionRef string, offset int) ([]string, error)
+	ExtractSummary(sessionRef string) (string, bool, error)
+}
+
+func WriteJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(v)
+}
+
+func ReadJSON[T any](r io.Reader) (*T, error) {
+	var value T
+	if err := json.NewDecoder(r).Decode(&value); err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
+func RepoRoot() string {
+	if root := os.Getenv("ENTIRE_REPO_ROOT"); root != "" {
+		return root
+	}
+	root, _ := os.Getwd()
+	return root
+}
+
+func HandleGetSessionID(stdin io.Reader, stdout io.Writer, provider sessionIDProvider) error {
+	input, err := ReadJSON[HookInputJSON](stdin)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionIDResponse{SessionID: provider.GetSessionID(input)})
+}
+
+func HandleGetSessionDir(args []string, stdout io.Writer, resolver sessionDirResolver) error {
+	fs := flag.NewFlagSet("get-session-dir", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	repoPath := fs.String("repo-path", "", "repo path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	sessionDir, err := resolver.GetSessionDir(*repoPath)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionDirResponse{SessionDir: sessionDir})
+}
+
+func HandleResolveSessionFile(args []string, stdout io.Writer, resolver sessionFileResolver) error {
+	fs := flag.NewFlagSet("resolve-session-file", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionDir := fs.String("session-dir", "", "session dir")
+	sessionID := fs.String("session-id", "", "session id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionFileResponse{SessionFile: resolver.ResolveSessionFile(*sessionDir, *sessionID)})
+}
+
+func HandleReadSession(stdin io.Reader, stdout io.Writer, reader sessionReader) error {
+	input, err := ReadJSON[HookInputJSON](stdin)
+	if err != nil {
+		return err
+	}
+	session, err := reader.ReadSession(input)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, session)
+}
+
+func HandleWriteSession(stdin io.Reader, writer sessionWriter) error {
+	session, err := ReadJSON[AgentSessionJSON](stdin)
+	if err != nil {
+		return err
+	}
+	return writer.WriteSession(*session)
+}
+
+func HandleReadTranscript(args []string, stdout io.Writer, reader transcriptReader) error {
+	fs := flag.NewFlagSet("read-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	data, err := reader.ReadTranscript(*sessionRef)
+	if err != nil {
+		return err
+	}
+	_, err = stdout.Write(data)
+	return err
+}
+
+func HandleChunkTranscript(args []string, stdin io.Reader, stdout io.Writer, chunker transcriptChunker) error {
+	fs := flag.NewFlagSet("chunk-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	maxSize := fs.Int("max-size", 0, "max size")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	content, err := io.ReadAll(stdin)
+	if err != nil {
+		return err
+	}
+	chunks, err := chunker.ChunkTranscript(content, *maxSize)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ChunkResponse{Chunks: chunks})
+}
+
+func HandleReassembleTranscript(stdin io.Reader, stdout io.Writer, chunker transcriptChunker) error {
+	input, err := ReadJSON[ChunkResponse](stdin)
+	if err != nil {
+		return err
+	}
+	data, err := chunker.ReassembleTranscript(input.Chunks)
+	if err != nil {
+		return err
+	}
+	_, err = stdout.Write(data)
+	return err
+}
+
+func HandleCompactTranscript(args []string, stdout io.Writer, compactor transcriptCompactor) error {
+	fs := flag.NewFlagSet("compact-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	compacted, err := compactor.CompactTranscript(*sessionRef)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, compacted)
+}
+
+func HandleFormatResumeCommand(args []string, stdout io.Writer, formatter resumeFormatter) error {
+	fs := flag.NewFlagSet("format-resume-command", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionID := fs.String("session-id", "", "session id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ResumeCommandResponse{Command: formatter.FormatResumeCommand(*sessionID)})
+}
+
+// readStdinWithTimeout reads from r but returns empty data if nothing arrives
+// within the timeout. This prevents blocking when an IDE keeps stdin open
+// without sending data (e.g., for hooks that have no payload).
+func readStdinWithTimeout(r io.Reader, timeout time.Duration) ([]byte, error) {
+	type result struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		data, err := io.ReadAll(r)
+		ch <- result{data, err}
+	}()
+	select {
+	case res := <-ch:
+		return res.data, res.err
+	case <-time.After(timeout):
+		return nil, nil
+	}
+}
+
+func HandleParseHook(args []string, stdin io.Reader, stdout io.Writer, parser hookParser) error {
+	fs := flag.NewFlagSet("parse-hook", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	hook := fs.String("hook", "", "hook name")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	input, err := readStdinWithTimeout(stdin, 100*time.Millisecond)
+	if err != nil {
+		return err
+	}
+	event, err := parser.ParseHook(*hook, input)
+	if err != nil {
+		return err
+	}
+	if event == nil {
+		_, err = io.WriteString(stdout, "null\n")
+		return err
+	}
+	return WriteJSON(stdout, event)
+}
+
+func HandleInstallHooks(args []string, stdout io.Writer, parser hookParser) error {
+	fs := flag.NewFlagSet("install-hooks", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	localDev := fs.Bool("local-dev", false, "local dev")
+	force := fs.Bool("force", false, "force")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	count, err := parser.InstallHooks(*localDev, *force)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, HooksInstalledCountResponse{HooksInstalled: count})
+}
+
+func HandleGetTranscriptPosition(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("get-transcript-position", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	path := fs.String("path", "", "path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	position, err := analyzer.GetTranscriptPosition(*path)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, TranscriptPositionResponse{Position: position})
+}
+
+func HandleExtractModifiedFiles(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-modified-files", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	path := fs.String("path", "", "path")
+	offset := fs.Int("offset", 0, "offset")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	files, currentPosition, err := analyzer.ExtractModifiedFiles(*path, *offset)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractFilesResponse{Files: files, CurrentPosition: currentPosition})
+}
+
+func HandleExtractPrompts(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-prompts", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	offset := fs.Int("offset", 0, "offset")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	prompts, err := analyzer.ExtractPrompts(*sessionRef, *offset)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractPromptsResponse{Prompts: prompts})
+}
+
+func HandleExtractSummary(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-summary", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	summary, hasSummary, err := analyzer.ExtractSummary(*sessionRef)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractSummaryResponse{Summary: summary, HasSummary: hasSummary})
+}
+
+func DefaultSessionDir(repoPath string) string {
+	return filepath.Join(repoPath, ".entire", "tmp")
+}
+
+func ResolveSessionFile(sessionDir, sessionID string) string {
+	return filepath.Join(sessionDir, sessionID+".json")
+}

--- a/agents/entire-agent-qwen/internal/protocol/types.go
+++ b/agents/entire-agent-qwen/internal/protocol/types.go
@@ -1,0 +1,130 @@
+package protocol
+
+import "encoding/json"
+
+const ProtocolVersion = 1
+
+type DeclaredCapabilities struct {
+	Hooks                  bool `json:"hooks"`
+	TranscriptAnalyzer     bool `json:"transcript_analyzer"`
+	TranscriptPreparer     bool `json:"transcript_preparer"`
+	TokenCalculator        bool `json:"token_calculator"`
+	CompactTranscript      bool `json:"compact_transcript"`
+	TextGenerator          bool `json:"text_generator"`
+	HookResponseWriter     bool `json:"hook_response_writer"`
+	SubagentAwareExtractor bool `json:"subagent_aware_extractor"`
+	UsesTerminal           bool `json:"uses_terminal"`
+}
+
+type InfoResponse struct {
+	ProtocolVersion int                  `json:"protocol_version"`
+	Name            string               `json:"name"`
+	Type            string               `json:"type"`
+	Description     string               `json:"description"`
+	IsPreview       bool                 `json:"is_preview"`
+	ProtectedDirs   []string             `json:"protected_dirs"`
+	HookNames       []string             `json:"hook_names"`
+	Capabilities    DeclaredCapabilities `json:"capabilities"`
+}
+
+type DetectResponse struct {
+	Present bool `json:"present"`
+}
+
+type SessionIDResponse struct {
+	SessionID string `json:"session_id"`
+}
+
+type SessionDirResponse struct {
+	SessionDir string `json:"session_dir"`
+}
+
+type SessionFileResponse struct {
+	SessionFile string `json:"session_file"`
+}
+
+type ChunkResponse struct {
+	Chunks [][]byte `json:"chunks"`
+}
+
+type ResumeCommandResponse struct {
+	Command string `json:"command"`
+}
+
+type HooksInstalledCountResponse struct {
+	HooksInstalled int `json:"hooks_installed"`
+}
+
+type AreHooksInstalledResponse struct {
+	Installed bool `json:"installed"`
+}
+
+type TranscriptPositionResponse struct {
+	Position int `json:"position"`
+}
+
+type ExtractFilesResponse struct {
+	Files           []string `json:"files"`
+	CurrentPosition int      `json:"current_position"`
+}
+
+type ExtractPromptsResponse struct {
+	Prompts []string `json:"prompts"`
+}
+
+type ExtractSummaryResponse struct {
+	Summary    string `json:"summary"`
+	HasSummary bool   `json:"has_summary"`
+}
+
+type CompactTranscriptResponse struct {
+	Transcript string                       `json:"transcript"`
+	Assets     []CompactTranscriptAssetJSON `json:"assets,omitempty"`
+}
+
+type CompactTranscriptAssetJSON struct {
+	Name      string `json:"name"`
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
+}
+
+type AgentSessionJSON struct {
+	SessionID     string   `json:"session_id"`
+	AgentName     string   `json:"agent_name"`
+	RepoPath      string   `json:"repo_path"`
+	SessionRef    string   `json:"session_ref"`
+	StartTime     string   `json:"start_time"`
+	NativeData    []byte   `json:"native_data"`
+	ModifiedFiles []string `json:"modified_files"`
+	NewFiles      []string `json:"new_files"`
+	DeletedFiles  []string `json:"deleted_files"`
+}
+
+type HookInputJSON struct {
+	HookType   string                 `json:"hook_type"`
+	SessionID  string                 `json:"session_id"`
+	SessionRef string                 `json:"session_ref"`
+	Timestamp  string                 `json:"timestamp"`
+	UserPrompt string                 `json:"user_prompt,omitempty"`
+	ToolName   string                 `json:"tool_name,omitempty"`
+	ToolUseID  string                 `json:"tool_use_id,omitempty"`
+	ToolInput  json.RawMessage        `json:"tool_input,omitempty"`
+	RawData    map[string]interface{} `json:"raw_data,omitempty"`
+}
+
+type EventJSON struct {
+	Type              int               `json:"type"`
+	SessionID         string            `json:"session_id"`
+	PreviousSessionID string            `json:"previous_session_id,omitempty"`
+	SessionRef        string            `json:"session_ref,omitempty"`
+	Prompt            string            `json:"prompt,omitempty"`
+	Model             string            `json:"model,omitempty"`
+	Timestamp         string            `json:"timestamp,omitempty"`
+	ToolUseID         string            `json:"tool_use_id,omitempty"`
+	SubagentID        string            `json:"subagent_id,omitempty"`
+	ToolInput         json.RawMessage   `json:"tool_input,omitempty"`
+	SubagentType      string            `json:"subagent_type,omitempty"`
+	TaskDescription   string            `json:"task_description,omitempty"`
+	ResponseMessage   string            `json:"response_message,omitempty"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+}

--- a/agents/entire-agent-qwen/internal/qwen/agent.go
+++ b/agents/entire-agent-qwen/internal/qwen/agent.go
@@ -1,0 +1,106 @@
+package qwen
+
+import (
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/entireio/external-agents/agents/entire-agent-qwen/internal/protocol"
+)
+
+type Agent struct {
+	LookPath func(string) (string, error)
+}
+
+func New() *Agent {
+	return &Agent{LookPath: exec.LookPath}
+}
+
+func (a *Agent) Info() protocol.InfoResponse {
+	return protocol.InfoResponse{
+		ProtocolVersion: protocol.ProtocolVersion,
+		Name:            AgentName,
+		Type:            AgentType,
+		Description:     "Qwen Code external agent integration for Entire",
+		IsPreview:       true,
+		ProtectedDirs:   []string{".qwen"},
+		HookNames: []string{
+			HookNameSessionStart,
+			HookNameUserPromptSubmit,
+			HookNameStop,
+			HookNameStopFailure,
+			HookNameSessionEnd,
+			HookNamePreCompact,
+			HookNamePostToolUse,
+			HookNamePostToolUseFailure,
+		},
+		Capabilities: protocol.DeclaredCapabilities{
+			Hooks:              true,
+			TranscriptAnalyzer: true,
+			CompactTranscript:  true,
+			UsesTerminal:       true,
+		},
+	}
+}
+
+func (a *Agent) Detect() protocol.DetectResponse {
+	lookPath := a.LookPath
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	_, err := lookPath(qwenBinary)
+	return protocol.DetectResponse{Present: err == nil}
+}
+
+func (a *Agent) GetSessionID(input *protocol.HookInputJSON) string {
+	if input != nil && strings.TrimSpace(input.SessionID) != "" {
+		return input.SessionID
+	}
+	return stubSessionID
+}
+
+func (a *Agent) GetSessionDir(repoPath string) (string, error) {
+	if strings.TrimSpace(repoPath) == "" {
+		repoPath = protocol.RepoRoot()
+	}
+	return filepath.Join(repoPath, ".entire", "tmp", AgentName), nil
+}
+
+func (a *Agent) ResolveSessionFile(sessionDir, sessionID string) string {
+	if strings.TrimSpace(sessionDir) == "" {
+		sessionDir, _ = a.GetSessionDir(protocol.RepoRoot())
+	}
+	if strings.TrimSpace(sessionID) == "" {
+		sessionID = stubSessionID
+	}
+	return filepath.Join(sessionDir, safeFilename(sessionID)+".jsonl")
+}
+
+func (a *Agent) FormatResumeCommand(sessionID string) string {
+	if strings.TrimSpace(sessionID) == "" {
+		return "qwen --continue"
+	}
+	return "qwen --resume " + shellQuote(sessionID)
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	if strings.IndexFunc(value, func(r rune) bool {
+		return !isSafeShellQuoteRune(r)
+	}) == -1 {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}
+
+func isSafeShellQuoteRune(r rune) bool {
+	return r == '-' || r == '_' || r == '.' || r == ':' ||
+		(r >= '0' && r <= '9') ||
+		(r >= 'a' && r <= 'z') ||
+		(r >= 'A' && r <= 'Z')
+}
+
+var errMissingSessionRef = errors.New("session_ref or session_id is required")

--- a/agents/entire-agent-qwen/internal/qwen/agent_test.go
+++ b/agents/entire-agent-qwen/internal/qwen/agent_test.go
@@ -1,0 +1,284 @@
+package qwen
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/external-agents/agents/entire-agent-qwen/internal/protocol"
+)
+
+func TestDetectUsesQwenBinary(t *testing.T) {
+	agent := New()
+	agent.LookPath = func(name string) (string, error) {
+		if name != qwenBinary {
+			t.Fatalf("unexpected binary lookup: %s", name)
+		}
+		return "/usr/local/bin/qwen", nil
+	}
+	if !agent.Detect().Present {
+		t.Fatal("expected qwen to be detected")
+	}
+
+	agent.LookPath = func(string) (string, error) {
+		return "", errors.New("not found")
+	}
+	if agent.Detect().Present {
+		t.Fatal("expected qwen to be absent")
+	}
+}
+
+func TestInstallHooksIdempotentAndUninstallPreservesUserSettings(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repo)
+
+	settingsPath := filepath.Join(repo, ".qwen", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	initial := `{
+  "theme": "dark",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {"type": "command", "name": "custom", "command": "echo custom"}
+        ]
+      }
+    ]
+  }
+}
+`
+	if err := os.WriteFile(settingsPath, []byte(initial), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	agent := New()
+	count, err := agent.InstallHooks(false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != len(hookSpecs) {
+		t.Fatalf("expected %d hooks installed, got %d", len(hookSpecs), count)
+	}
+	if !agent.AreHooksInstalled() {
+		t.Fatal("expected hooks installed")
+	}
+
+	count, err = agent.InstallHooks(false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("expected idempotent install count 0, got %d", count)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"theme": "dark"`) {
+		t.Fatalf("user setting was not preserved:\n%s", data)
+	}
+	if !strings.Contains(string(data), `"custom"`) {
+		t.Fatalf("custom hook was not preserved:\n%s", data)
+	}
+
+	if err := agent.UninstallHooks(); err != nil {
+		t.Fatal(err)
+	}
+	if agent.AreHooksInstalled() {
+		t.Fatal("expected hooks uninstalled")
+	}
+	data, err = os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"custom"`) {
+		t.Fatalf("custom hook was removed:\n%s", data)
+	}
+	if strings.Contains(string(data), "entire hooks qwen") {
+		t.Fatalf("Entire hook command still present:\n%s", data)
+	}
+}
+
+func TestParseHookLifecycleEvents(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repo)
+
+	agent := New()
+	input := []byte(`{
+  "session_id": "qwen-test-session",
+  "transcript_path": "/tmp/qwen-native.jsonl",
+  "cwd": "/repo",
+  "timestamp": "2026-05-20T12:00:00Z",
+  "prompt": "write a file",
+  "model": "qwen3-coder-plus",
+  "last_assistant_message": "done",
+  "error": "server_error",
+  "error_details": "api failed",
+  "tool_name": "write_file",
+  "tool_use_id": "tool-1",
+  "tool_input": {"file_path":"hello.txt"},
+  "tool_response": {"ok":true}
+}`)
+
+	tests := []struct {
+		hookName string
+		wantType int
+		wantNil  bool
+	}{
+		{HookNameSessionStart, 1, false},
+		{HookNameUserPromptSubmit, 2, false},
+		{HookNameStop, 3, false},
+		{HookNameStopFailure, 3, false},
+		{HookNameSessionEnd, 5, false},
+		{HookNamePreCompact, 4, false},
+		{HookNamePostToolUse, 0, true},
+		{HookNamePostToolUseFailure, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.hookName, func(t *testing.T) {
+			event, err := agent.ParseHook(tt.hookName, input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tt.wantNil {
+				if event != nil {
+					t.Fatalf("expected nil event, got %#v", event)
+				}
+				return
+			}
+			if event == nil {
+				t.Fatal("expected event")
+			}
+			if event.Type != tt.wantType {
+				t.Fatalf("expected type %d, got %d", tt.wantType, event.Type)
+			}
+			if event.SessionID != "qwen-test-session" {
+				t.Fatalf("unexpected session id %q", event.SessionID)
+			}
+			if !strings.Contains(event.SessionRef, ".entire/tmp/qwen/qwen-test-session.jsonl") {
+				t.Fatalf("unexpected session ref %q", event.SessionRef)
+			}
+			if event.Metadata["native_transcript_path"] != "/tmp/qwen-native.jsonl" {
+				t.Fatalf("native transcript path missing from metadata: %#v", event.Metadata)
+			}
+		})
+	}
+}
+
+func TestTranscriptAnalysisAndCompactTranscript(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repo)
+	agent := New()
+
+	inputs := map[string]string{
+		HookNameUserPromptSubmit: `{"session_id":"qwen-test","timestamp":"2026-05-20T12:00:00Z","prompt":"Create hello.txt"}`,
+		HookNamePostToolUse:      `{"session_id":"qwen-test","timestamp":"2026-05-20T12:00:01Z","tool_name":"write_file","tool_use_id":"tool-1","tool_input":{"file_path":"hello.txt"},"tool_response":{"ok":true}}`,
+		HookNameStop:             `{"session_id":"qwen-test","timestamp":"2026-05-20T12:00:02Z","last_assistant_message":"Created hello.txt"}`,
+	}
+	for _, hook := range []string{HookNameUserPromptSubmit, HookNamePostToolUse, HookNameStop} {
+		if _, err := agent.ParseHook(hook, []byte(inputs[hook])); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sessionRef := agent.sidecarPath("qwen-test")
+	position, err := agent.GetTranscriptPosition(sessionRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if position != 3 {
+		t.Fatalf("expected 3 records, got %d", position)
+	}
+
+	prompts, err := agent.ExtractPrompts(sessionRef, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prompts) != 1 || prompts[0] != "Create hello.txt" {
+		t.Fatalf("unexpected prompts: %#v", prompts)
+	}
+
+	files, current, err := agent.ExtractModifiedFiles(sessionRef, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current != 3 {
+		t.Fatalf("expected current position 3, got %d", current)
+	}
+	if len(files) != 1 || files[0] != "hello.txt" {
+		t.Fatalf("unexpected modified files: %#v", files)
+	}
+
+	summary, ok, err := agent.ExtractSummary(sessionRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || summary != "Created hello.txt" {
+		t.Fatalf("unexpected summary %q ok=%v", summary, ok)
+	}
+
+	compacted, err := agent.CompactTranscript(sessionRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(compacted.Transcript)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(decoded), `"type":"user"`) ||
+		!strings.Contains(string(decoded), `"tool_use"`) ||
+		!strings.HasSuffix(string(decoded), "\n") {
+		t.Fatalf("unexpected compact transcript:\n%s", decoded)
+	}
+}
+
+func TestSessionReadWriteAndChunking(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repo)
+	agent := New()
+	sessionRef := agent.sidecarPath("roundtrip")
+	nativeData := []byte(`{"v":1}` + "\n")
+
+	if err := agent.WriteSession(protocol.AgentSessionJSON{
+		SessionID:  "roundtrip",
+		AgentName:  AgentName,
+		SessionRef: sessionRef,
+		NativeData: nativeData,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	session, err := agent.ReadSession(&protocol.HookInputJSON{SessionID: "roundtrip", SessionRef: sessionRef})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(session.NativeData) != string(nativeData) {
+		t.Fatalf("native data mismatch: %q", session.NativeData)
+	}
+
+	chunks, err := agent.ChunkTranscript([]byte("abcdef"), 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined, err := agent.ReassembleTranscript(chunks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(joined) != "abcdef" {
+		t.Fatalf("unexpected reassembled content %q", joined)
+	}
+
+	var decoded protocol.AgentSessionJSON
+	data, _ := json.Marshal(session)
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/agents/entire-agent-qwen/internal/qwen/compact.go
+++ b/agents/entire-agent-qwen/internal/qwen/compact.go
@@ -1,0 +1,168 @@
+package qwen
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/entireio/external-agents/agents/entire-agent-qwen/internal/protocol"
+)
+
+const compactCLIVersion = "unknown"
+
+type compactLine struct {
+	V          int    `json:"v"`
+	Agent      string `json:"agent"`
+	CLIVersion string `json:"cli_version"`
+	Type       string `json:"type"`
+	TS         string `json:"ts,omitempty"`
+	ID         string `json:"id,omitempty"`
+	Content    any    `json:"content"`
+}
+
+type compactUserTextBlock struct {
+	Text string `json:"text"`
+}
+
+type compactAssistantTextBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type compactToolUseBlock struct {
+	Type   string             `json:"type"`
+	ID     string             `json:"id,omitempty"`
+	Name   string             `json:"name"`
+	Input  any                `json:"input,omitempty"`
+	Result *compactToolResult `json:"result,omitempty"`
+}
+
+type compactToolResult struct {
+	Output string `json:"output"`
+	Status string `json:"status"`
+}
+
+func (a *Agent) CompactTranscript(sessionRef string) (protocol.CompactTranscriptResponse, error) {
+	data, err := os.ReadFile(sessionRef)
+	if err != nil {
+		return protocol.CompactTranscriptResponse{}, err
+	}
+	compacted, err := compactTranscriptBytes(data)
+	if err != nil {
+		return protocol.CompactTranscriptResponse{}, err
+	}
+	return protocol.CompactTranscriptResponse{Transcript: base64.StdEncoding.EncodeToString(compacted)}, nil
+}
+
+func compactTranscriptBytes(data []byte) ([]byte, error) {
+	records, err := parseSidecarRecords(data)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	for _, record := range records {
+		switch record.Event {
+		case "UserPromptSubmit":
+			if record.Prompt == "" {
+				continue
+			}
+			if err := writeCompactLine(&buf, compactLine{
+				V:          1,
+				Agent:      AgentName,
+				CLIVersion: compactCLIVersion,
+				Type:       "user",
+				TS:         record.TS,
+				Content:    []compactUserTextBlock{{Text: record.Prompt}},
+			}); err != nil {
+				return nil, err
+			}
+		case "PostToolUse", "PostToolUseFailure":
+			block := compactToolUseBlock{
+				Type:  "tool_use",
+				ID:    record.ToolUseID,
+				Name:  record.ToolName,
+				Input: decodeRawObject(record.ToolInput),
+			}
+			if len(record.ToolResponse) > 0 {
+				block.Result = &compactToolResult{Output: string(record.ToolResponse), Status: "success"}
+			}
+			if record.Error != "" || record.ErrorDetails != "" {
+				block.Result = &compactToolResult{Output: record.Error + " " + record.ErrorDetails, Status: "error"}
+			}
+			if err := writeCompactLine(&buf, compactLine{
+				V:          1,
+				Agent:      AgentName,
+				CLIVersion: compactCLIVersion,
+				Type:       "assistant",
+				TS:         record.TS,
+				ID:         record.ToolUseID,
+				Content:    []any{block},
+			}); err != nil {
+				return nil, err
+			}
+		case "Stop", "StopFailure":
+			text := record.LastAssistantMessage
+			if text == "" {
+				text = record.ErrorDetails
+			}
+			if text == "" {
+				continue
+			}
+			if err := writeCompactLine(&buf, compactLine{
+				V:          1,
+				Agent:      AgentName,
+				CLIVersion: compactCLIVersion,
+				Type:       "assistant",
+				TS:         record.TS,
+				Content:    []compactAssistantTextBlock{{Type: "text", Text: text}},
+			}); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if buf.Len() == 0 {
+		return nil, errors.New("compact transcript produced no output")
+	}
+	return buf.Bytes(), nil
+}
+
+func parseSidecarRecords(data []byte) ([]sidecarRecord, error) {
+	lines := bytes.Split(data, []byte("\n"))
+	records := make([]sidecarRecord, 0, len(lines))
+	for _, line := range lines {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var record sidecarRecord
+		if err := json.Unmarshal(line, &record); err != nil {
+			return nil, fmt.Errorf("parse sidecar record: %w", err)
+		}
+		records = append(records, record)
+	}
+	return records, nil
+}
+
+func writeCompactLine(buf *bytes.Buffer, line compactLine) error {
+	data, err := json.Marshal(line)
+	if err != nil {
+		return err
+	}
+	buf.Write(data)
+	buf.WriteByte('\n')
+	return nil
+}
+
+func decodeRawObject(raw json.RawMessage) any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return string(raw)
+	}
+	return value
+}

--- a/agents/entire-agent-qwen/internal/qwen/hooks.go
+++ b/agents/entire-agent-qwen/internal/qwen/hooks.go
@@ -1,0 +1,365 @@
+package qwen
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/entireio/external-agents/agents/entire-agent-qwen/internal/protocol"
+)
+
+func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, error) {
+	raw, err := parseHookInput(input)
+	if err != nil {
+		return nil, err
+	}
+	raw.HookEventName = qwenEventName(hookName, raw.HookEventName)
+	normalizeRawHook(&raw, hookName)
+
+	if err := a.appendSidecar(raw); err != nil {
+		return nil, err
+	}
+
+	sessionRef := a.sidecarPath(raw.SessionID)
+	metadata := hookMetadata(raw)
+
+	switch hookName {
+	case HookNameSessionStart:
+		return &protocol.EventJSON{
+			Type:       1,
+			SessionID:  raw.SessionID,
+			SessionRef: sessionRef,
+			Model:      raw.Model,
+			Timestamp:  raw.Timestamp,
+			Metadata:   metadata,
+		}, nil
+	case HookNameUserPromptSubmit:
+		return &protocol.EventJSON{
+			Type:       2,
+			SessionID:  raw.SessionID,
+			SessionRef: sessionRef,
+			Prompt:     raw.Prompt,
+			Model:      raw.Model,
+			Timestamp:  raw.Timestamp,
+			Metadata:   metadata,
+		}, nil
+	case HookNameStop:
+		return &protocol.EventJSON{
+			Type:            3,
+			SessionID:       raw.SessionID,
+			SessionRef:      sessionRef,
+			Model:           raw.Model,
+			Timestamp:       raw.Timestamp,
+			ResponseMessage: raw.LastAssistantMessage,
+			Metadata:        metadata,
+		}, nil
+	case HookNameStopFailure:
+		return &protocol.EventJSON{
+			Type:            3,
+			SessionID:       raw.SessionID,
+			SessionRef:      sessionRef,
+			Model:           raw.Model,
+			Timestamp:       raw.Timestamp,
+			ResponseMessage: raw.ErrorDetails,
+			Metadata:        metadata,
+		}, nil
+	case HookNameSessionEnd:
+		return &protocol.EventJSON{
+			Type:       5,
+			SessionID:  raw.SessionID,
+			SessionRef: sessionRef,
+			Timestamp:  raw.Timestamp,
+			Metadata:   metadata,
+		}, nil
+	case HookNamePreCompact:
+		return &protocol.EventJSON{
+			Type:       4,
+			SessionID:  raw.SessionID,
+			SessionRef: sessionRef,
+			Timestamp:  raw.Timestamp,
+			Metadata:   metadata,
+		}, nil
+	case HookNamePostToolUse, HookNamePostToolUseFailure:
+		return nil, nil
+	default:
+		return nil, nil
+	}
+}
+
+func (a *Agent) InstallHooks(_ bool, force bool) (int, error) {
+	repoRoot := protocol.RepoRoot()
+	settingsPath := filepath.Join(repoRoot, ".qwen", settingsFileName)
+
+	rawSettings, rawHooks, err := readSettings(settingsPath)
+	if err != nil {
+		return 0, err
+	}
+
+	if force {
+		removeEntireHooks(rawHooks)
+	}
+
+	count := 0
+	for _, spec := range hookSpecs {
+		var matchers []qwenHookMatcher
+		parseHookType(rawHooks, spec.QwenEvent, &matchers)
+		command := hookCommand(spec.HookName)
+		if !hookExists(matchers, spec.Matcher, spec.EntryName, command) {
+			matchers = addHook(matchers, spec.Matcher, spec.EntryName, command)
+			count++
+		}
+		marshalHookType(rawHooks, spec.QwenEvent, matchers)
+	}
+
+	if count == 0 && !force {
+		return 0, nil
+	}
+	return count, writeSettings(settingsPath, rawSettings, rawHooks)
+}
+
+func (a *Agent) UninstallHooks() error {
+	repoRoot := protocol.RepoRoot()
+	settingsPath := filepath.Join(repoRoot, ".qwen", settingsFileName)
+	if _, err := os.Stat(settingsPath); errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	rawSettings, rawHooks, err := readSettings(settingsPath)
+	if err != nil {
+		return err
+	}
+	removeEntireHooks(rawHooks)
+	return writeSettings(settingsPath, rawSettings, rawHooks)
+}
+
+func (a *Agent) AreHooksInstalled() bool {
+	repoRoot := protocol.RepoRoot()
+	settingsPath := filepath.Join(repoRoot, ".qwen", settingsFileName)
+	_, rawHooks, err := readSettings(settingsPath)
+	if err != nil {
+		return false
+	}
+	for _, spec := range hookSpecs {
+		var matchers []qwenHookMatcher
+		parseHookType(rawHooks, spec.QwenEvent, &matchers)
+		if !hookExists(matchers, spec.Matcher, spec.EntryName, hookCommand(spec.HookName)) {
+			return false
+		}
+	}
+	return true
+}
+
+func parseHookInput(input []byte) (qwenHookInputRaw, error) {
+	var raw qwenHookInputRaw
+	input = bytes.TrimSpace(input)
+	if len(input) == 0 {
+		return raw, nil
+	}
+	if err := json.Unmarshal(input, &raw); err != nil {
+		return raw, fmt.Errorf("parse qwen hook input: %w", err)
+	}
+	return raw, nil
+}
+
+func normalizeRawHook(raw *qwenHookInputRaw, hookName string) {
+	if strings.TrimSpace(raw.SessionID) == "" {
+		raw.SessionID = stubSessionID
+	}
+	if strings.TrimSpace(raw.Timestamp) == "" {
+		raw.Timestamp = time.Now().UTC().Format(time.RFC3339)
+	}
+	if strings.TrimSpace(raw.Model) == "" && raw.LLMRequest.Model != "" {
+		raw.Model = raw.LLMRequest.Model
+	}
+	if raw.ToolName == "" && (hookName == HookNamePostToolUse || hookName == HookNamePostToolUseFailure) {
+		raw.ToolName = "unknown"
+	}
+}
+
+func qwenEventName(hookName string, existing string) string {
+	if strings.TrimSpace(existing) != "" {
+		return existing
+	}
+	switch hookName {
+	case HookNameSessionStart:
+		return "SessionStart"
+	case HookNameUserPromptSubmit:
+		return "UserPromptSubmit"
+	case HookNameStop:
+		return "Stop"
+	case HookNameStopFailure:
+		return "StopFailure"
+	case HookNameSessionEnd:
+		return "SessionEnd"
+	case HookNamePreCompact:
+		return "PreCompact"
+	case HookNamePostToolUse:
+		return "PostToolUse"
+	case HookNamePostToolUseFailure:
+		return "PostToolUseFailure"
+	default:
+		return hookName
+	}
+}
+
+func hookMetadata(raw qwenHookInputRaw) map[string]string {
+	metadata := map[string]string{
+		"agent":           AgentName,
+		"hook_event_name": raw.HookEventName,
+	}
+	if raw.TranscriptPath != "" {
+		metadata["native_transcript_path"] = raw.TranscriptPath
+	}
+	if raw.CWD != "" {
+		metadata["cwd"] = raw.CWD
+	}
+	if raw.Source != "" {
+		metadata["source"] = raw.Source
+	}
+	if raw.Reason != "" {
+		metadata["reason"] = raw.Reason
+	}
+	if raw.Error != "" {
+		metadata["error"] = raw.Error
+	}
+	return metadata
+}
+
+func readSettings(path string) (map[string]json.RawMessage, map[string]json.RawMessage, error) {
+	rawSettings := make(map[string]json.RawMessage)
+	rawHooks := make(map[string]json.RawMessage)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return rawSettings, rawHooks, nil
+		}
+		return nil, nil, err
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return rawSettings, rawHooks, nil
+	}
+	if err := json.Unmarshal(data, &rawSettings); err != nil {
+		return nil, nil, fmt.Errorf("parse .qwen/settings.json: %w", err)
+	}
+	if hooksRaw, ok := rawSettings["hooks"]; ok {
+		if err := json.Unmarshal(hooksRaw, &rawHooks); err != nil {
+			return nil, nil, fmt.Errorf("parse .qwen/settings.json hooks: %w", err)
+		}
+	}
+	return rawSettings, rawHooks, nil
+}
+
+func writeSettings(path string, rawSettings map[string]json.RawMessage, rawHooks map[string]json.RawMessage) error {
+	hooksJSON, err := json.Marshal(rawHooks)
+	if err != nil {
+		return err
+	}
+	rawSettings["hooks"] = hooksJSON
+	data, err := json.MarshalIndent(rawSettings, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+func parseHookType(rawHooks map[string]json.RawMessage, event string, target *[]qwenHookMatcher) {
+	if data, ok := rawHooks[event]; ok {
+		_ = json.Unmarshal(data, target)
+	}
+}
+
+func marshalHookType(rawHooks map[string]json.RawMessage, event string, matchers []qwenHookMatcher) {
+	if len(matchers) == 0 {
+		delete(rawHooks, event)
+		return
+	}
+	data, err := json.Marshal(matchers)
+	if err == nil {
+		rawHooks[event] = data
+	}
+}
+
+func hookCommand(hookName string) string {
+	return fmt.Sprintf("sh -c 'if command -v entire >/dev/null 2>&1; then entire hooks qwen %s >/dev/null 2>&1 || true; fi'", hookName)
+}
+
+func hookExists(matchers []qwenHookMatcher, matcher string, entryName string, command string) bool {
+	for _, m := range matchers {
+		if m.Matcher != matcher {
+			continue
+		}
+		for _, h := range m.Hooks {
+			if h.Type == "command" && h.Name == entryName && h.Command == command {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func addHook(matchers []qwenHookMatcher, matcher string, entryName string, command string) []qwenHookMatcher {
+	for i := range matchers {
+		if matchers[i].Matcher == matcher {
+			matchers[i].Hooks = append(matchers[i].Hooks, qwenHookEntry{
+				Type:    "command",
+				Name:    entryName,
+				Command: command,
+				Timeout: 10000,
+			})
+			return matchers
+		}
+	}
+	return append(matchers, qwenHookMatcher{
+		Matcher: matcher,
+		Hooks: []qwenHookEntry{{
+			Type:    "command",
+			Name:    entryName,
+			Command: command,
+			Timeout: 10000,
+		}},
+	})
+}
+
+func removeEntireHooks(rawHooks map[string]json.RawMessage) {
+	for _, spec := range hookSpecs {
+		var matchers []qwenHookMatcher
+		parseHookType(rawHooks, spec.QwenEvent, &matchers)
+		matchers = removeEntireHooksFromMatchers(matchers)
+		marshalHookType(rawHooks, spec.QwenEvent, matchers)
+	}
+}
+
+func removeEntireHooksFromMatchers(matchers []qwenHookMatcher) []qwenHookMatcher {
+	filteredMatchers := make([]qwenHookMatcher, 0, len(matchers))
+	for _, matcher := range matchers {
+		filteredHooks := make([]qwenHookEntry, 0, len(matcher.Hooks))
+		for _, hook := range matcher.Hooks {
+			if isEntireHook(hook) {
+				continue
+			}
+			filteredHooks = append(filteredHooks, hook)
+		}
+		if len(filteredHooks) == 0 {
+			continue
+		}
+		matcher.Hooks = filteredHooks
+		filteredMatchers = append(filteredMatchers, matcher)
+	}
+	return filteredMatchers
+}
+
+func isEntireHook(hook qwenHookEntry) bool {
+	if strings.HasPrefix(hook.Name, "entire-") {
+		return true
+	}
+	return strings.Contains(hook.Command, "entire hooks qwen")
+}

--- a/agents/entire-agent-qwen/internal/qwen/transcript.go
+++ b/agents/entire-agent-qwen/internal/qwen/transcript.go
@@ -1,0 +1,405 @@
+package qwen
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/entireio/external-agents/agents/entire-agent-qwen/internal/protocol"
+)
+
+var fileModificationTools = map[string]struct{}{
+	"write_file":        {},
+	"edit":              {},
+	"edit_file":         {},
+	"replace":           {},
+	"save_file":         {},
+	"WriteFile":         {},
+	"Edit":              {},
+	"MultiEdit":         {},
+	"NotebookEdit":      {},
+	"Shell":             {},
+	"Bash":              {},
+	"run_shell_command": {},
+	"shell":             {},
+}
+
+var commonPathKeys = []string{
+	"file_path",
+	"filePath",
+	"path",
+	"notebook_path",
+	"target_file",
+	"filename",
+}
+
+func (a *Agent) ReadSession(input *protocol.HookInputJSON) (protocol.AgentSessionJSON, error) {
+	sessionID, sessionRef := a.sessionIDAndRef(input)
+	data, err := os.ReadFile(sessionRef)
+	if errors.Is(err, os.ErrNotExist) {
+		data = nil
+	} else if err != nil {
+		return protocol.AgentSessionJSON{}, err
+	}
+	modifiedFiles, _, err := a.ExtractModifiedFiles(sessionRef, 0)
+	if errors.Is(err, os.ErrNotExist) {
+		modifiedFiles = nil
+	} else if err != nil {
+		return protocol.AgentSessionJSON{}, err
+	}
+	return protocol.AgentSessionJSON{
+		SessionID:     sessionID,
+		AgentName:     AgentName,
+		RepoPath:      protocol.RepoRoot(),
+		SessionRef:    sessionRef,
+		StartTime:     time.Now().UTC().Format(time.RFC3339),
+		NativeData:    data,
+		ModifiedFiles: modifiedFiles,
+		NewFiles:      []string{},
+		DeletedFiles:  []string{},
+	}, nil
+}
+
+func (a *Agent) WriteSession(session protocol.AgentSessionJSON) error {
+	if strings.TrimSpace(session.SessionRef) == "" {
+		return errMissingSessionRef
+	}
+	if err := os.MkdirAll(filepath.Dir(session.SessionRef), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(session.SessionRef, session.NativeData, 0o600)
+}
+
+func (a *Agent) ReadTranscript(sessionRef string) ([]byte, error) {
+	return os.ReadFile(sessionRef)
+}
+
+func (a *Agent) ChunkTranscript(content []byte, maxSize int) ([][]byte, error) {
+	if maxSize <= 0 {
+		return nil, fmt.Errorf("max-size must be positive, got %d", maxSize)
+	}
+	if len(content) == 0 {
+		return [][]byte{[]byte{}}, nil
+	}
+	var chunks [][]byte
+	for start := 0; start < len(content); start += maxSize {
+		end := start + maxSize
+		if end > len(content) {
+			end = len(content)
+		}
+		chunk := make([]byte, end-start)
+		copy(chunk, content[start:end])
+		chunks = append(chunks, chunk)
+	}
+	return chunks, nil
+}
+
+func (a *Agent) ReassembleTranscript(chunks [][]byte) ([]byte, error) {
+	return bytes.Join(chunks, nil), nil
+}
+
+func (a *Agent) GetTranscriptPosition(path string) (int, error) {
+	records, err := readSidecarRecords(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return len(records), nil
+}
+
+func (a *Agent) ExtractModifiedFiles(path string, offset int) ([]string, int, error) {
+	records, err := readSidecarRecords(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, 0, nil
+	}
+	if err != nil {
+		return nil, 0, err
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > len(records) {
+		offset = len(records)
+	}
+	files := modifiedFilesFromRecords(records[offset:])
+	return files, len(records), nil
+}
+
+func (a *Agent) ExtractPrompts(path string, offset int) ([]string, error) {
+	records, err := readSidecarRecords(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > len(records) {
+		offset = len(records)
+	}
+	var prompts []string
+	for _, record := range records[offset:] {
+		if record.Event == "UserPromptSubmit" && strings.TrimSpace(record.Prompt) != "" {
+			prompts = append(prompts, record.Prompt)
+		}
+	}
+	return prompts, nil
+}
+
+func (a *Agent) ExtractSummary(path string) (string, bool, error) {
+	records, err := readSidecarRecords(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	for i := len(records) - 1; i >= 0; i-- {
+		record := records[i]
+		if strings.TrimSpace(record.LastAssistantMessage) != "" {
+			return record.LastAssistantMessage, true, nil
+		}
+		if strings.TrimSpace(record.ErrorDetails) != "" {
+			return record.ErrorDetails, true, nil
+		}
+		if strings.TrimSpace(record.CompactSummary) != "" {
+			return record.CompactSummary, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func (a *Agent) appendSidecar(raw qwenHookInputRaw) error {
+	path := a.sidecarPath(raw.SessionID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	record := sidecarRecord{
+		V:                    1,
+		Agent:                AgentName,
+		Event:                raw.HookEventName,
+		SessionID:            raw.SessionID,
+		TS:                   raw.Timestamp,
+		CWD:                  raw.CWD,
+		NativeTranscriptPath: raw.TranscriptPath,
+		Prompt:               raw.Prompt,
+		Model:                raw.Model,
+		Reason:               raw.Reason,
+		Source:               raw.Source,
+		Trigger:              raw.Trigger,
+		ToolName:             raw.ToolName,
+		ToolUseID:            raw.ToolUseID,
+		ToolInput:            copyRawMessage(raw.ToolInput),
+		ToolResponse:         copyRawMessage(raw.ToolResponse),
+		Error:                raw.Error,
+		ErrorDetails:         raw.ErrorDetails,
+		LastAssistantMessage: raw.LastAssistantMessage,
+		CompactSummary:       raw.CompactSummary,
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a *Agent) sessionIDAndRef(input *protocol.HookInputJSON) (string, string) {
+	sessionID := stubSessionID
+	sessionRef := ""
+	if input != nil {
+		if strings.TrimSpace(input.SessionID) != "" {
+			sessionID = input.SessionID
+		}
+		sessionRef = input.SessionRef
+	}
+	if strings.TrimSpace(sessionRef) == "" {
+		sessionRef = a.sidecarPath(sessionID)
+	}
+	if strings.TrimSpace(sessionID) == "" {
+		sessionID = strings.TrimSuffix(filepath.Base(sessionRef), filepath.Ext(sessionRef))
+	}
+	return sessionID, sessionRef
+}
+
+func (a *Agent) sidecarPath(sessionID string) string {
+	sessionDir, _ := a.GetSessionDir(protocol.RepoRoot())
+	return a.ResolveSessionFile(sessionDir, sessionID)
+}
+
+func safeFilename(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return stubSessionID
+	}
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r == '-' || r == '_' || r == '.':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		default:
+			if unicode.IsLetter(r) || unicode.IsNumber(r) {
+				b.WriteRune(r)
+			} else {
+				b.WriteByte('_')
+			}
+		}
+	}
+	out := strings.Trim(b.String(), "._")
+	if out == "" {
+		return stubSessionID
+	}
+	return out
+}
+
+func readSidecarRecords(path string) ([]sidecarRecord, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	var records []sidecarRecord
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var record sidecarRecord
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	return records, scanner.Err()
+}
+
+func modifiedFilesFromRecords(records []sidecarRecord) []string {
+	seen := map[string]struct{}{}
+	for _, record := range records {
+		if !isFileModificationTool(record.ToolName) {
+			continue
+		}
+		for _, path := range pathsFromToolInput(record.ToolInput, record.ToolName) {
+			normalized := strings.TrimSpace(path)
+			if normalized == "" {
+				continue
+			}
+			seen[normalized] = struct{}{}
+		}
+	}
+	files := make([]string, 0, len(seen))
+	for file := range seen {
+		files = append(files, file)
+	}
+	sort.Strings(files)
+	return files
+}
+
+func isFileModificationTool(name string) bool {
+	if _, ok := fileModificationTools[name]; ok {
+		return true
+	}
+	lower := strings.ToLower(name)
+	return strings.Contains(lower, "write") ||
+		strings.Contains(lower, "edit") ||
+		strings.Contains(lower, "replace") ||
+		strings.Contains(lower, "shell") ||
+		strings.Contains(lower, "bash")
+}
+
+func pathsFromToolInput(raw json.RawMessage, toolName string) []string {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil
+	}
+	var value map[string]any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil
+	}
+	var paths []string
+	for _, key := range commonPathKeys {
+		paths = append(paths, stringValues(value[key])...)
+	}
+	if command, ok := value["command"].(string); ok && isShellTool(toolName) {
+		paths = append(paths, pathsFromShellCommand(command)...)
+	}
+	return paths
+}
+
+func stringValues(value any) []string {
+	switch v := value.(type) {
+	case string:
+		if strings.TrimSpace(v) == "" {
+			return nil
+		}
+		return []string{v}
+	case []any:
+		var out []string
+		for _, item := range v {
+			out = append(out, stringValues(item)...)
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func isShellTool(toolName string) bool {
+	lower := strings.ToLower(toolName)
+	return lower == "bash" || lower == "shell" || strings.Contains(lower, "shell")
+}
+
+var shellPathPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?:^|\s)(?:>|>>)\s*['"]?([^'"\s;&|]+)`),
+	regexp.MustCompile(`(?:^|\s)tee\s+(?:-a\s+)?['"]?([^'"\s;&|]+)`),
+	regexp.MustCompile(`(?:^|\s)touch\s+['"]?([^'"\s;&|]+)`),
+}
+
+func pathsFromShellCommand(command string) []string {
+	var paths []string
+	for _, pattern := range shellPathPatterns {
+		matches := pattern.FindAllStringSubmatch(command, -1)
+		for _, match := range matches {
+			if len(match) > 1 {
+				paths = append(paths, strings.Trim(match[1], `"'`))
+			}
+		}
+	}
+	return paths
+}
+
+func copyRawMessage(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]byte, len(raw))
+	copy(out, raw)
+	return out
+}

--- a/agents/entire-agent-qwen/internal/qwen/types.go
+++ b/agents/entire-agent-qwen/internal/qwen/types.go
@@ -1,0 +1,106 @@
+package qwen
+
+import "encoding/json"
+
+const (
+	AgentName        = "qwen"
+	AgentType        = "Qwen Code"
+	qwenBinary       = "qwen"
+	stubSessionID    = "qwen-session-000"
+	settingsFileName = "settings.json"
+)
+
+const (
+	HookNameSessionStart       = "session-start"
+	HookNameUserPromptSubmit   = "user-prompt-submit"
+	HookNameStop               = "stop"
+	HookNameStopFailure        = "stop-failure"
+	HookNameSessionEnd         = "session-end"
+	HookNamePreCompact         = "pre-compact"
+	HookNamePostToolUse        = "post-tool-use"
+	HookNamePostToolUseFailure = "post-tool-use-failure"
+)
+
+var hookSpecs = []hookSpec{
+	{QwenEvent: "SessionStart", HookName: HookNameSessionStart, EntryName: "entire-session-start"},
+	{QwenEvent: "UserPromptSubmit", HookName: HookNameUserPromptSubmit, EntryName: "entire-user-prompt-submit"},
+	{QwenEvent: "Stop", HookName: HookNameStop, EntryName: "entire-stop"},
+	{QwenEvent: "StopFailure", HookName: HookNameStopFailure, EntryName: "entire-stop-failure"},
+	{QwenEvent: "SessionEnd", HookName: HookNameSessionEnd, EntryName: "entire-session-end"},
+	{QwenEvent: "PreCompact", HookName: HookNamePreCompact, EntryName: "entire-pre-compact"},
+	{QwenEvent: "PostToolUse", HookName: HookNamePostToolUse, EntryName: "entire-post-tool-use", Matcher: "*"},
+	{QwenEvent: "PostToolUseFailure", HookName: HookNamePostToolUseFailure, EntryName: "entire-post-tool-use-failure", Matcher: "*"},
+}
+
+type hookSpec struct {
+	QwenEvent string
+	HookName  string
+	EntryName string
+	Matcher   string
+}
+
+type qwenHookMatcher struct {
+	Matcher    string          `json:"matcher,omitempty"`
+	Sequential *bool           `json:"sequential,omitempty"`
+	Hooks      []qwenHookEntry `json:"hooks"`
+}
+
+type qwenHookEntry struct {
+	Type        string `json:"type"`
+	Command     string `json:"command"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Timeout     int    `json:"timeout,omitempty"`
+	Async       bool   `json:"async,omitempty"`
+	Shell       string `json:"shell,omitempty"`
+}
+
+type qwenHookInputRaw struct {
+	SessionID            string          `json:"session_id"`
+	TranscriptPath       string          `json:"transcript_path"`
+	CWD                  string          `json:"cwd"`
+	HookEventName        string          `json:"hook_event_name"`
+	Timestamp            string          `json:"timestamp"`
+	Prompt               string          `json:"prompt,omitempty"`
+	Model                string          `json:"model,omitempty"`
+	Source               string          `json:"source,omitempty"`
+	Reason               string          `json:"reason,omitempty"`
+	PermissionMode       string          `json:"permission_mode,omitempty"`
+	StopHookActive       bool            `json:"stop_hook_active,omitempty"`
+	LastAssistantMessage string          `json:"last_assistant_message,omitempty"`
+	ToolName             string          `json:"tool_name,omitempty"`
+	ToolUseID            string          `json:"tool_use_id,omitempty"`
+	ToolInput            json.RawMessage `json:"tool_input,omitempty"`
+	ToolResponse         json.RawMessage `json:"tool_response,omitempty"`
+	Error                string          `json:"error,omitempty"`
+	ErrorDetails         string          `json:"error_details,omitempty"`
+	Trigger              string          `json:"trigger,omitempty"`
+	CustomInstructions   string          `json:"custom_instructions,omitempty"`
+	CompactSummary       string          `json:"compact_summary,omitempty"`
+	LLMRequest           struct {
+		Model string `json:"model"`
+	} `json:"llm_request,omitempty"`
+}
+
+type sidecarRecord struct {
+	V                    int             `json:"v"`
+	Agent                string          `json:"agent"`
+	Event                string          `json:"event"`
+	SessionID            string          `json:"session_id"`
+	TS                   string          `json:"ts"`
+	CWD                  string          `json:"cwd,omitempty"`
+	NativeTranscriptPath string          `json:"native_transcript_path,omitempty"`
+	Prompt               string          `json:"prompt,omitempty"`
+	Model                string          `json:"model,omitempty"`
+	Reason               string          `json:"reason,omitempty"`
+	Source               string          `json:"source,omitempty"`
+	Trigger              string          `json:"trigger,omitempty"`
+	ToolName             string          `json:"tool_name,omitempty"`
+	ToolUseID            string          `json:"tool_use_id,omitempty"`
+	ToolInput            json.RawMessage `json:"tool_input,omitempty"`
+	ToolResponse         json.RawMessage `json:"tool_response,omitempty"`
+	Error                string          `json:"error,omitempty"`
+	ErrorDetails         string          `json:"error_details,omitempty"`
+	LastAssistantMessage string          `json:"last_assistant_message,omitempty"`
+	CompactSummary       string          `json:"compact_summary,omitempty"`
+}

--- a/agents/entire-agent-qwen/mise.toml
+++ b/agents/entire-agent-qwen/mise.toml
@@ -1,0 +1,10 @@
+[tools]
+go = "1.26.0"
+
+[tasks.build]
+description = "Build the entire-agent-qwen binary"
+run = "go build -o entire-agent-qwen ./cmd/entire-agent-qwen"
+
+[tasks.test]
+description = "Run unit tests"
+run = "go test ./..."

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -55,6 +55,7 @@ cd e2e && go test -tags=e2e -v -count=1 -run TestLifecycle_SinglePromptManualCom
 | `E2E_ARTIFACT_DIR` | Override artifact output directory. |
 | `E2E_KEEP_REPOS` | Set to any value to preserve temp repos after tests. |
 | `E2E_CONCURRENT_TEST_LIMIT` | Override per-agent concurrency limit (default: 2 for kiro). |
+| `QWEN_E2E` | Set to `1` with `E2E_AGENT=qwen` to include live Qwen Code tests. |
 
 ## Adding a New Agent
 

--- a/e2e/agents/qwen.go
+++ b/e2e/agents/qwen.go
@@ -1,0 +1,108 @@
+package agents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func init() {
+	if os.Getenv("QWEN_E2E") != "1" || os.Getenv("E2E_AGENT") != "qwen" {
+		return
+	}
+	Register(&Qwen{})
+	RegisterGate("qwen", 1)
+}
+
+type Qwen struct{}
+
+func (q *Qwen) Name() string               { return "qwen" }
+func (q *Qwen) Binary() string             { return "qwen" }
+func (q *Qwen) EntireAgent() string        { return "qwen" }
+func (q *Qwen) PromptPattern() string      { return `>` }
+func (q *Qwen) TimeoutMultiplier() float64 { return 2.0 }
+func (q *Qwen) IsExternalAgent() bool      { return true }
+
+func (q *Qwen) IsTransientError(out Output, _ error) bool {
+	combined := strings.ToLower(out.Stdout + out.Stderr)
+	patterns := []string{
+		"overloaded",
+		"rate limit",
+		"429",
+		"500",
+		"503",
+		"econnreset",
+		"etimedout",
+		"timeout",
+	}
+	for _, pattern := range patterns {
+		if strings.Contains(combined, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func (q *Qwen) Bootstrap() error {
+	return nil
+}
+
+func (q *Qwen) RunPrompt(ctx context.Context, dir string, prompt string, opts ...Option) (Output, error) {
+	cfg := &runConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	bin, err := exec.LookPath(q.Binary())
+	if err != nil {
+		return Output{}, fmt.Errorf("%s not in PATH: %w", q.Binary(), err)
+	}
+
+	args := []string{"-p", prompt, "--yolo"}
+	displayArgs := []string{"-p", fmt.Sprintf("%q", prompt), "--yolo"}
+	if cfg.Model != "" {
+		args = append(args, "--model", cfg.Model)
+		displayArgs = append(displayArgs, "--model", cfg.Model)
+	}
+
+	env := filterEnv(os.Environ(), "ENTIRE_TEST_TTY")
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	cmd.WaitDelay = 5 * time.Second
+
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+	exitCode := 0
+	if err != nil {
+		exitErr := &exec.ExitError{}
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = -1
+		}
+	}
+
+	return Output{
+		Command:  q.Binary() + " " + strings.Join(displayArgs, " "),
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+		ExitCode: exitCode,
+	}, err
+}
+
+func (q *Qwen) StartSession(context.Context, string) (Session, error) {
+	return nil, nil
+}


### PR DESCRIPTION
## Summary
Adds official Qwen Code support via a new native Go external-agent binary, `entire-agent-qwen`.

Closes #20.

## What changed
- Adds `agents/entire-agent-qwen` with Qwen Code protocol support.
- Installs Qwen command hooks in `.qwen/settings.json` for session, prompt, stop, compaction, and tool events.
- Maps Qwen lifecycle hooks into Entire normalized events.
- Stores a stable Entire sidecar transcript in `.entire/tmp/qwen/<session_id>.jsonl` while preserving Qwen native `transcript_path` metadata.
- Adds transcript analysis and compact transcript support.
- Adds gated Qwen lifecycle e2e adapter behind `QWEN_E2E=1 E2E_AGENT=qwen`.
- Updates docs and available-agent tables.

## Validation
- `mise run build agents/entire-agent-qwen`
- `mise run test agents/entire-agent-qwen`
- `mise run build/test` for existing Amp and Kiro agents, plus Qwen
- `external-agents-tests verify agents/entire-agent-qwen/entire-agent-qwen`
- `mise exec -- golangci-lint run` in `agents/entire-agent-qwen`
- `mise exec -- golangci-lint run` in `e2e`
- `E2E_AGENT=qwen mise run test:e2e:lifecycle` verifies Qwen is skipped unless `QWEN_E2E=1`

## Notes
- Live Qwen lifecycle tests require `qwen` installed and authenticated, so they are intentionally opt-in.
- This PR targets Qwen Code CLI (`qwen`), not the lower-level Qwen-Agent Python framework.