### PR TITLE
Document Cursor ACP-in-JetBrains capture limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ External agents communicate with Entire CLI via subcommands that accept and retu
 
 See each agent's own README for setup and usage instructions.
 
+### Native agent notes
+
+The Entire CLI integrates several AI coding agents natively; see [entireio/cli](https://github.com/entireio/cli) for the current list. Known gaps in native integrations that surface to contributors here:
+
+- **Cursor inside JetBrains via ACP is not captured.** JetBrains AI Chat's Agent Client Protocol (which Cursor [joined 2026-03-04](https://blog.jetbrains.com/ai/2026/03/cursor-joined-the-acp-registry-and-is-now-live-in-your-jetbrains-ide/)) does not invoke the `.cursor/hooks.json` hooks Entire installs. Workaround for JetBrains workflows: use standalone Cursor IDE or the `cursor agent` CLI. Tracking: [#18](https://github.com/entireio/external-agents/issues/18).
+
 ## Enabling External Agents
 
 External agent discovery is opt-in. Once an `entire-agent-<name>` binary is on your `PATH`, set `external_agents: true` in the repo's `.entire/settings.json` so Entire scans for it:


### PR DESCRIPTION
## Summary

Adds a "Native agent notes" subsection to the README's Available Agents section. Documents that Cursor running inside JetBrains via ACP is not captured by `.cursor/hooks.json` hooks, and points JetBrains-workflow users at standalone Cursor IDE or `cursor agent` CLI.

## Why

Cursor's JetBrains ACP integration [shipped 2026-03-04](https://blog.jetbrains.com/ai/2026/03/cursor-joined-the-acp-registry-and-is-now-live-in-your-jetbrains-ide/), postdating the cursor agent code in `entireio/cli` (first commit 2026-02-19). ACP is a distinct protocol surface from `.cursor/hooks.json` and does not invoke those hooks. Verified by sentinel test: parallel `sh -c 'date > .entire/SENTINEL-*.txt'` commands added alongside Entire's hook on `sessionStart`, `beforeSubmitPrompt`, and `sessionEnd`. All three sentinels never wrote when a prompt was sent via JetBrains AI Chat with the Cursor ACP agent. Full reproduction context in entireio/cli#2346.

## Test plan

- [x] README.md renders correctly on GitHub
- [x] Link to entireio/cli#2346 resolves
- [x] Link to JetBrains AI Blog post resolves
- [x] \`mise run build\` passes
- [x] \`mise run test\` passes

Closes entireio/cli#2346