### PR TITLE
Revert checkpoints v2

### DIFF
--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,8 +1,5 @@
 {
   "external_agents": true,
   "enabled": true,
-  "telemetry": true,
-  "strategy_options": {
-    "checkpoints_version": "2"
-  }
+  "telemetry": true
 }


### PR DESCRIPTION
We're reassessing checkpoints v2 and working on a v1.1 with the parts that worked. We should be able to safely switch back to checkpoints v1 at this time (transcripts, commands etc. will fall back to v2 as long as the v2 ref is around).

We will keep the v2 checkpoint ref around for a bit while we work on fully migrating back to v1 for those checkpoints that were in v2-only mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that drops a single feature flag/strategy override; impact is limited to whatever reads this settings file.
> 
> **Overview**
> Reverts the checkpoints v2 configuration by removing `strategy_options.checkpoints_version: "2"` from `.entire/settings.json`.
> 
> Leaves `telemetry` enabled and otherwise keeps the settings unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82f6999d26b00f1e3aab8e7987093b9ec7b1d0fc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->