### PR TITLE
Pin ruby.compile = false in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,9 @@
 [env]
 _.path = ["bin"]
 
+[settings]
+ruby.compile = false
+
 [tools]
 go = "1.26.0"
 golangci-lint = "2.11.3"


### PR DESCRIPTION
On a fresh mise install on macOS arm64, ruby-build attempts to compile Ruby 3.4.7 from source and the psych extension cannot be configured against the system libyaml, so the build aborts before license_finder is installed. mise's own WARN points at `mise settings ruby.compile=false` as the workaround: setting it makes mise prefer precompiled Ruby binaries (which exist for macOS arm64 and Linux x86_64) and skip the broken source-build path entirely.

Pinning it in mise.toml applies the same setting per-project, so every contributor on a fresh clone gets the working path without needing to discover and apply the workaround themselves.

This becomes mise's default behaviour in 2026.8.0, at which point the pin can be removed but keeping it there would also not matter.

Closes #31 