### PR TITLE
Add Oh My Pi external agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ External agents communicate with Entire CLI via subcommands that accept and retu
 | [Kiro](agents/entire-agent-kiro/) | `agents/entire-agent-kiro/` | Implemented — hooks + transcript analysis |
 | [Amp](agents/entire-agent-amp/) | `agents/entire-agent-amp/` | Implemented — hooks + transcript analysis + token calculation + compact transcripts |
 | [Qwen Code](agents/entire-agent-qwen/) | `agents/entire-agent-qwen/` | Implemented — hooks + transcript analysis + compact transcripts |
+| [Oh My Pi](agents/entire-agent-omp/) | `agents/entire-agent-omp/` | Implemented — hooks + transcript analysis + compact transcripts |
 
 See each agent's own README for setup and usage instructions.
 
@@ -130,6 +131,7 @@ agents/                          # Standalone external agent projects
   entire-agent-kiro/             # Kiro agent (Go binary)
   entire-agent-amp/              # Amp agent (Go binary)
   entire-agent-qwen/             # Qwen Code agent (Go binary)
+  entire-agent-omp/              # Oh My Pi agent (Go binary)
 e2e/                             # Lifecycle integration harness
 .github/workflows/               # CI, including protocol compliance via external-agents-tests
 .claude/skills/entire-external-agent/  # Skill files (research, test-writer, implementer)

--- a/agents/entire-agent-omp/.gitignore
+++ b/agents/entire-agent-omp/.gitignore
@@ -1,0 +1,1 @@
+/entire-agent-omp

--- a/agents/entire-agent-omp/AGENT.md
+++ b/agents/entire-agent-omp/AGENT.md
@@ -71,6 +71,8 @@ Native filenames are `<timestamp>_<session-id>.jsonl`. Session ID lookup therefo
 
 Legacy files can begin directly with the session header. The adapter accepts both layouts. Conversation state is a tree: the active transcript starts at the last valid entry, follows `parentId` to the root, then reverses that chain. File order alone does not define the active branch.
 
+Transcript analysis and compaction also accept checkpoint-scoped slices that begin at a native entry and omit the title and session header. A slice that includes either header form must contain a valid session header.
+
 Message entries use roles `user`, `assistant`, and `toolResult`. Assistant content can contain `text`, `thinking`, and `toolCall` blocks. Tool calls carry `id`, `name`, and `arguments`; tool results refer back through `toolCallId`.
 
 At TurnEnd, the adapter copies the source to:
@@ -104,7 +106,7 @@ The adapter rejects a source unless it resolves to a regular direct-child `.json
 | `extract-modified-files` | Active-branch `write`, `edit`, and `apply_patch` tool paths after the physical-line offset |
 | `extract-prompts` | Active-branch user text after the physical-line offset |
 | `extract-summary` | Last non-empty active-branch assistant text |
-| `compact-transcript` | Base64-wrapped Entire v1 compact JSONL with user text, assistant text, tool calls/results, and available input/output usage |
+| `compact-transcript` | Full sessions or checkpoint-scoped slices to base64-wrapped Entire v1 compact JSONL with user text, assistant text, tool calls/results, and available input/output usage |
 
 ## Declared Capabilities
 

--- a/agents/entire-agent-omp/AGENT.md
+++ b/agents/entire-agent-omp/AGENT.md
@@ -1,0 +1,140 @@
+# Oh My Pi Integration Contract
+
+## Compatibility Target
+
+| Interface | Target |
+|---|---|
+| `omp` CLI and extension API | 17.1.1 |
+| `omp` session format | JSONL version 3, with legacy header-first and current title-slot-first physical layouts |
+| Entire external-agent protocol | 1 |
+| Entire lifecycle validation | 0.8.42 on Linux |
+
+Compatibility claims below are limited to these versions and the tagged `omp` sources listed under Evidence.
+
+## Native Interface
+
+- Product: Oh My Pi; official short name and binary: `omp`.
+- Print mode: `omp -p <prompt>`.
+- Unattended approval: `--approval-mode=yolo`.
+- Resume: `omp --resume <session-id>`; continue the latest terminal session with `omp --continue`.
+- Project extensions: `<cwd>/.omp/extensions`; a directory entry resolves through `index.ts` before `index.js`.
+- Extension factory: a default-exported function receiving `ExtensionAPI` from `@oh-my-pi/pi-coding-agent`.
+
+### Lifecycle Mapping
+
+| `omp` extension event | Native guarantee used | Entire event |
+|---|---|---|
+| `session_start` | Initial session load; session manager and project cwd are available | type 1, SessionStart |
+| `session_switch` | `/new`, resume, fork, or handoff completed | type 1, SessionStart after draining the previous turn |
+| `session_branch` | Branch navigation completed | type 1, SessionStart after draining the previous turn |
+| `before_agent_start` | Pre-send prompt notification; may be superseded before execution | no protocol event; caches the pending prompt |
+| `agent_start` | Agent loop actually begins; repeats from an automatic continuation are skipped | type 2, TurnStart with the pending prompt |
+| `agent_end` | Emitted after `omp` decides whether the settled turn will continue; `willContinue: true` is skipped | type 3, TurnEnd, synchronously forwarded under hook name `agent_end` |
+| `session_shutdown` | Session cleanup | no protocol event; clears adapter-local identity cache |
+
+`omp` 17.1.1 can supersede a `before_agent_start` notification before the agent loop begins, so the adapter waits for `agent_start` before opening the Entire turn. Intermediate settles carry `willContinue: true`; they and repeated start events from automatic continuations stay within the existing turn. The final settle is forwarded synchronously so print-mode shutdown cannot discard the Entire TurnEnd event. Session switches and branches use the same reset path as initial loading, with any previous TurnEnd completed before the new SessionStart.
+
+The generated extension reads session identity through `ctx.sessionManager.getSessionId()` and the native transcript path through `ctx.sessionManager.getSessionFile()`. Hook subprocess failures are contained and never abort `omp`.
+
+## Session Storage
+
+Default root:
+
+```text
+$HOME/${PI_CONFIG_DIR:-.omp}/agent/sessions/<encoded-cwd>/
+```
+
+Overrides:
+
+- `PI_CONFIG_DIR=<config-dir>` changes the config directory relative to home.
+- `PI_CODING_AGENT_DIR=<agent-dir>` selects the absolute-resolved `<agent-dir>/sessions` and normally takes precedence over XDG.
+- `OMP_PROFILE=<name>` selects `$HOME/${PI_CONFIG_DIR:-.omp}/profiles/<name>/agent/sessions`; `PI_PROFILE` is the fallback when `OMP_PROFILE` is unset. An empty value or `default` selects the default profile.
+- On Linux and macOS, an existing `$XDG_DATA_HOME/omp` selects its `sessions` directory for the default profile. A named profile instead requires and selects `$XDG_DATA_HOME/omp/profiles/<name>/sessions`. Windows does not activate XDG roots.
+
+`omp` canonicalizes cwd before deriving `<encoded-cwd>`:
+
+- inside home: `-<relative-path>`;
+- inside the OS temporary root: `-tmp-<relative-path>`;
+- elsewhere: `--<absolute-path-without-leading-separator>--`.
+
+For every form, `/`, `\\`, and `:` inside the encoded portion are replaced by `-`; the encoding is one directory name, not a nested path. Home itself is `-`, and the temporary root itself is `-tmp`.
+
+Native filenames are `<timestamp>_<session-id>.jsonl`. Session ID lookup therefore scans direct `.jsonl` files and compares the parsed header ID rather than assuming the ID is the filename.
+
+### Physical JSONL Layout
+
+`omp` 17.1.1 may write:
+
+1. a `type: "title"` slot exactly 256 UTF-8 bytes including its newline;
+2. a `type: "session"` header containing `version`, `id`, `timestamp`, and `cwd`;
+3. append-only entries carrying `id`, `parentId`, `timestamp`, and an entry-specific payload.
+
+Legacy files can begin directly with the session header. The adapter accepts both layouts. Conversation state is a tree: the active transcript starts at the last valid entry, follows `parentId` to the root, then reverses that chain. File order alone does not define the active branch.
+
+Message entries use roles `user`, `assistant`, and `toolResult`. Assistant content can contain `text`, `thinking`, and `toolCall` blocks. Tool calls carry `id`, `name`, and `arguments`; tool results refer back through `toolCallId`.
+
+At TurnEnd, the adapter copies the source to:
+
+```text
+<managed omp project session directory>/.entire/<session-id>.jsonl
+```
+
+The adapter rejects a source unless it resolves to a regular direct-child `.jsonl` file under the computed `omp` project session directory, and rejects a destination that is a symlink or not a directory. These same-user path checks are not a race-resistant filesystem boundary. Directory and file modes are restricted to `0700` and `0600`. A failed validation or copy emits TurnEnd without `session_ref` or `model`; it never exposes an unstable source path.
+
+## Protocol Mapping
+
+| Subcommand | `omp` mapping |
+|---|---|
+| `info` | Name `omp`; protected directory `.omp`; protected file `.omp/extensions/entire/index.ts` |
+| `detect` | `omp` lookup on `PATH` |
+| `get-session-id` | Hook `session_id` |
+| `get-session-dir` | `omp`-managed project session directory |
+| `resolve-session-file` | Header-ID scan, then safe `<session-id>.jsonl` fallback |
+| `read-session` | Header metadata plus byte-for-byte native JSONL; opaque protocol data remains readable |
+| `write-session` | Atomic private write of `native_data` to `session_ref` |
+| `read-transcript` | Raw `session_ref` bytes |
+| `chunk-transcript` | Size-bounded raw byte chunks |
+| `reassemble-transcript` | Exact byte concatenation |
+| `format-resume-command` | `omp --resume <quoted-id>` or `omp --continue` |
+| `parse-hook` | Lifecycle table above |
+| `install-hooks` | Atomic install of `.omp/extensions/entire/index.ts`; foreign content is preserved unless forced |
+| `uninstall-hooks` | Remove only a marker-owned extension |
+| `are-hooks-installed` | Marker check on the owned extension |
+| `get-transcript-position` | Physical JSONL line count |
+| `extract-modified-files` | Active-branch `write`, `edit`, and `apply_patch` tool paths after the physical-line offset |
+| `extract-prompts` | Active-branch user text after the physical-line offset |
+| `extract-summary` | Last non-empty active-branch assistant text |
+| `compact-transcript` | Base64-wrapped Entire v1 compact JSONL with user text, assistant text, tool calls/results, and available input/output usage |
+
+## Declared Capabilities
+
+| Capability | Value | Basis |
+|---|---:|---|
+| `hooks` | true | Project extension lifecycle events |
+| `transcript_analyzer` | true | Native JSONL contains prompts, assistant text, tool calls, and paths |
+| `compact_transcript` | true | Native messages map to Entire compact JSONL |
+| `uses_terminal` | true | `omp` supports print and interactive terminal modes |
+| `transcript_preparer` | false | Native transcript already exists on disk |
+| `token_calculator` | false | No separate aggregate-token protocol implementation |
+| `text_generator` | false | `omp` execution remains outside the adapter protocol |
+| `hook_response_writer` | false | Lifecycle forwarding needs no `omp` response channel |
+| `subagent_aware_extractor` | false | No declared external-agent subagent transcript contract |
+
+## Limits
+
+- `--no-extensions` prevents lifecycle forwarding.
+- Explicit `--session-dir` paths fall outside the managed-directory proof and produce TurnEnd without a transcript reference.
+- Modified-file extraction covers explicit mutating tool calls. It does not infer arbitrary shell side effects.
+- The adapter ignores thinking/image/custom blocks in compact output unless they contain supported user or assistant text.
+- `omp` schema or lifecycle changes after 17.1.1 require renewed compatibility verification.
+
+## Evidence
+
+- `omp` 17.1.1 extension API: <https://github.com/can1357/oh-my-pi/blob/v17.1.1/docs/extensions.md>
+- `omp` 17.1.1 extension discovery: <https://github.com/can1357/oh-my-pi/blob/v17.1.1/docs/extension-loading.md>
+- `omp` 17.1.1 session model: <https://github.com/can1357/oh-my-pi/blob/v17.1.1/docs/session.md>
+- `omp` 17.1.1 lifecycle routing: <https://github.com/can1357/oh-my-pi/blob/v17.1.1/packages/coding-agent/src/session/agent-session.ts>
+- `omp` 17.1.1 lifecycle event contracts: <https://github.com/can1357/oh-my-pi/blob/v17.1.1/packages/coding-agent/src/extensibility/shared-events.ts>
+- `omp` 17.1.1 directory roots: <https://github.com/can1357/oh-my-pi/blob/v17.1.1/packages/utils/src/dirs.ts>
+- `omp` 17.1.1 cwd encoding: <https://github.com/can1357/oh-my-pi/blob/v17.1.1/packages/coding-agent/src/session/session-paths.ts>
+- `omp` 17.1.1 fixed title slot: <https://github.com/can1357/oh-my-pi/blob/v17.1.1/packages/coding-agent/src/session/session-title-slot.ts>

--- a/agents/entire-agent-omp/README.md
+++ b/agents/entire-agent-omp/README.md
@@ -1,0 +1,75 @@
+# entire-agent-omp
+
+External agent binary that adds Oh My Pi (`omp`) support to Entire CLI.
+
+## Requirements
+
+- `entire` on `PATH` with external-agent discovery enabled.
+- `omp` on `PATH`. This adapter is validated against `omp` 17.1.1.
+
+## Installation
+
+Using mise:
+
+```bash
+cd agents/entire-agent-omp
+mise run build
+cp entire-agent-omp ~/.local/bin/
+```
+
+Using Go directly:
+
+```bash
+cd agents/entire-agent-omp
+go build -o entire-agent-omp ./cmd/entire-agent-omp
+cp entire-agent-omp ~/.local/bin/
+```
+
+## Enable in a Repository
+
+Set `external_agents` in `.entire/settings.json`:
+
+```json
+{
+  "external_agents": true
+}
+```
+
+Then enable Oh My Pi:
+
+```bash
+entire enable --agent omp --telemetry=false
+```
+
+Entire installs the project extension at `.omp/extensions/entire/index.ts`. `omp` loads this extension automatically when started from that repository.
+
+## Usage
+
+```bash
+omp -p "Create hello.txt with hello world" --approval-mode=yolo
+git add hello.txt
+git commit -m "add hello.txt"
+entire checkpoint list
+```
+
+Interactive `omp` sessions use the same extension. Entire can resume a recorded session through `omp --resume <session-id>`; an empty session ID maps to `omp --continue`.
+
+## Behavior
+
+| Capability | Behavior |
+|---|---|
+| `hooks` | Maps `omp` initial load, session switch/branch, the first actual `agent_start`, and the final `agent_end` to Entire session start, turn start, and turn end events. The preceding prompt is captured from `before_agent_start`; automatic continuations remain within the open Entire turn. |
+| `transcript_analyzer` | Reads `omp` JSONL, follows the active parent chain, extracts user prompts, the latest assistant text, and paths from `write`, `edit`, and `apply_patch` tool calls. |
+| `compact_transcript` | Emits Entire v1 compact JSONL with user text, assistant text, tool calls/results, and available per-message token counts. |
+| `uses_terminal` | Supports print and interactive `omp` sessions. |
+
+At turn end, the adapter copies the native transcript to `<omp project session directory>/.entire/<session-id>.jsonl`. The copy is private and stable while Entire records the turn. The source must be a regular `.jsonl` file directly inside the project session directory managed by `omp`.
+
+The installed extension also exports `GIT_TERMINAL_PROMPT=0` for `omp` bash tool calls unless the command already sets it, preventing unattended Git commands from waiting for terminal credentials.
+
+## Limitations
+
+- `omp --no-extensions` disables Entire lifecycle capture.
+- Explicit `omp --session-dir` paths are not accepted for turn-end snapshots. Use the default `omp` directory, `PI_CONFIG_DIR`, profile/`PI_CODING_AGENT_DIR`, or active XDG-managed session directory.
+- Modified-file analysis does not infer paths changed indirectly by arbitrary shell commands.
+- `omp` event and session formats are versioned interfaces. Versions other than 17.1.1 require compatibility verification.

--- a/agents/entire-agent-omp/cmd/entire-agent-omp/main.go
+++ b/agents/entire-agent-omp/cmd/entire-agent-omp/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/entireio/external-agents/agents/entire-agent-omp/internal/omp"
+	"github.com/entireio/external-agents/agents/entire-agent-omp/internal/protocol"
+)
+
+func main() {
+	agent := omp.New()
+	if len(os.Args) < 2 {
+		fatalf("usage: entire-agent-omp <subcommand> [args]")
+	}
+
+	var err error
+	switch os.Args[1] {
+	case "info":
+		err = protocol.WriteJSON(os.Stdout, agent.Info())
+	case "detect":
+		err = protocol.WriteJSON(os.Stdout, agent.Detect())
+	case "get-session-id":
+		err = protocol.HandleGetSessionID(os.Stdin, os.Stdout, agent)
+	case "get-session-dir":
+		err = protocol.HandleGetSessionDir(os.Args[2:], os.Stdout, agent)
+	case "resolve-session-file":
+		err = protocol.HandleResolveSessionFile(os.Args[2:], os.Stdout, agent)
+	case "read-session":
+		err = protocol.HandleReadSession(os.Stdin, os.Stdout, agent)
+	case "write-session":
+		err = protocol.HandleWriteSession(os.Stdin, agent)
+	case "read-transcript":
+		err = protocol.HandleReadTranscript(os.Args[2:], os.Stdout, agent)
+	case "chunk-transcript":
+		err = protocol.HandleChunkTranscript(os.Args[2:], os.Stdin, os.Stdout, agent)
+	case "reassemble-transcript":
+		err = protocol.HandleReassembleTranscript(os.Stdin, os.Stdout, agent)
+	case "compact-transcript":
+		err = protocol.HandleCompactTranscript(os.Args[2:], os.Stdout, agent)
+	case "format-resume-command":
+		err = protocol.HandleFormatResumeCommand(os.Args[2:], os.Stdout, agent)
+	case "parse-hook":
+		err = protocol.HandleParseHook(os.Args[2:], os.Stdin, os.Stdout, agent)
+	case "install-hooks":
+		err = protocol.HandleInstallHooks(os.Args[2:], os.Stdout, agent)
+	case "uninstall-hooks":
+		err = agent.UninstallHooks()
+	case "are-hooks-installed":
+		err = protocol.WriteJSON(os.Stdout, protocol.AreHooksInstalledResponse{Installed: agent.AreHooksInstalled()})
+	case "get-transcript-position":
+		err = protocol.HandleGetTranscriptPosition(os.Args[2:], os.Stdout, agent)
+	case "extract-modified-files":
+		err = protocol.HandleExtractModifiedFiles(os.Args[2:], os.Stdout, agent)
+	case "extract-prompts":
+		err = protocol.HandleExtractPrompts(os.Args[2:], os.Stdout, agent)
+	case "extract-summary":
+		err = protocol.HandleExtractSummary(os.Args[2:], os.Stdout, agent)
+	default:
+		fatalf("unknown subcommand: %s", os.Args[1])
+	}
+	if err != nil {
+		fatalf("%v", err)
+	}
+}
+
+func fatalf(format string, args ...any) {
+	_, _ = fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/agents/entire-agent-omp/go.mod
+++ b/agents/entire-agent-omp/go.mod
@@ -1,0 +1,3 @@
+module github.com/entireio/external-agents/agents/entire-agent-omp
+
+go 1.26.0

--- a/agents/entire-agent-omp/internal/omp/agent.go
+++ b/agents/entire-agent-omp/internal/omp/agent.go
@@ -1,0 +1,67 @@
+package omp
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/entireio/external-agents/agents/entire-agent-omp/internal/protocol"
+)
+
+type Agent struct{}
+
+func New() *Agent { return &Agent{} }
+
+func (a *Agent) Info() protocol.InfoResponse {
+	return protocol.InfoResponse{
+		ProtocolVersion: protocol.ProtocolVersion,
+		Name:            "omp",
+		Type:            "Oh My Pi",
+		Description:     "Oh My Pi terminal coding agent",
+		IsPreview:       true,
+		ProtectedDirs:   []string{".omp"},
+		ProtectedFiles:  []string{extensionRelFile},
+		HookNames: []string{
+			HookNameSessionStart,
+			HookNameAgentStart,
+			HookNameAgentEnd,
+			HookNameSessionShutdown,
+		},
+		Capabilities: protocol.DeclaredCapabilities{
+			Hooks:              true,
+			TranscriptAnalyzer: true,
+			CompactTranscript:  true,
+			UsesTerminal:       true,
+		},
+	}
+}
+
+func (a *Agent) Detect() protocol.DetectResponse {
+	_, err := exec.LookPath("omp")
+	return protocol.DetectResponse{Present: err == nil}
+}
+
+func (a *Agent) GetSessionID(input *protocol.HookInputJSON) string {
+	if input == nil {
+		return ""
+	}
+	return input.SessionID
+}
+
+func (a *Agent) FormatResumeCommand(sessionID string) string {
+	if sessionID == "" {
+		return "omp --continue"
+	}
+	return "omp --resume " + shellQuote(sessionID)
+}
+
+func shellQuote(value string) string {
+	if strings.IndexFunc(value, func(r rune) bool { return !safeShellRune(r) }) == -1 {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}
+
+func safeShellRune(r rune) bool {
+	return r == '-' || r == '_' || r == '.' || r == ':' ||
+		(r >= '0' && r <= '9') || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+}

--- a/agents/entire-agent-omp/internal/omp/agent_test.go
+++ b/agents/entire-agent-omp/internal/omp/agent_test.go
@@ -1,0 +1,48 @@
+package omp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/external-agents/agents/entire-agent-omp/internal/protocol"
+)
+
+func TestDetectUsesPath(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+	if New().Detect().Present {
+		t.Fatal("Detect().Present = true without omp on PATH")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "omp"), []byte("#!/bin/sh\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if !New().Detect().Present {
+		t.Fatal("Detect().Present = false with omp on PATH")
+	}
+}
+
+func TestGetSessionID(t *testing.T) {
+	agent := New()
+	if got := agent.GetSessionID(nil); got != "" {
+		t.Fatalf("GetSessionID(nil) = %q", got)
+	}
+	if got := agent.GetSessionID(&protocol.HookInputJSON{SessionID: "session-1"}); got != "session-1" {
+		t.Fatalf("GetSessionID() = %q", got)
+	}
+}
+
+func TestFormatResumeCommand(t *testing.T) {
+	tests := []struct{ id, want string }{
+		{"", "omp --continue"},
+		{"019abc-safe", "omp --resume 019abc-safe"},
+		{"two words", "omp --resume 'two words'"},
+		{"a'b", "omp --resume 'a'\\''b'"},
+		{"$(touch nope)", "omp --resume '$(touch nope)'"},
+	}
+	for _, test := range tests {
+		if got := New().FormatResumeCommand(test.id); got != test.want {
+			t.Errorf("FormatResumeCommand(%q) = %q, want %q", test.id, got, test.want)
+		}
+	}
+}

--- a/agents/entire-agent-omp/internal/omp/compact.go
+++ b/agents/entire-agent-omp/internal/omp/compact.go
@@ -59,7 +59,11 @@ func (a *Agent) CompactTranscript(sessionRef string) (protocol.CompactTranscript
 }
 
 func compactTranscriptBytes(data []byte) ([]byte, error) {
-	session, err := parseSession(data)
+	// Use the tolerant parser: Entire scopes checkpoint transcripts from a
+	// mid-session offset before calling compact-transcript, so the title/session
+	// header is often absent. The transcript_analyzer methods already parse
+	// loosely; compaction must too, or scoped slices fail to summarize.
+	session, err := parseSessionLoose(data)
 	if err != nil {
 		return nil, err
 	}

--- a/agents/entire-agent-omp/internal/omp/compact.go
+++ b/agents/entire-agent-omp/internal/omp/compact.go
@@ -1,0 +1,203 @@
+package omp
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/entireio/external-agents/agents/entire-agent-omp/internal/protocol"
+)
+
+type compactLine struct {
+	V            int    `json:"v"`
+	Agent        string `json:"agent"`
+	CLIVersion   string `json:"cli_version"`
+	Type         string `json:"type"`
+	TS           string `json:"ts,omitempty"`
+	ID           string `json:"id,omitempty"`
+	InputTokens  int    `json:"input_tokens,omitempty"`
+	OutputTokens int    `json:"output_tokens,omitempty"`
+	Content      any    `json:"content"`
+}
+
+type compactUserBlock struct {
+	Text string `json:"text"`
+}
+
+type compactTextBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type compactToolBlock struct {
+	Type   string             `json:"type"`
+	ID     string             `json:"id,omitempty"`
+	Name   string             `json:"name"`
+	Input  any                `json:"input"`
+	Result *compactToolResult `json:"result,omitempty"`
+}
+
+type compactToolResult struct {
+	Output string `json:"output"`
+	Status string `json:"status"`
+}
+
+func (a *Agent) CompactTranscript(sessionRef string) (protocol.CompactTranscriptResponse, error) {
+	data, err := os.ReadFile(sessionRef)
+	if err != nil {
+		return protocol.CompactTranscriptResponse{}, fmt.Errorf("failed to read transcript: %w", err)
+	}
+	compacted, err := compactTranscriptBytes(data)
+	if err != nil {
+		return protocol.CompactTranscriptResponse{}, err
+	}
+	return protocol.CompactTranscriptResponse{Transcript: base64.StdEncoding.EncodeToString(compacted)}, nil
+}
+
+func compactTranscriptBytes(data []byte) ([]byte, error) {
+	session, err := parseSession(data)
+	if err != nil {
+		return nil, err
+	}
+	results := collectOMPToolResults(session.Active)
+	var output bytes.Buffer
+	for _, record := range session.Active {
+		message := record.Entry.Message
+		if message == nil {
+			continue
+		}
+		switch message.Role {
+		case "user":
+			content := compactOMPUserBlocks(message.Content)
+			if len(content) == 0 {
+				continue
+			}
+			if err := writeCompactLine(&output, compactLine{
+				V: 1, Agent: "omp", CLIVersion: compactCLIVersion(), Type: "user",
+				TS: record.Entry.Timestamp, Content: content,
+			}); err != nil {
+				return nil, err
+			}
+		case "assistant":
+			content := compactAssistantBlocks(message.Content, results)
+			if len(content) == 0 {
+				continue
+			}
+			line := compactLine{
+				V: 1, Agent: "omp", CLIVersion: compactCLIVersion(), Type: "assistant",
+				TS: record.Entry.Timestamp, ID: record.Entry.ID, Content: content,
+			}
+			if message.Usage != nil {
+				line.InputTokens = message.Usage.Input
+				line.OutputTokens = message.Usage.Output
+			}
+			if err := writeCompactLine(&output, line); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if output.Len() == 0 {
+		return nil, errors.New("compact transcript produced no output")
+	}
+	return output.Bytes(), nil
+}
+
+func compactOMPUserBlocks(raw json.RawMessage) []compactUserBlock {
+	var text string
+	if json.Unmarshal(raw, &text) == nil {
+		if text == "" {
+			return nil
+		}
+		return []compactUserBlock{{Text: text}}
+	}
+	var output []compactUserBlock
+	for _, block := range messageBlocks(raw) {
+		if block.Type == "text" && block.Text != "" {
+			output = append(output, compactUserBlock{Text: block.Text})
+		}
+	}
+	return output
+}
+
+func collectOMPToolResults(entries []parsedEntry) map[string]compactToolResult {
+	results := make(map[string]compactToolResult)
+	for _, record := range entries {
+		message := record.Entry.Message
+		if message == nil || message.Role != "toolResult" || message.ToolCallID == "" {
+			continue
+		}
+		status := "success"
+		if message.IsError {
+			status = "error"
+		}
+		results[message.ToolCallID] = compactToolResult{Output: messageText(message.Content), Status: status}
+	}
+	return results
+}
+
+func compactAssistantBlocks(raw json.RawMessage, results map[string]compactToolResult) []any {
+	var output []any
+	for _, block := range messageBlocks(raw) {
+		switch block.Type {
+		case "text":
+			if block.Text != "" {
+				output = append(output, compactTextBlock{Type: "text", Text: block.Text})
+			}
+		case "toolCall":
+			if block.Name == "" {
+				continue
+			}
+			tool := compactToolBlock{
+				Type: "tool_use", ID: block.ID, Name: compactToolName(block.Name), Input: decodeToolArguments(block.Arguments),
+			}
+			if result, ok := results[block.ID]; ok {
+				tool.Result = &result
+			}
+			output = append(output, tool)
+		}
+	}
+	return output
+}
+
+func compactToolName(name string) string {
+	normalized := normalizeToolName(name)
+	switch normalized {
+	case "read", "write", "edit":
+		return normalized
+	case "apply_patch":
+		return "edit"
+	default:
+		return name
+	}
+}
+
+func decodeToolArguments(raw json.RawMessage) any {
+	if len(raw) == 0 {
+		return map[string]any{}
+	}
+	var value any
+	if json.Unmarshal(raw, &value) != nil {
+		return map[string]any{}
+	}
+	return value
+}
+
+func writeCompactLine(output *bytes.Buffer, line compactLine) error {
+	encoded, err := json.Marshal(line)
+	if err != nil {
+		return err
+	}
+	output.Write(encoded)
+	return output.WriteByte('\n')
+}
+
+func compactCLIVersion() string {
+	if version := strings.TrimSpace(os.Getenv("ENTIRE_CLI_VERSION")); version != "" {
+		return version
+	}
+	return "unknown"
+}

--- a/agents/entire-agent-omp/internal/omp/compact.go
+++ b/agents/entire-agent-omp/internal/omp/compact.go
@@ -82,13 +82,13 @@ func compactTranscriptBytes(data []byte) ([]byte, error) {
 			}); err != nil {
 				return nil, err
 			}
-		case "assistant":
+		case roleAssistant:
 			content := compactAssistantBlocks(message.Content, results)
 			if len(content) == 0 {
 				continue
 			}
 			line := compactLine{
-				V: 1, Agent: "omp", CLIVersion: compactCLIVersion(), Type: "assistant",
+				V: 1, Agent: "omp", CLIVersion: compactCLIVersion(), Type: roleAssistant,
 				TS: record.Entry.Timestamp, ID: record.Entry.ID, Content: content,
 			}
 			if message.Usage != nil {

--- a/agents/entire-agent-omp/internal/omp/compact.go
+++ b/agents/entire-agent-omp/internal/omp/compact.go
@@ -59,11 +59,7 @@ func (a *Agent) CompactTranscript(sessionRef string) (protocol.CompactTranscript
 }
 
 func compactTranscriptBytes(data []byte) ([]byte, error) {
-	// Use the tolerant parser: Entire scopes checkpoint transcripts from a
-	// mid-session offset before calling compact-transcript, so the title/session
-	// header is often absent. The transcript_analyzer methods already parse
-	// loosely; compaction must too, or scoped slices fail to summarize.
-	session, err := parseSessionLoose(data)
+	session, err := parseSessionSlice(data)
 	if err != nil {
 		return nil, err
 	}

--- a/agents/entire-agent-omp/internal/omp/compact_test.go
+++ b/agents/entire-agent-omp/internal/omp/compact_test.go
@@ -128,6 +128,26 @@ func TestCompactStringUserAndMalformedBlocks(t *testing.T) {
 	}
 }
 
+func TestCompactToleratesMissingSessionHeader(t *testing.T) {
+	// Entire scopes checkpoint transcripts from a mid-session offset before
+	// calling compact-transcript, so the title/session header is dropped.
+	// Compaction must still succeed on the header-less slice, matching the
+	// tolerant behavior of the transcript_analyzer methods.
+	parts := strings.SplitN(string(ompCompactFixture()), "\n", 3)
+	if len(parts) < 3 {
+		t.Fatalf("fixture too short to strip header")
+	}
+	headerless := []byte(parts[2])
+
+	data, err := compactTranscriptBytes(headerless)
+	if err != nil {
+		t.Fatalf("compact header-less slice: %v", err)
+	}
+	if lines := decodeCompactLines(t, data); len(lines) != 3 {
+		t.Fatalf("lines = %d, want 3: %s", len(lines), data)
+	}
+}
+
 func TestCompactRejectsNoOutputAndInvalidNative(t *testing.T) {
 	noOutput := []byte(ompHeader() +
 		`{"type":"message","id":"thinking","parentId":null,"message":{"role":"assistant","content":[{"type":"thinking","thinking":"hidden"},{"type":"image","data":"x"}]}}` + "\n")

--- a/agents/entire-agent-omp/internal/omp/compact_test.go
+++ b/agents/entire-agent-omp/internal/omp/compact_test.go
@@ -129,19 +129,19 @@ func TestCompactStringUserAndMalformedBlocks(t *testing.T) {
 }
 
 func TestCompactToleratesMissingSessionHeader(t *testing.T) {
-	// Entire scopes checkpoint transcripts from a mid-session offset before
-	// calling compact-transcript, so the title/session header is dropped.
-	// Compaction must still succeed on the header-less slice, matching the
-	// tolerant behavior of the transcript_analyzer methods.
 	parts := strings.SplitN(string(ompCompactFixture()), "\n", 3)
 	if len(parts) < 3 {
 		t.Fatalf("fixture too short to strip header")
 	}
-	headerless := []byte(parts[2])
+	path := writeOMPFixture(t, []byte(parts[2]))
 
-	data, err := compactTranscriptBytes(headerless)
+	response, err := (&Agent{}).CompactTranscript(path)
 	if err != nil {
 		t.Fatalf("compact header-less slice: %v", err)
+	}
+	data, err := base64.StdEncoding.DecodeString(response.Transcript)
+	if err != nil {
+		t.Fatal(err)
 	}
 	if lines := decodeCompactLines(t, data); len(lines) != 3 {
 		t.Fatalf("lines = %d, want 3: %s", len(lines), data)

--- a/agents/entire-agent-omp/internal/omp/compact_test.go
+++ b/agents/entire-agent-omp/internal/omp/compact_test.go
@@ -1,0 +1,147 @@
+package omp
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+func ompCompactFixture() []byte {
+	return []byte(ompTitleSlot() + ompHeader() +
+		`{"type":"model_change","id":"model","parentId":null,"timestamp":"2026-07-26T03:14:07Z","model":"openai/gpt"}` + "\n" +
+		`{"type":"thinking_level_change","id":"thinking-level","parentId":"model","timestamp":"2026-07-26T03:14:08Z","thinkingLevel":"medium"}` + "\n" +
+		`{"type":"custom_message","customType":"notice","content":"hidden","id":"custom","parentId":"thinking-level","timestamp":"2026-07-26T03:14:09Z"}` + "\n" +
+		`{"type":"message","id":"user","parentId":"custom","timestamp":"2026-07-26T03:14:10Z","message":{"role":"user","content":[{"type":"text","text":"first"},42,{"type":"image","data":"ignored"},{"type":"text","text":"second"}]}}` + "\n" +
+		`{"type":"message","id":"assistant-tool","parentId":"user","timestamp":"2026-07-26T03:14:11Z","message":{"role":"assistant","model":"openai/gpt-5","content":[{"type":"thinking","thinking":"hidden"},{"type":"toolCall","id":"tool-1","name":"Write","arguments":{"path":"x.go"}},{"type":"toolCall","id":"tool-2","name":"mcp:read","arguments":{"path":"x.go"}},{"type":"image","data":"ignored"}],"usage":{"input":101,"output":23}}}` + "\n" +
+		`{"type":"message","id":"result-1","parentId":"assistant-tool","timestamp":"2026-07-26T03:14:12Z","message":{"role":"toolResult","toolCallId":"tool-1","toolName":"Write","content":[{"type":"text","text":"written"}],"isError":false}}` + "\n" +
+		`{"type":"message","id":"result-2","parentId":"result-1","timestamp":"2026-07-26T03:14:13Z","message":{"role":"toolResult","toolCallId":"tool-2","toolName":"read","content":"permission denied","isError":true}}` + "\n" +
+		`{"type":"message","id":"assistant-final","parentId":"result-2","timestamp":"2026-07-26T03:14:14Z","message":{"role":"assistant","model":"openai/gpt-5","content":[{"type":"fallback","text":"ignored"},"bad block",{"type":"text","text":"done"}]}}` + "\n")
+}
+
+type decodedCompactLine struct {
+	V            int               `json:"v"`
+	Agent        string            `json:"agent"`
+	CLIVersion   string            `json:"cli_version"`
+	Type         string            `json:"type"`
+	ID           string            `json:"id"`
+	InputTokens  int               `json:"input_tokens"`
+	OutputTokens int               `json:"output_tokens"`
+	Content      []json.RawMessage `json:"content"`
+}
+
+func decodeCompactLines(t *testing.T, data []byte) []decodedCompactLine {
+	t.Helper()
+	var lines []decodedCompactLine
+	for _, encoded := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		var line decodedCompactLine
+		if err := json.Unmarshal([]byte(encoded), &line); err != nil {
+			t.Fatal(err)
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+func TestCompactActiveMessagesToolsResultsAndTokens(t *testing.T) {
+	data, err := compactTranscriptBytes(ompCompactFixture())
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := decodeCompactLines(t, data)
+	if len(lines) != 3 {
+		t.Fatalf("lines = %d, want 3: %s", len(lines), data)
+	}
+	if lines[0].V != 1 || lines[0].Agent != "omp" || lines[0].CLIVersion == "" || lines[0].Type != "user" || len(lines[0].Content) != 2 {
+		t.Fatalf("unexpected user line: %+v", lines[0])
+	}
+	var first, second compactUserBlock
+	if err := json.Unmarshal(lines[0].Content[0], &first); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(lines[0].Content[1], &second); err != nil {
+		t.Fatal(err)
+	}
+	if first.Text != "first" || second.Text != "second" {
+		t.Fatalf("user blocks = %+v, %+v", first, second)
+	}
+	if lines[1].Type != "assistant" || lines[1].ID != "assistant-tool" || lines[1].InputTokens != 101 || lines[1].OutputTokens != 23 || len(lines[1].Content) != 2 {
+		t.Fatalf("unexpected tool line: %+v", lines[1])
+	}
+	var writeTool, readTool compactToolBlock
+	if err := json.Unmarshal(lines[1].Content[0], &writeTool); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(lines[1].Content[1], &readTool); err != nil {
+		t.Fatal(err)
+	}
+	if writeTool.Name != "write" || writeTool.Result == nil || writeTool.Result.Status != "success" || writeTool.Result.Output != "written" {
+		t.Fatalf("write tool = %+v", writeTool)
+	}
+	if readTool.Name != "read" || readTool.Result == nil || readTool.Result.Status != "error" || readTool.Result.Output != "permission denied" {
+		t.Fatalf("read tool = %+v", readTool)
+	}
+	if lines[2].Type != "assistant" || lines[2].ID != "assistant-final" || len(lines[2].Content) != 1 {
+		t.Fatalf("unexpected final line: %+v", lines[2])
+	}
+	var text compactTextBlock
+	if err := json.Unmarshal(lines[2].Content[0], &text); err != nil {
+		t.Fatal(err)
+	}
+	if text.Type != "text" || text.Text != "done" {
+		t.Fatalf("text block = %+v", text)
+	}
+}
+
+func TestCompactTranscriptReturnsBase64V1JSONL(t *testing.T) {
+	path := writeOMPFixture(t, ompCompactFixture())
+	response, err := (&Agent{}).CompactTranscript(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(response.Transcript)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := decodeCompactLines(t, decoded)
+	if len(lines) != 3 || lines[0].V != 1 {
+		t.Fatalf("decoded compact transcript = %s", decoded)
+	}
+}
+
+func TestCompactStringUserAndMalformedBlocks(t *testing.T) {
+	data := []byte(ompHeader() +
+		`{"type":"message","id":"user","parentId":null,"message":{"role":"user","content":"plain user"}}` + "\n" +
+		`{"type":"message","id":"assistant","parentId":"user","message":{"role":"assistant","content":[null,7,{"type":"toolCall","id":"missing-name","arguments":"bad"},{"type":"text","text":"valid"}]}}` + "\n")
+	compacted, err := compactTranscriptBytes(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := decodeCompactLines(t, compacted)
+	if len(lines) != 2 || len(lines[0].Content) != 1 || len(lines[1].Content) != 1 {
+		t.Fatalf("unexpected lines: %s", compacted)
+	}
+	var user compactUserBlock
+	if err := json.Unmarshal(lines[0].Content[0], &user); err != nil || user.Text != "plain user" {
+		t.Fatalf("user = %+v, err = %v", user, err)
+	}
+}
+
+func TestCompactRejectsNoOutputAndInvalidNative(t *testing.T) {
+	noOutput := []byte(ompHeader() +
+		`{"type":"message","id":"thinking","parentId":null,"message":{"role":"assistant","content":[{"type":"thinking","thinking":"hidden"},{"type":"image","data":"x"}]}}` + "\n")
+	if _, err := compactTranscriptBytes(noOutput); err == nil {
+		t.Fatal("expected no-output error")
+	}
+	if _, err := compactTranscriptBytes([]byte("{}\n")); err == nil {
+		t.Fatal("expected invalid native transcript error")
+	}
+	path := writeOMPFixture(t, noOutput)
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := (&Agent{}).CompactTranscript(path); err == nil {
+		t.Fatal("expected compact method no-output error")
+	}
+}

--- a/agents/entire-agent-omp/internal/omp/hooks.go
+++ b/agents/entire-agent-omp/internal/omp/hooks.go
@@ -1,0 +1,521 @@
+package omp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/entireio/external-agents/agents/entire-agent-omp/internal/protocol"
+)
+
+const (
+	HookNameSessionStart    = "session_start"
+	HookNameAgentStart      = "agent_start"
+	HookNameAgentEnd        = "agent_end"
+	HookNameSessionShutdown = "session_shutdown"
+
+	extensionRelDir       = ".omp/extensions/entire"
+	extensionRelFile      = ".omp/extensions/entire/index.ts"
+	extensionMarker       = "// entire-agent-omp: project-local Entire integration for omp."
+	legacyExtensionMarker = "// entire-agent-omp: project-local Entire integration for OMP."
+	activeSessionFile     = "active-session"
+)
+
+type hookPayload struct {
+	Type        string `json:"type"`
+	CWD         string `json:"cwd,omitempty"`
+	SessionID   string `json:"session_id,omitempty"`
+	SessionFile string `json:"session_file,omitempty"`
+	SessionRef  string `json:"session_ref,omitempty"`
+	Prompt      string `json:"prompt,omitempty"`
+	UserPrompt  string `json:"user_prompt,omitempty"`
+	Model       string `json:"model,omitempty"`
+}
+
+func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, error) {
+	if hookName == HookNameSessionShutdown {
+		_ = clearCachedSessionID()
+		return nil, nil
+	}
+	if len(bytes.TrimSpace(input)) == 0 {
+		return nil, nil
+	}
+
+	var payload hookPayload
+	if err := json.Unmarshal(input, &payload); err != nil {
+		return nil, fmt.Errorf("parse hook payload: %w", err)
+	}
+
+	switch hookName {
+	case HookNameSessionStart, HookNameAgentStart, HookNameAgentEnd:
+	default:
+		return nil, nil
+	}
+
+	sessionID := resolveSessionID(payload)
+	if sessionID == "" {
+		return nil, nil
+	}
+	if !validSessionID(sessionID) {
+		return nil, fmt.Errorf("unsafe session id %q", sessionID)
+	}
+	_ = cacheSessionID(sessionID)
+
+	event := &protocol.EventJSON{
+		SessionID: sessionID,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+	switch hookName {
+	case HookNameSessionStart:
+		event.Type = 1
+		event.SessionRef = hookSessionRef(payload)
+	case HookNameAgentStart:
+		event.Type = 2
+		event.SessionRef = hookSessionRef(payload)
+		event.Prompt = payload.Prompt
+		if event.Prompt == "" {
+			event.Prompt = payload.UserPrompt
+		}
+	case HookNameAgentEnd:
+		event.Type = 3
+		if source := hookSessionRef(payload); source != "" {
+			if snapshot, err := snapshotSession(source, payload.CWD, sessionID); err == nil {
+				event.SessionRef = snapshot
+				event.Model = payload.Model
+				if event.Model == "" {
+					event.Model = extractModelFromPath(snapshot)
+				}
+			}
+		}
+	}
+	return event, nil
+}
+
+func resolveSessionID(payload hookPayload) string {
+	if id := strings.TrimSpace(payload.SessionID); id != "" {
+		return id
+	}
+	if id := sessionIDFromFilename(hookSessionRef(payload)); id != "" {
+		return id
+	}
+	return readCachedSessionID()
+}
+
+func hookSessionRef(payload hookPayload) string {
+	if ref := strings.TrimSpace(payload.SessionFile); ref != "" {
+		return ref
+	}
+	return strings.TrimSpace(payload.SessionRef)
+}
+
+func sessionIDFromFilename(path string) string {
+	base := filepath.Base(strings.TrimSpace(path))
+	if base == "." || base == "" {
+		return ""
+	}
+	base = strings.TrimSuffix(base, filepath.Ext(base))
+	if i := strings.LastIndexByte(base, '_'); i >= 0 {
+		base = base[i+1:]
+	}
+	if !validSessionID(base) {
+		return ""
+	}
+	return base
+}
+
+func validSessionID(id string) bool {
+	if id == "" || id == "." || id == ".." {
+		return false
+	}
+	for _, r := range id {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func ompPrivateDir() string {
+	return filepath.Join(protocol.DefaultSessionDir(protocol.RepoRoot()), "omp")
+}
+
+func cachedSessionPath() string {
+	return filepath.Join(ompPrivateDir(), activeSessionFile)
+}
+
+func cacheSessionID(id string) error {
+	if !validSessionID(id) {
+		return fmt.Errorf("unsafe session id %q", id)
+	}
+	if err := ensurePrivateDir(ompPrivateDir()); err != nil {
+		return err
+	}
+	return atomicWriteFile(cachedSessionPath(), []byte(id+"\n"), 0o600)
+}
+
+func readCachedSessionID() string {
+	data, err := os.ReadFile(cachedSessionPath())
+	if err != nil {
+		return ""
+	}
+	id := strings.TrimSpace(string(data))
+	if !validSessionID(id) {
+		return ""
+	}
+	return id
+}
+
+func clearCachedSessionID() error {
+	err := os.Remove(cachedSessionPath())
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("clear active session: %w", err)
+	}
+	return nil
+}
+
+func ensurePrivateDir(path string) error {
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		return fmt.Errorf("create omp private directory: %w", err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("inspect omp private directory: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("omp private path is not a directory: %s", path)
+	}
+	//nolint:gosec // Directories require execute bits; 0700 is the private-directory equivalent of 0600.
+	if err := os.Chmod(path, 0o700); err != nil {
+		return fmt.Errorf("secure omp private directory: %w", err)
+	}
+	return nil
+}
+
+func snapshotSession(source, cwd, sessionID string) (string, error) {
+	if !validSessionID(sessionID) {
+		return "", fmt.Errorf("unsafe session id %q", sessionID)
+	}
+	if strings.TrimSpace(source) == "" {
+		return "", errors.New("session file is required for agent_end")
+	}
+	if strings.TrimSpace(cwd) == "" {
+		return "", errors.New("cwd is required for agent_end snapshot")
+	}
+	sessionDir, err := New().GetSessionDir(cwd)
+	if err != nil {
+		return "", err
+	}
+	canonicalSessionDir, err := canonicalPath(sessionDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve omp session directory: %w", err)
+	}
+	canonicalSource, err := canonicalPath(source)
+	if err != nil {
+		return "", fmt.Errorf("resolve omp session file: %w", err)
+	}
+	if filepath.Dir(canonicalSource) != canonicalSessionDir || filepath.Ext(canonicalSource) != ".jsonl" {
+		return "", errors.New("omp session file is outside the managed session directory")
+	}
+	info, err := os.Stat(canonicalSource)
+	if err != nil {
+		return "", fmt.Errorf("inspect omp session: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", errors.New("omp session file is not a regular file")
+	}
+	src, err := os.Open(canonicalSource)
+	if err != nil {
+		return "", fmt.Errorf("open omp session: %w", err)
+	}
+	defer src.Close()
+
+	snapshotDir := filepath.Join(canonicalSessionDir, ".entire")
+	if err := ensurePrivateDir(snapshotDir); err != nil {
+		return "", err
+	}
+	destination := filepath.Join(snapshotDir, sessionID+".jsonl")
+	tmp, err := os.CreateTemp(snapshotDir, ".snapshot-*")
+	if err != nil {
+		return "", fmt.Errorf("create transcript snapshot: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if err := tmp.Chmod(0o600); err != nil {
+		return "", errors.Join(err, tmp.Close())
+	}
+	if _, err := io.Copy(tmp, src); err != nil {
+		return "", errors.Join(fmt.Errorf("copy transcript snapshot: %w", err), tmp.Close())
+	}
+	if err := tmp.Sync(); err != nil {
+		return "", errors.Join(fmt.Errorf("sync transcript snapshot: %w", err), tmp.Close())
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("close transcript snapshot: %w", err)
+	}
+	if err := os.Rename(tmpName, destination); err != nil {
+		return "", fmt.Errorf("publish transcript snapshot: %w", err)
+	}
+	return destination, nil
+}
+
+func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".write-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(mode); err != nil {
+		return errors.Join(err, tmp.Close())
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return errors.Join(err, tmp.Close())
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+func isOwnedExtension(data []byte) bool {
+	return bytes.Contains(data, []byte(extensionMarker)) ||
+		bytes.Contains(data, []byte(legacyExtensionMarker))
+}
+
+func (a *Agent) InstallHooks(_ bool, force bool) (int, error) {
+	root := protocol.RepoRoot()
+	path := filepath.Join(root, extensionRelFile)
+	if data, err := os.ReadFile(path); err == nil {
+		if bytes.Equal(data, []byte(generatedExtension)) && !force {
+			return 0, nil
+		}
+		if !isOwnedExtension(data) && !force {
+			return 0, fmt.Errorf("refusing to overwrite foreign omp extension %s", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return 0, err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return 0, fmt.Errorf("create omp extension directory: %w", err)
+	}
+	if err := atomicWriteFile(path, []byte(generatedExtension), 0o600); err != nil {
+		return 0, fmt.Errorf("write omp extension: %w", err)
+	}
+	return 4, nil
+}
+
+func (a *Agent) UninstallHooks() error {
+	root := protocol.RepoRoot()
+	path := filepath.Join(root, extensionRelFile)
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read omp extension: %w", err)
+	}
+	if !isOwnedExtension(data) {
+		return nil
+	}
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("remove omp extension: %w", err)
+	}
+	_ = os.Remove(filepath.Join(root, extensionRelDir))
+	return nil
+}
+
+func (a *Agent) AreHooksInstalled() bool {
+	data, err := os.ReadFile(filepath.Join(protocol.RepoRoot(), extensionRelFile))
+	return err == nil && isOwnedExtension(data)
+}
+
+const generatedExtension = `import type { ExtensionAPI, ExtensionContext } from "@oh-my-pi/pi-coding-agent";
+import { execFile, execFileSync } from "node:child_process";
+
+// entire-agent-omp: project-local Entire integration for omp.
+export default function entireAgent(pi: ExtensionAPI): void {
+  let turnOpen = false;
+  let pendingPrompt: string | undefined;
+  let runEnd: Promise<boolean> | undefined;
+  let resolveRunEnd: ((willContinue: boolean) => void) | undefined;
+  let deferredEnd: Record<string, unknown> | undefined;
+  let turnIdentity: Record<string, unknown> | undefined;
+  let sessionGeneration = 0;
+
+  function armRunEnd(): Promise<boolean> {
+    if (!runEnd) {
+      runEnd = new Promise((resolve) => {
+        resolveRunEnd = resolve;
+      });
+    }
+    return runEnd;
+  }
+
+  function settleRunEnd(willContinue: boolean): void {
+    resolveRunEnd?.(willContinue);
+    resolveRunEnd = undefined;
+  }
+
+  async function crossRunEnd(): Promise<boolean | undefined> {
+    const generation = sessionGeneration;
+    const barrier = armRunEnd();
+    const willContinue = await barrier;
+    if (generation !== sessionGeneration) return undefined;
+    if (runEnd === barrier) runEnd = undefined;
+    return willContinue;
+  }
+
+  function runHook(name: string, payload: Record<string, unknown>, timeout = 10_000): Promise<void> {
+    return new Promise((resolve) => {
+      let body: string;
+      try {
+        body = JSON.stringify(payload);
+      } catch {
+        resolve();
+        return;
+      }
+      try {
+        const child = execFile(
+          "entire",
+          ["hooks", "omp", name],
+          { timeout, windowsHide: true, maxBuffer: 4 * 1024 * 1024 },
+          () => resolve(),
+        );
+        child.stdin?.on("error", () => resolve());
+        child.stdin?.end(body);
+      } catch {
+        resolve();
+      }
+    });
+  }
+
+  function runHookSync(name: string, payload: Record<string, unknown>, timeout = 10_000): void {
+    let body: string;
+    try {
+      body = JSON.stringify(payload);
+    } catch {
+      return;
+    }
+    try {
+      execFileSync(
+        "entire",
+        ["hooks", "omp", name],
+        { input: body, timeout, windowsHide: true, maxBuffer: 4 * 1024 * 1024 },
+      );
+    } catch {
+      // Hook failures must not terminate omp.
+    }
+  }
+
+  async function startSession(_event: unknown, ctx: ExtensionContext): Promise<void> {
+    const previousEnd = turnOpen ? armRunEnd() : undefined;
+    sessionGeneration++;
+    pendingPrompt = undefined;
+    if (previousEnd) {
+      const willContinue = await previousEnd;
+      if (willContinue && deferredEnd) runHookSync("agent_end", deferredEnd);
+    }
+    turnOpen = false;
+    runEnd = undefined;
+    resolveRunEnd = undefined;
+    deferredEnd = undefined;
+    turnIdentity = undefined;
+    await runHook("session_start", {
+      type: "session_start",
+      cwd: ctx.cwd,
+      session_id: ctx.sessionManager.getSessionId(),
+      session_file: ctx.sessionManager.getSessionFile(),
+    });
+  }
+
+  pi.on("session_start", startSession);
+  pi.on("session_switch", startSession);
+  pi.on("session_branch", startSession);
+
+  pi.on("before_agent_start", (event) => {
+    pendingPrompt = event.prompt;
+  });
+
+  pi.on("agent_start", async (_event, ctx) => {
+    if (pendingPrompt === undefined) {
+      if (!turnOpen) return;
+      const willContinue = await crossRunEnd();
+      if (willContinue) {
+        deferredEnd = undefined;
+        armRunEnd();
+      }
+      return;
+    }
+    const prompt = pendingPrompt;
+    pendingPrompt = undefined;
+    if (turnOpen) {
+      const willContinue = await crossRunEnd();
+      if (willContinue === undefined) return;
+      if (willContinue) {
+        deferredEnd = undefined;
+        armRunEnd();
+        return;
+      }
+    }
+    runEnd = undefined;
+    deferredEnd = undefined;
+    turnIdentity = {
+      cwd: ctx.cwd,
+      session_id: ctx.sessionManager.getSessionId(),
+      session_file: ctx.sessionManager.getSessionFile(),
+    };
+    runHookSync("agent_start", {
+      type: "agent_start",
+      ...turnIdentity,
+      prompt,
+    });
+    turnOpen = true;
+    armRunEnd();
+  });
+
+  pi.on("agent_end", (event) => {
+    if (!turnOpen || !turnIdentity) return;
+    const willContinue = event.willContinue === true;
+    const endPayload = {
+      type: "agent_end",
+      ...turnIdentity,
+      model: (event.messages.findLast((message) => message.role === "assistant") as
+        { model?: string } | undefined)?.model,
+    };
+    if (!willContinue) {
+      runHookSync("agent_end", endPayload);
+      turnOpen = false;
+      deferredEnd = undefined;
+      turnIdentity = undefined;
+    } else {
+      deferredEnd = endPayload;
+    }
+    settleRunEnd(willContinue);
+  });
+
+  pi.on("session_shutdown", async (_event, ctx) => {
+    await runHook("session_shutdown", {
+      type: "session_shutdown",
+      cwd: ctx.cwd,
+      session_id: ctx.sessionManager.getSessionId(),
+      session_file: ctx.sessionManager.getSessionFile(),
+    }, 1_500);
+  });
+
+  pi.on("tool_call", (event) => {
+    if (event.toolName !== "bash" || typeof event.input?.command !== "string") return;
+    if (/(^|\s)GIT_TERMINAL_PROMPT\s*=/.test(event.input.command)) return;
+    event.input.command = ` + "`export GIT_TERMINAL_PROMPT=0\n${event.input.command}`" + `;
+  });
+}
+`

--- a/agents/entire-agent-omp/internal/omp/hooks_test.go
+++ b/agents/entire-agent-omp/internal/omp/hooks_test.go
@@ -11,6 +11,12 @@ import (
 
 func TestParseHookLifecycle(t *testing.T) {
 	root := t.TempDir()
+	// Canonicalize so the expected snapshot path matches what the agent
+	// produces on platforms where TempDir() is a symlink (macOS: /var ->
+	// /private/var); the agent resolves symlinks via EvalSymlinks.
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolved
+	}
 	t.Setenv("ENTIRE_REPO_ROOT", root)
 	t.Setenv("HOME", root)
 	t.Setenv("PI_CODING_AGENT_DIR", "")

--- a/agents/entire-agent-omp/internal/omp/hooks_test.go
+++ b/agents/entire-agent-omp/internal/omp/hooks_test.go
@@ -1,0 +1,762 @@
+package omp
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseHookLifecycle(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", root)
+	t.Setenv("HOME", root)
+	t.Setenv("PI_CODING_AGENT_DIR", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	sessionDir, err := New().GetSessionDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(sessionDir, "2026-07-26T00-00-00-000Z_file-id.jsonl")
+	original := []byte(
+		"{\"type\":\"title\"}\n" +
+			"{\"type\":\"session\",\"version\":3,\"id\":\"payload-id\"}\n" +
+			"{\"type\":\"message\",\"id\":\"m1\",\"parentId\":null," +
+			"\"message\":{\"role\":\"assistant\",\"model\":\"model-x\",\"content\":[]}}\n",
+	)
+	if err := os.WriteFile(source, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agent := &Agent{}
+
+	start, err := agent.ParseHook(HookNameSessionStart, []byte(`{
+		"type":"session_start",
+		"cwd":"`+root+`",
+		"session_id":"payload-id",
+		"session_file":"`+source+`"
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if start == nil || start.Type != 1 || start.SessionID != "payload-id" || start.SessionRef != source {
+		t.Fatalf("session_start event = %+v", start)
+	}
+
+	turnStart, err := agent.ParseHook(HookNameAgentStart, []byte(`{
+		"type":"agent_start",
+		"cwd":"`+root+`",
+		"session_id":"payload-id",
+		"session_file":"`+source+`",
+		"prompt":"keep this prompt"
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if turnStart == nil || turnStart.Type != 2 || turnStart.SessionID != "payload-id" ||
+		turnStart.SessionRef != source || turnStart.Prompt != "keep this prompt" {
+		t.Fatalf("agent_start event = %+v", turnStart)
+	}
+
+	turnEnd, err := agent.ParseHook(HookNameAgentEnd, []byte(`{
+		"type":"agent_end",
+		"cwd":"`+root+`",
+		"session_id":"payload-id",
+		"session_file":"`+source+`"
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSnapshot := filepath.Join(filepath.Dir(source), ".entire", "payload-id.jsonl")
+	if turnEnd == nil || turnEnd.Type != 3 || turnEnd.SessionID != "payload-id" ||
+		turnEnd.SessionRef != wantSnapshot || turnEnd.Model != "model-x" {
+		t.Fatalf("agent_end event = %+v", turnEnd)
+	}
+	snapshot, err := os.ReadFile(wantSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(snapshot) != string(original) {
+		t.Fatalf("snapshot = %q, want %q", snapshot, original)
+	}
+
+	cache := cachedSessionPath()
+	if _, err := os.Stat(cache); err != nil {
+		t.Fatalf("active session cache missing: %v", err)
+	}
+	shutdown, err := agent.ParseHook(HookNameSessionShutdown, []byte(`{malformed`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if shutdown != nil {
+		t.Fatalf("session_shutdown event = %+v, want nil", shutdown)
+	}
+	if _, err := os.Stat(cache); !os.IsNotExist(err) {
+		t.Fatalf("active session cache remains after shutdown: %v", err)
+	}
+}
+
+func TestParseHookEmptyMalformedAndUnknown(t *testing.T) {
+	t.Setenv("ENTIRE_REPO_ROOT", t.TempDir())
+	agent := &Agent{}
+	for _, input := range [][]byte{nil, {}, []byte(" \n\t")} {
+		event, err := agent.ParseHook(HookNameSessionStart, input)
+		if err != nil || event != nil {
+			t.Fatalf("empty payload: event=%+v err=%v", event, err)
+		}
+	}
+	if event, err := agent.ParseHook(HookNameSessionStart, []byte(`{`)); err == nil || event != nil {
+		t.Fatalf("malformed payload: event=%+v err=%v", event, err)
+	}
+	if event, err := agent.ParseHook("unknown", []byte(`{"session_id":"id"}`)); err != nil || event != nil {
+		t.Fatalf("unknown hook: event=%+v err=%v", event, err)
+	}
+	if event, err := agent.ParseHook(HookNameAgentStart, []byte(`{}`)); err != nil || event != nil {
+		t.Fatalf("missing identity: event=%+v err=%v", event, err)
+	}
+}
+
+func TestParseHookSessionIDPrecedenceAndFallbacks(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", root)
+	agent := &Agent{}
+	path := filepath.Join(root, "2026-07-26T03-14-06-592Z_filename-id.jsonl")
+
+	event, err := agent.ParseHook(HookNameAgentStart, []byte(`{
+		"session_id":"payload-id",
+		"session_file":"`+path+`",
+		"prompt":"one"
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.SessionID != "payload-id" {
+		t.Fatalf("payload ID did not win: %+v", event)
+	}
+
+	event, err = agent.ParseHook(HookNameAgentStart, []byte(`{
+		"session_file":"`+path+`",
+		"prompt":"two"
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.SessionID != "filename-id" {
+		t.Fatalf("filename fallback = %+v", event)
+	}
+
+	event, err = agent.ParseHook(HookNameAgentStart, []byte(`{"prompt":"three"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.SessionID != "filename-id" {
+		t.Fatalf("cache fallback = %+v", event)
+	}
+}
+
+func TestParseHookRejectsUnsafeSessionIDs(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", root)
+	agent := &Agent{}
+	for _, id := range []string{"../escape", "nested/id", `nested\id`, ".", "..", "white space"} {
+		event, err := agent.ParseHook(HookNameSessionStart, []byte(`{"session_id":"`+id+`"}`))
+		if err == nil || event != nil {
+			t.Fatalf("unsafe ID %q: event=%+v err=%v", id, event, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(root, ".entire", "tmp", "escape.jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("unsafe ID created a file: %v", err)
+	}
+}
+
+func TestTurnEndSnapshotIsStableAndPrivate(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", root)
+	t.Setenv("HOME", root)
+	t.Setenv("PI_CODING_AGENT_DIR", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	sessionDir, err := New().GetSessionDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(sessionDir, "live.jsonl")
+	snapshotDir := filepath.Join(filepath.Dir(source), ".entire")
+	if err := os.MkdirAll(snapshotDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(snapshotDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source, []byte("first\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	event, err := (&Agent{}).ParseHook(HookNameAgentEnd, []byte(`{
+		"cwd":"`+root+`",
+		"session_id":"stable-id",
+		"session_file":"`+source+`",
+		"model":"payload-model"
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Model != "payload-model" {
+		t.Fatalf("agent_end model = %q, want payload-model", event.Model)
+	}
+	if err := os.WriteFile(source, []byte("second\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(event.SessionRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "first\n" {
+		t.Fatalf("snapshot changed with live transcript: %q", data)
+	}
+	assertMode(t, filepath.Dir(event.SessionRef), 0o700)
+	assertMode(t, event.SessionRef, 0o600)
+	assertMode(t, cachedSessionPath(), 0o600)
+	if strings.HasPrefix(event.SessionRef, filepath.Join(root, ".entire", "tmp")) {
+		t.Fatalf("snapshot overlaps another agent's session directory: %s", event.SessionRef)
+	}
+}
+
+func TestTurnEndWithoutLiveSessionFileStillEmits(t *testing.T) {
+	t.Setenv("ENTIRE_REPO_ROOT", t.TempDir())
+	event, err := (&Agent{}).ParseHook(HookNameAgentEnd, []byte(`{"session_id":"safe-id"}`))
+	if err != nil || event == nil || event.Type != 3 || event.SessionID != "safe-id" ||
+		event.SessionRef != "" || event.Model != "" {
+		t.Fatalf("agent_end without session file: event=%+v err=%v", event, err)
+	}
+}
+
+func TestTurnEndMissingLiveSessionFileDoesNotLeakRef(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", root)
+	t.Setenv("HOME", root)
+	t.Setenv("PI_CODING_AGENT_DIR", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	outside := t.TempDir()
+	missing := filepath.Join(outside, "missing.jsonl")
+	event, err := (&Agent{}).ParseHook(HookNameAgentEnd, []byte(`{
+		"cwd":"`+root+`",
+		"session_id":"safe-id",
+		"session_file":"`+missing+`"
+	}`))
+	if err != nil || event == nil || event.Type != 3 || event.SessionRef != "" || event.Model != "" {
+		t.Fatalf("agent_end with missing session file: event=%+v err=%v", event, err)
+	}
+	if _, err := os.Stat(filepath.Join(outside, ".entire")); !os.IsNotExist(err) {
+		t.Fatalf("agent_end wrote outside the managed session directory: %v", err)
+	}
+}
+
+func TestTurnEndRejectsSymlinkSnapshotDirectory(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", root)
+	t.Setenv("HOME", root)
+	t.Setenv("PI_CODING_AGENT_DIR", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	sessionDir, err := New().GetSessionDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(sessionDir, "session.jsonl")
+	if err := os.WriteFile(source, []byte(ompHeader()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := t.TempDir()
+	if err := os.Chmod(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(sessionDir, ".entire")); err != nil {
+		t.Fatal(err)
+	}
+
+	event, err := (&Agent{}).ParseHook(HookNameAgentEnd, []byte(`{
+		"cwd":"`+root+`",
+		"session_id":"safe-id",
+		"session_file":"`+source+`"
+	}`))
+	if err != nil || event == nil || event.SessionRef != "" {
+		t.Fatalf("agent_end with symlink snapshot dir: event=%+v err=%v", event, err)
+	}
+	assertMode(t, target, 0o755)
+}
+
+func TestParseHookAcceptsGenericProtocolAliases(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", root)
+	source := filepath.Join(root, "generic-id.jsonl")
+	if err := os.WriteFile(source, []byte(ompHeader()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	start, err := (&Agent{}).ParseHook(HookNameAgentStart, []byte(`{
+		"session_id":"generic-id",
+		"session_ref":"`+source+`",
+		"user_prompt":"generic prompt"
+	}`))
+	if err != nil || start == nil || start.SessionRef != source || start.Prompt != "generic prompt" {
+		t.Fatalf("generic hook aliases: event=%+v err=%v", start, err)
+	}
+}
+
+func TestInstallHooksIdempotentForceAndUninstall(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", root)
+	agent := &Agent{}
+	path := filepath.Join(root, extensionRelFile)
+
+	count, err := agent.InstallHooks(false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 4 || !agent.AreHooksInstalled() {
+		t.Fatalf("install count=%d installed=%v", count, agent.AreHooksInstalled())
+	}
+	assertMode(t, filepath.Dir(path), 0o700)
+	assertMode(t, path, 0o600)
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count, err = agent.InstallHooks(true, false)
+	if err != nil || count != 0 {
+		t.Fatalf("repeated install count=%d err=%v", count, err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("repeated install changed the extension")
+	}
+
+	const oldExtension = `import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+import { execFileSync } from "node:child_process";
+
+// entire-agent-omp: project-local Entire integration for OMP.
+export default function entireAgentOMP(pi: ExtensionAPI): void {
+  pi.on("before_agent_start", (event, ctx) => {
+    execFileSync("entire", ["hooks", "omp", "agent_start"], {
+      input: JSON.stringify({
+        type: "agent_start",
+        cwd: ctx.cwd,
+        session_id: ctx.sessionManager.getSessionId(),
+        session_file: ctx.sessionManager.getSessionFile(),
+        prompt: event.prompt,
+      }),
+    });
+  });
+}
+`
+	if err := os.WriteFile(path, []byte(oldExtension), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	count, err = agent.InstallHooks(false, false)
+	if err != nil || count != 4 {
+		t.Fatalf("owned upgrade count=%d err=%v", count, err)
+	}
+	upgraded, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(upgraded) != generatedExtension {
+		t.Fatal("owned extension was not upgraded to the current content")
+	}
+	if !bytes.Contains(upgraded, []byte(`pi.on("agent_start"`)) ||
+		!bytes.Contains(upgraded, []byte(`type: "agent_start"`)) {
+		t.Fatal("owned upgrade dropped the Type2 agent_start hook")
+	}
+
+	if err := os.WriteFile(path, []byte("foreign extension\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	count, err = agent.InstallHooks(false, false)
+	if err == nil || count != 0 {
+		t.Fatalf("foreign install count=%d err=%v", count, err)
+	}
+	foreign, readErr := os.ReadFile(path)
+	if readErr != nil || string(foreign) != "foreign extension\n" {
+		t.Fatalf("foreign extension was changed: %q err=%v", foreign, readErr)
+	}
+	count, err = agent.InstallHooks(false, true)
+	if err != nil || count != 4 || !agent.AreHooksInstalled() {
+		t.Fatalf("forced install count=%d installed=%v err=%v", count, agent.AreHooksInstalled(), err)
+	}
+
+	sibling := filepath.Join(root, ".omp", "extensions", "keep.ts")
+	if err := os.WriteFile(sibling, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.UninstallHooks(); err != nil {
+		t.Fatal(err)
+	}
+	if agent.AreHooksInstalled() {
+		t.Fatal("hooks remain installed")
+	}
+	if _, err := os.Stat(filepath.Join(root, extensionRelDir)); !os.IsNotExist(err) {
+		t.Fatalf("owned extension directory remains: %v", err)
+	}
+	if data, err := os.ReadFile(sibling); err != nil || string(data) != "keep" {
+		t.Fatalf("uninstall changed sibling extension: %q err=%v", data, err)
+	}
+	if err := agent.UninstallHooks(); err != nil {
+		t.Fatalf("repeated uninstall: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(oldExtension), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !agent.AreHooksInstalled() {
+		t.Fatal("legacy marker was not recognized")
+	}
+	if err := agent.UninstallHooks(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("legacy extension remains after uninstall: %v", err)
+	}
+}
+
+func TestAreHooksInstalledRequiresMarker(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", root)
+	path := filepath.Join(root, extensionRelFile)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("export default function foreign() {}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if (&Agent{}).AreHooksInstalled() {
+		t.Fatal("foreign extension reported as installed")
+	}
+	if err := (&Agent{}).UninstallHooks(); err != nil {
+		t.Fatal(err)
+	}
+	if data, err := os.ReadFile(path); err != nil || string(data) != "export default function foreign() {}" {
+		t.Fatalf("uninstall changed foreign extension: %q err=%v", data, err)
+	}
+}
+
+func TestGeneratedExtensionLifecyclePrivacyAndBashGuard(t *testing.T) {
+	for _, snippet := range []string{
+		`from "@oh-my-pi/pi-coding-agent"`,
+		`"entire",`,
+		`["hooks", "omp", name]`,
+		`windowsHide: true`,
+		`maxBuffer: 4 * 1024 * 1024`,
+		`async function startSession(_event: unknown, ctx: ExtensionContext): Promise<void>`,
+		`pi.on("session_start", startSession)`,
+		`pi.on("session_switch", startSession)`,
+		`pi.on("session_branch", startSession)`,
+		`sessionGeneration++`,
+		`const previousEnd = turnOpen ? armRunEnd() : undefined`,
+		`const willContinue = await previousEnd`,
+		`turnOpen = false`,
+		`pendingPrompt = undefined`,
+		`runEnd = undefined`,
+		`pi.on("before_agent_start"`,
+		`pendingPrompt = event.prompt`,
+		`pi.on("agent_start"`,
+		`if (pendingPrompt === undefined) {`,
+		`const willContinue = await crossRunEnd()`,
+		`const prompt = pendingPrompt`,
+		`runHookSync("agent_start"`,
+		`pi.on("agent_end"`,
+		`if (!turnOpen) return`,
+		`const willContinue = event.willContinue === true`,
+		`event.messages.findLast((message) => message.role === "assistant")`,
+		`{ model?: string } | undefined`,
+		`runHookSync("agent_end"`,
+		`settleRunEnd(willContinue)`,
+		`execFileSync(`,
+		`{ input: body, timeout, windowsHide: true, maxBuffer: 4 * 1024 * 1024 }`,
+		`pi.on("session_shutdown"`,
+		`}, 1_500)`,
+		`await runHook`,
+		`child.stdin?.on("error"`,
+		`if (event.toolName !== "bash" || typeof event.input?.command !== "string") return`,
+		`GIT_TERMINAL_PROMPT\s*=`,
+		"export GIT_TERMINAL_PROMPT=0\n${event.input.command}",
+	} {
+		if !strings.Contains(generatedExtension, snippet) {
+			t.Errorf("generated extension missing %q", snippet)
+		}
+	}
+	for _, forbidden := range []string{
+		"SessionEnd",
+		"session_end",
+		`pi.on("session_stop"`,
+		"systemPrompt",
+		"messages:",
+		"modified_files",
+		"shell:",
+		"env:",
+	} {
+		if strings.Contains(generatedExtension, forbidden) {
+			t.Errorf("generated extension leaks or configures forbidden %q", forbidden)
+		}
+	}
+	if strings.Count(generatedExtension, "timeout = 10_000") != 2 {
+		t.Fatal("hook timeout defaults are not 10 seconds")
+	}
+}
+
+func TestGeneratedExtensionPairsLogicalTurnsAcrossContinuations(t *testing.T) {
+	if got := strings.Count(generatedExtension, `pi.on("agent_end"`); got != 1 {
+		t.Fatalf("agent_end handler count = %d, want 1", got)
+	}
+	if got := strings.Count(generatedExtension, `runHookSync("agent_end"`); got != 2 {
+		t.Fatalf("synchronous agent_end hook count = %d, want 2 lifecycle paths", got)
+	}
+
+	handlerStart := strings.Index(generatedExtension, `pi.on("agent_end"`)
+	if handlerStart < 0 {
+		t.Fatal("agent_end handler not found")
+	}
+	handlerEnd := strings.Index(generatedExtension[handlerStart:], "\n\n  pi.on(\"session_shutdown\"")
+	if handlerEnd < 0 {
+		t.Fatal("agent_end handler not found")
+	}
+	handler := generatedExtension[handlerStart : handlerStart+handlerEnd]
+	guard := strings.Index(handler, `if (!turnOpen || !turnIdentity) return;`)
+	invoke := strings.Index(handler, `runHookSync("agent_end"`)
+	closeTurn := strings.Index(handler, `turnOpen = false;`)
+	settle := strings.Index(handler, `settleRunEnd(willContinue);`)
+	if guard < 0 || invoke < 0 || closeTurn < 0 || settle < 0 ||
+		guard > invoke || invoke > closeTurn || closeTurn > settle {
+		t.Fatal("agent_end must synchronously close a final turn before releasing its run barrier")
+	}
+	if strings.Contains(handler, "async") || strings.Contains(handler, "await ") {
+		t.Fatal("agent_end handler must finish its hook before returning")
+	}
+
+	beforeStart := strings.Index(generatedExtension, `pi.on("before_agent_start"`)
+	if beforeStart < 0 {
+		t.Fatal("before_agent_start handler not found")
+	}
+	beforeEnd := strings.Index(generatedExtension[beforeStart:], "\n\n  pi.on(\"agent_start\"")
+	if beforeEnd < 0 {
+		t.Fatal("before_agent_start handler not found")
+	}
+	before := generatedExtension[beforeStart : beforeStart+beforeEnd]
+	savePrompt := strings.Index(before, `pendingPrompt = event.prompt;`)
+	if savePrompt < 0 || strings.Contains(before, `if (turnOpen) return;`) {
+		t.Fatal("before_agent_start must retain a prompt that races the preceding agent_end")
+	}
+	for _, forbidden := range []string{`turnOpen = true`, `runHook(`, `runHookSync(`} {
+		if strings.Contains(before, forbidden) {
+			t.Fatalf("before_agent_start must not open or emit a turn; found %q", forbidden)
+		}
+	}
+
+	sessionStart := strings.Index(generatedExtension, `async function startSession(`)
+	if sessionStart < 0 {
+		t.Fatal("shared session-start handler not found")
+	}
+	sessionEnd := strings.Index(generatedExtension[sessionStart:], "\n\n  pi.on(\"session_start\"")
+	if sessionEnd < 0 {
+		t.Fatal("shared session-start handler end not found")
+	}
+	session := generatedExtension[sessionStart : sessionStart+sessionEnd]
+	capturePrevious := strings.Index(session, `const previousEnd = turnOpen ? armRunEnd() : undefined;`)
+	invalidateWaiters := strings.Index(session, `sessionGeneration++;`)
+	resetOpen := strings.Index(session, `turnOpen = false;`)
+	resetPending := strings.Index(session, `pendingPrompt = undefined;`)
+	waitPrevious := strings.Index(session, `const willContinue = await previousEnd;`)
+	flushDeferred := strings.Index(session, `if (willContinue && deferredEnd) runHookSync("agent_end", deferredEnd);`)
+	resetBarrier := strings.Index(session, `runEnd = undefined;`)
+	resetResolver := strings.Index(session, `resolveRunEnd = undefined;`)
+	resetDeferred := strings.Index(session, `deferredEnd = undefined;`)
+	resetIdentity := strings.Index(session, `turnIdentity = undefined;`)
+	emit := strings.Index(session, `await runHook("session_start"`)
+	if capturePrevious < 0 || invalidateWaiters < 0 || resetOpen < 0 || resetPending < 0 ||
+		waitPrevious < 0 || flushDeferred < 0 || resetBarrier < 0 || resetResolver < 0 ||
+		resetDeferred < 0 || resetIdentity < 0 || emit < 0 ||
+		capturePrevious > invalidateWaiters || invalidateWaiters > resetPending ||
+		resetPending > waitPrevious || waitPrevious > flushDeferred || flushDeferred > resetOpen ||
+		resetOpen > resetBarrier || resetBarrier > resetResolver || resetResolver > resetDeferred ||
+		resetDeferred > resetIdentity || resetIdentity > emit {
+		t.Fatal("session changes must drain the old run before resetting and emitting the new session")
+	}
+}
+
+func TestGeneratedExtensionSharesSessionChangeHandler(t *testing.T) {
+	for _, event := range []string{"session_start", "session_switch", "session_branch"} {
+		subscription := `pi.on("` + event + `", startSession);`
+		if got := strings.Count(generatedExtension, subscription); got != 1 {
+			t.Fatalf("%s subscription count = %d, want 1 shared handler", event, got)
+		}
+	}
+	if got := strings.Count(generatedExtension, `async function startSession(`); got != 1 {
+		t.Fatalf("shared session-start implementation count = %d, want 1", got)
+	}
+	if got := strings.Count(generatedExtension, `await runHook("session_start"`); got != 1 {
+		t.Fatalf("external session_start emission count = %d, want 1 shared implementation", got)
+	}
+	if strings.Contains(generatedExtension, `runHook("session_switch"`) ||
+		strings.Contains(generatedExtension, `runHook("session_branch"`) {
+		t.Fatal("native session changes must retain the external session_start hook contract")
+	}
+}
+
+func TestGeneratedExtensionStartsOnlyDeliveredPrompts(t *testing.T) {
+	start := extensionHandler(t, "agent_start", "agent_end")
+	guard := strings.Index(start, `if (pendingPrompt === undefined) {`)
+	copyPrompt := strings.Index(start, `const prompt = pendingPrompt;`)
+	clearPending := strings.Index(start, `pendingPrompt = undefined;`)
+	wait := strings.LastIndex(start, `const willContinue = await crossRunEnd();`)
+	resetBarrier := strings.Index(start, `runEnd = undefined;`)
+	emit := strings.Index(start, `runHookSync("agent_start"`)
+	open := strings.Index(start, `turnOpen = true;`)
+	if guard < 0 || copyPrompt < 0 || clearPending < 0 || wait < 0 || resetBarrier < 0 || emit < 0 || open < 0 ||
+		guard > copyPrompt || copyPrompt > clearPending || clearPending > wait ||
+		wait > resetBarrier || resetBarrier > emit || emit > open {
+		t.Fatal("agent_start must consume one prompt, cross the preceding run barrier, then synchronously open")
+	}
+	if !strings.Contains(start, `pi.on("agent_start", async`) {
+		t.Fatal("agent_start must be awaitable while the preceding agent_end notification catches up")
+	}
+	noPrompt := strings.Index(start, `if (pendingPrompt === undefined) {`)
+	directWait := strings.Index(start, `const willContinue = await crossRunEnd();`)
+	directRearm := strings.Index(start, `armRunEnd();`)
+	if noPrompt < 0 || directWait < noPrompt || directRearm < directWait || directRearm > copyPrompt {
+		t.Fatal("a direct continuation agent_start must consume and rearm the physical-run barrier")
+	}
+}
+
+func TestGeneratedExtensionCancellationContinuationAndOrphanContracts(t *testing.T) {
+	before := extensionHandler(t, "before_agent_start", "agent_start")
+	start := extensionHandler(t, "agent_start", "agent_end")
+	end := extensionHandler(t, "agent_end", "session_shutdown")
+
+	// A second pre-send before_agent_start overwrites the cancelled generation's
+	// prompt; no open-turn flag can cause the replacement agent_start to be lost.
+	if strings.Count(before, `pendingPrompt = event.prompt;`) != 1 || strings.Contains(before, `turnOpen = true`) {
+		t.Fatal("pre-send cancellation must leave only the latest prompt pending and no turn open")
+	}
+	// The prompt must survive until the delayed end result decides whether this
+	// physical run continues the open logical turn or starts a new one.
+	if strings.Contains(before, `if (turnOpen) return;`) {
+		t.Fatal("a racing before_agent_start still drops its prompt")
+	}
+	if !strings.Contains(start, `if (pendingPrompt === undefined) {`) ||
+		!strings.Contains(start, `if (willContinue) {`) {
+		t.Fatal("agent_start does not reject orphans and fold confirmed continuations")
+	}
+	if !strings.Contains(end, `if (!turnOpen || !turnIdentity) return;`) ||
+		!strings.Contains(end, `if (!willContinue) {`) {
+		t.Fatal("agent_end does not reject orphans and close only final runs")
+	}
+	if !strings.Contains(end, `...turnIdentity`) || strings.Contains(end, `ctx.sessionManager`) {
+		t.Fatal("agent_end must use the identity captured when its logical turn opened")
+	}
+}
+
+func TestGeneratedExtensionRunEndBarrierOrdering(t *testing.T) {
+	start := extensionHandler(t, "agent_start", "agent_end")
+	end := extensionHandler(t, "agent_end", "session_shutdown")
+	wait := strings.LastIndex(start, `const willContinue = await crossRunEnd();`)
+	fold := strings.LastIndex(start, `if (willContinue) {`)
+	startHook := strings.Index(start, `runHookSync("agent_start"`)
+	endHook := strings.Index(end, `runHookSync("agent_end"`)
+	release := strings.Index(end, `settleRunEnd(willContinue);`)
+	if wait < 0 || fold < wait || startHook < fold || endHook < 0 || release < endHook {
+		t.Fatal("generated extension does not wait, fold, and release in lifecycle order")
+	}
+
+	for _, tc := range []struct {
+		name         string
+		willContinue bool
+		want         string
+	}{
+		{name: "final", want: "T2(A),T3(A),T2(B),T3(B)"},
+		{name: "continuation", willContinue: true, want: "T2(A),T3(A)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			actions := []string{"T2(A)"}
+			barrier := make(chan bool, 1)
+			waiting := make(chan struct{})
+			started := make(chan string, 1)
+			done := make(chan struct{})
+
+			// omp awaits B's agent_start handler, but A's fire-and-forget
+			// agent_end emit may enter this extension concurrently and release it.
+			go func() {
+				close(waiting)
+				if willContinue := <-barrier; !willContinue {
+					started <- "T2(B)"
+				}
+				close(done)
+			}()
+			<-waiting
+			select {
+			case <-done:
+				t.Fatal("B agent_start crossed the barrier before A agent_end arrived")
+			default:
+			}
+
+			if !tc.willContinue {
+				actions = append(actions, "T3(A)")
+			}
+			barrier <- tc.willContinue
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("B agent_start deadlocked waiting for A agent_end")
+			}
+			select {
+			case action := <-started:
+				actions = append(actions, action)
+			default:
+			}
+			if tc.willContinue {
+				actions = append(actions, "T3(A)")
+			} else {
+				actions = append(actions, "T3(B)")
+			}
+			if got := strings.Join(actions, ","); got != tc.want {
+				t.Fatalf("lifecycle = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func extensionHandler(t *testing.T, name, next string) string {
+	t.Helper()
+	start := strings.Index(generatedExtension, `pi.on("`+name+`"`)
+	if start < 0 {
+		t.Fatalf("%s handler not found", name)
+	}
+	end := strings.Index(generatedExtension[start:], "\n\n  pi.on(\""+next+"\"")
+	if end < 0 {
+		t.Fatalf("%s handler end not found", name)
+	}
+	return generatedExtension[start : start+end]
+}
+
+func assertMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("%s mode = %#o, want %#o", path, got, want)
+	}
+}

--- a/agents/entire-agent-omp/internal/omp/paths.go
+++ b/agents/entire-agent-omp/internal/omp/paths.go
@@ -1,0 +1,284 @@
+package omp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+const maxSessionHeaderBytes = 64 * 1024
+
+var (
+	profileNameRE            = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
+	windowsReservedProfileRE = regexp.MustCompile(`(?i)^(CON|PRN|AUX|NUL|COM[0-9]|LPT[0-9])(\..*)?$`)
+)
+
+type envValue struct {
+	value string
+	set   bool
+}
+
+type sessionHeader struct {
+	Type      string `json:"type"`
+	Version   int    `json:"version"`
+	ID        string `json:"id"`
+	Timestamp string `json:"timestamp"`
+	Cwd       string `json:"cwd"`
+}
+
+func parseSessionHeader(data []byte) (sessionHeader, error) {
+	line, rest, ok := nextJSONLLine(data)
+	if !ok {
+		return sessionHeader{}, errors.New("parse omp session header: missing first JSONL line")
+	}
+
+	var kind struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(line, &kind); err != nil {
+		return sessionHeader{}, fmt.Errorf("parse omp session header first line: %w", err)
+	}
+	if kind.Type == "title" {
+		line, _, ok = nextJSONLLine(rest)
+		if !ok {
+			return sessionHeader{}, errors.New("parse omp session header: title slot is not followed by a session line")
+		}
+	}
+
+	var header sessionHeader
+	if err := json.Unmarshal(line, &header); err != nil {
+		return sessionHeader{}, fmt.Errorf("parse omp session header JSON: %w", err)
+	}
+	if header.Type != "session" {
+		return sessionHeader{}, fmt.Errorf("parse omp session header: type is %q, want %q", header.Type, "session")
+	}
+	if header.ID == "" {
+		return sessionHeader{}, errors.New("parse omp session header: id is empty")
+	}
+	if header.Version <= 0 {
+		return sessionHeader{}, fmt.Errorf("parse omp session header: version is %d, want a positive value", header.Version)
+	}
+	return header, nil
+}
+
+func nextJSONLLine(data []byte) (line, rest []byte, ok bool) {
+	index := bytes.IndexByte(data, '\n')
+	if index < 0 {
+		if len(data) == 0 {
+			return nil, nil, false
+		}
+		return bytes.TrimSuffix(data, []byte{'\r'}), nil, true
+	}
+	return bytes.TrimSuffix(data[:index], []byte{'\r'}), data[index+1:], true
+}
+
+func (a *Agent) GetSessionDir(repoPath string) (string, error) {
+	root, err := ompSessionsRoot()
+	if err != nil {
+		return "", err
+	}
+	name, err := encodeSessionDirName(repoPath)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, name), nil
+}
+
+func ompSessionsRoot() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	return ompSessionsRootFor(
+		runtime.GOOS,
+		home,
+		os.Getenv("PI_CODING_AGENT_DIR"),
+		os.Getenv("PI_CONFIG_DIR"),
+		os.Getenv("XDG_DATA_HOME"),
+		lookupEnv("OMP_PROFILE"),
+		lookupEnv("PI_PROFILE"),
+		func(path string) bool {
+			_, err := os.Stat(path)
+			return err == nil
+		},
+	)
+}
+
+func lookupEnv(key string) envValue {
+	value, set := os.LookupEnv(key)
+	return envValue{value: value, set: set}
+}
+
+func normalizeProfileName(profile string) string {
+	profile = strings.TrimSpace(profile)
+	if profile == "" || profile == "default" {
+		return ""
+	}
+	if profile == "." || profile == ".." || strings.HasSuffix(profile, ".") ||
+		!profileNameRE.MatchString(profile) || windowsReservedProfileRE.MatchString(profile) {
+		return ""
+	}
+	return profile
+}
+
+func ompSessionsRootFor(
+	goos, home, agentDir, configDir, xdgData string,
+	ompProfile, piProfile envValue,
+	exists func(string) bool,
+) (string, error) {
+	if configDir == "" {
+		configDir = ".omp"
+	}
+	baseConfigRoot := filepath.Join(home, configDir)
+	profileValue := piProfile
+	if ompProfile.set {
+		profileValue = ompProfile
+	}
+	profile := normalizeProfileName(profileValue.value)
+	configRoot := baseConfigRoot
+	if profile != "" {
+		configRoot = filepath.Join(baseConfigRoot, "profiles", profile)
+	}
+	defaultAgentDir := filepath.Join(configRoot, "agent")
+
+	profileAgentSource := profile
+	if profileAgentSource == "" {
+		profileAgentSource = normalizeProfileName(piProfile.value)
+	}
+	switch {
+	case profile != "" || (profileAgentSource != "" && agentDir == filepath.Join(baseConfigRoot, "profiles", profileAgentSource, "agent")):
+		agentDir = defaultAgentDir
+	case agentDir == "":
+		agentDir = defaultAgentDir
+	default:
+		absolute, err := filepath.Abs(agentDir)
+		if err != nil {
+			return "", fmt.Errorf("resolve PI_CODING_AGENT_DIR: %w", err)
+		}
+		agentDir = absolute
+	}
+	if (goos == "linux" || goos == "darwin") && agentDir == defaultAgentDir && xdgData != "" {
+		appRoot := filepath.Join(xdgData, "omp")
+		xdgRoot := appRoot
+		if profile != "" {
+			xdgRoot = filepath.Join(appRoot, "profiles", profile)
+		}
+		if exists(xdgRoot) {
+			return filepath.Join(xdgRoot, "sessions"), nil
+		}
+	}
+	return filepath.Join(agentDir, "sessions"), nil
+}
+
+func encodeSessionDirName(cwd string) (string, error) {
+	canonicalCwd, err := canonicalPath(cwd)
+	if err != nil {
+		return "", fmt.Errorf("resolve omp session cwd %q: %w", cwd, err)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	canonicalHome, err := canonicalPath(home)
+	if err != nil {
+		return "", fmt.Errorf("resolve canonical home directory: %w", err)
+	}
+	canonicalTemp, err := canonicalPath(os.TempDir())
+	if err != nil {
+		return "", fmt.Errorf("resolve canonical temporary directory: %w", err)
+	}
+
+	if relative, ok := relativeWithin(canonicalHome, canonicalCwd); ok {
+		return encodeRelative("-", relative), nil
+	}
+	if relative, ok := relativeWithin(canonicalTemp, canonicalCwd); ok {
+		return encodeRelative("-tmp", relative), nil
+	}
+	trimmed := strings.TrimLeft(canonicalCwd, "/\\")
+	replacer := strings.NewReplacer("/", "-", "\\", "-", ":", "-")
+	return "--" + replacer.Replace(trimmed) + "--", nil
+}
+
+func canonicalPath(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	canonical, err := filepath.EvalSymlinks(absolute)
+	if err == nil {
+		return canonical, nil
+	}
+	return filepath.Clean(absolute), nil
+}
+
+func relativeWithin(root, candidate string) (string, bool) {
+	relative, err := filepath.Rel(root, candidate)
+	if err != nil {
+		return "", false
+	}
+	return relative, relative == "." || (relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) && !filepath.IsAbs(relative))
+}
+
+func encodeRelative(prefix, relative string) string {
+	if relative == "." || relative == "" {
+		return prefix
+	}
+	replacer := strings.NewReplacer("/", "-", "\\", "-", ":", "-")
+	encoded := replacer.Replace(relative)
+	if strings.HasSuffix(prefix, "-") {
+		return prefix + encoded
+	}
+	return prefix + "-" + encoded
+}
+
+func (a *Agent) ResolveSessionFile(sessionDir, sessionID string) string {
+	if !safeSessionID(sessionID) {
+		return ""
+	}
+	entries, _ := os.ReadDir(sessionDir)
+	exactFilename := filepath.Join(sessionDir, sessionID+".jsonl")
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".jsonl" {
+			continue
+		}
+		path := filepath.Join(sessionDir, entry.Name())
+		header, err := readSessionHeader(path)
+		if err == nil && header.ID == sessionID {
+			return path
+		}
+	}
+	return exactFilename
+}
+
+func readSessionHeader(path string) (sessionHeader, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return sessionHeader{}, err
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, maxSessionHeaderBytes))
+	if err != nil {
+		return sessionHeader{}, err
+	}
+	return parseSessionHeader(data)
+}
+
+func safeSessionID(sessionID string) bool {
+	if sessionID == "" || sessionID == "." || sessionID == ".." {
+		return false
+	}
+	for _, r := range sessionID {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '.' || r == '_' || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/agents/entire-agent-omp/internal/omp/paths_test.go
+++ b/agents/entire-agent-omp/internal/omp/paths_test.go
@@ -116,11 +116,18 @@ func TestEncodeSessionDirName(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Canonicalize the temp base so the expectations hold on platforms where
+	// os.TempDir() is itself a symlink (e.g. /var -> /private/var on macOS).
+	tmp, err := filepath.EvalSymlinks(os.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tests := []struct{ path, want string }{
 		{home, "-"},
 		{insideHome, "-src-repo"},
-		{os.TempDir(), "-tmp"},
-		{filepath.Join(os.TempDir(), "omp", "repo"), "-tmp-omp-repo"},
+		{tmp, "-tmp"},
+		{filepath.Join(tmp, "omp", "repo"), "-tmp-omp-repo"},
 		{filepath.Join(string(filepath.Separator), "opt", "omp", "repo"), "--opt-omp-repo--"},
 	}
 	for _, test := range tests {

--- a/agents/entire-agent-omp/internal/omp/paths_test.go
+++ b/agents/entire-agent-omp/internal/omp/paths_test.go
@@ -1,0 +1,246 @@
+package omp
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGetSessionDirRoots(t *testing.T) {
+	home := t.TempDir()
+	repo := filepath.Join(home, "src", "project")
+	if err := os.MkdirAll(repo, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("PI_CODING_AGENT_DIR", "")
+	t.Setenv("PI_CONFIG_DIR", ".custom-omp")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("OMP_PROFILE", "")
+	t.Setenv("PI_PROFILE", "")
+
+	got, err := New().GetSessionDir(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(home, ".custom-omp", "agent", "sessions", "-src-project")
+	if got != want {
+		t.Fatalf("custom config session dir = %q, want %q", got, want)
+	}
+
+	xdg := filepath.Join(home, "xdg")
+	profileRoot := filepath.Join(xdg, "omp", "profiles", "work")
+	if err := os.MkdirAll(profileRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PI_CONFIG_DIR", "")
+	t.Setenv("XDG_DATA_HOME", xdg)
+	t.Setenv("OMP_PROFILE", "work")
+	t.Setenv("PI_PROFILE", "")
+	got, err = New().GetSessionDir(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = filepath.Join(profileRoot, "sessions", "-src-project")
+	if got != want {
+		t.Fatalf("profile XDG session dir = %q, want %q", got, want)
+	}
+}
+
+func TestOMPSessionsRootPlatformAndXDGSelection(t *testing.T) {
+	t.Parallel()
+
+	home := filepath.Join(string(filepath.Separator), "home", "user")
+	xdg := filepath.Join(string(filepath.Separator), "xdg", "data")
+	appRoot := filepath.Join(xdg, "omp")
+	workXDG := filepath.Join(appRoot, "profiles", "work")
+
+	tests := []struct {
+		name      string
+		goos      string
+		agentDir  string
+		configDir string
+		xdgData   string
+		omp       envValue
+		pi        envValue
+		existing  string
+		want      string
+	}{
+		{"default Linux XDG", "linux", "", "", xdg, envValue{}, envValue{}, appRoot, filepath.Join(appRoot, "sessions")},
+		{"default macOS XDG", "darwin", "", "", xdg, envValue{}, envValue{}, appRoot, filepath.Join(appRoot, "sessions")},
+		{"inactive Linux XDG", "linux", "", "", xdg, envValue{}, envValue{}, "", filepath.Join(home, ".omp", "agent", "sessions")},
+		{"Windows ignores active XDG", "windows", "", "", xdg, envValue{}, envValue{}, appRoot, filepath.Join(home, ".omp", "agent", "sessions")},
+		{"custom config root", "linux", "", ".custom-omp", "", envValue{}, envValue{}, "", filepath.Join(home, ".custom-omp", "agent", "sessions")},
+		{"agent override takes priority", "linux", filepath.Join(home, "agent"), ".custom-omp", xdg, envValue{}, envValue{}, appRoot, filepath.Join(home, "agent", "sessions")},
+		{"default agent override still permits XDG", "linux", filepath.Join(home, ".omp", "agent"), "", xdg, envValue{}, envValue{}, appRoot, filepath.Join(appRoot, "sessions")},
+		{"named profile home", "linux", "", "", xdg, envValue{"work", true}, envValue{}, "", filepath.Join(home, ".omp", "profiles", "work", "agent", "sessions")},
+		{"named profile XDG", "linux", "", "", xdg, envValue{"work", true}, envValue{}, workXDG, filepath.Join(workXDG, "sessions")},
+		{"named profile ignores custom agent", "linux", filepath.Join(home, "custom-agent"), "", "", envValue{"work", true}, envValue{}, "", filepath.Join(home, ".omp", "profiles", "work", "agent", "sessions")},
+		{"PI profile fallback", "linux", "", "", "", envValue{}, envValue{"work", true}, "", filepath.Join(home, ".omp", "profiles", "work", "agent", "sessions")},
+		{"OMP_PROFILE precedence", "linux", "", "", "", envValue{"personal", true}, envValue{"work", true}, "", filepath.Join(home, ".omp", "profiles", "personal", "agent", "sessions")},
+		{"explicit empty OMP_PROFILE selects default", "linux", "", "", "", envValue{"", true}, envValue{"work", true}, "", filepath.Join(home, ".omp", "agent", "sessions")},
+		{"default sentinel selects default", "linux", "", "", "", envValue{"default", true}, envValue{"work", true}, "", filepath.Join(home, ".omp", "agent", "sessions")},
+		{"inherited profile agent suppressed", "linux", filepath.Join(home, ".omp", "profiles", "work", "agent"), "", "", envValue{"", true}, envValue{"work", true}, "", filepath.Join(home, ".omp", "agent", "sessions")},
+		{"default profile custom override", "linux", filepath.Join(home, "custom-agent"), "", "", envValue{"default", true}, envValue{"work", true}, "", filepath.Join(home, "custom-agent", "sessions")},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ompSessionsRootFor(
+				test.goos,
+				home,
+				test.agentDir,
+				test.configDir,
+				test.xdgData,
+				test.omp,
+				test.pi,
+				func(path string) bool { return path == test.existing },
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Fatalf("session root = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestEncodeSessionDirName(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	insideHome := filepath.Join(home, "src", "repo")
+	if err := os.MkdirAll(insideHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct{ path, want string }{
+		{home, "-"},
+		{insideHome, "-src-repo"},
+		{os.TempDir(), "-tmp"},
+		{filepath.Join(os.TempDir(), "omp", "repo"), "-tmp-omp-repo"},
+		{filepath.Join(string(filepath.Separator), "opt", "omp", "repo"), "--opt-omp-repo--"},
+	}
+	for _, test := range tests {
+		got, err := encodeSessionDirName(test.path)
+		if err != nil {
+			t.Errorf("encodeSessionDirName(%q) error = %v", test.path, err)
+			continue
+		}
+		if got != test.want {
+			t.Errorf("encodeSessionDirName(%q) = %q, want %q", test.path, got, test.want)
+		}
+	}
+}
+
+func TestEncodeSessionDirNameCanonicalizesSymlinks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	target := filepath.Join(home, "real", "repo")
+	if err := os.MkdirAll(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(home, "alias")
+	if err := os.Symlink(filepath.Join(home, "real"), alias); err != nil {
+		t.Fatal(err)
+	}
+	got, err := encodeSessionDirName(filepath.Join(alias, "repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "-real-repo" {
+		t.Fatalf("encoded symlink cwd = %q, want -real-repo", got)
+	}
+}
+
+func TestParseSessionHeader(t *testing.T) {
+	headerLine := `{"type":"session","version":3,"id":"session-1","timestamp":"2026-07-26T00:00:00Z","cwd":"/repo"}`
+	title := titleSlotLine(t)
+	tests := []struct {
+		name    string
+		data    string
+		wantID  string
+		wantErr string
+	}{
+		{"legacy physical layout", headerLine + "\n", "session-1", ""},
+		{"fixed title slot", title + headerLine + "\n", "session-1", ""},
+		{"missing header after title", title, "", "not followed"},
+		{"wrong type", `{"type":"message","version":3,"id":"x"}` + "\n", "", "type is"},
+		{"missing id", `{"type":"session","version":3}` + "\n", "", "id is empty"},
+		{"missing version", `{"type":"session","id":"x"}` + "\n", "", "positive"},
+		{"malformed", "not-json\n", "", "first line"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			header, err := parseSessionHeader([]byte(test.data))
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("error = %v, want containing %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if header.ID != test.wantID || header.Version != 3 || header.Cwd != "/repo" {
+				t.Fatalf("header = %#v", header)
+			}
+		})
+	}
+}
+
+func TestResolveSessionFileByHeaderID(t *testing.T) {
+	dir := t.TempDir()
+	writeSession := func(name, id string, title bool) {
+		t.Helper()
+		body := fmt.Sprintf(`{"type":"session","version":3,"id":%q,"timestamp":"2026-07-26T00:00:00Z","cwd":"/repo"}`+"\n", id)
+		if title {
+			body = titleSlotLine(t) + body
+		}
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeSession("z-later.jsonl", "duplicate", false)
+	writeSession("a-first.jsonl", "duplicate", true)
+	writeSession("timestamp_unrelated.jsonl", "other", true)
+
+	if got, want := New().ResolveSessionFile(dir, "duplicate"), filepath.Join(dir, "a-first.jsonl"); got != want {
+		t.Fatalf("ResolveSessionFile() = %q, want %q", got, want)
+	}
+	if got, want := New().ResolveSessionFile(dir, "new-session"), filepath.Join(dir, "new-session.jsonl"); got != want {
+		t.Fatalf("fallback = %q, want %q", got, want)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "filename-only.jsonl"), []byte("corrupt\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := New().ResolveSessionFile(dir, "filename-only"), filepath.Join(dir, "filename-only.jsonl"); got != want {
+		t.Fatalf("exact filename fallback = %q, want %q", got, want)
+	}
+}
+
+func TestResolveSessionFileRejectsUnsafeIDs(t *testing.T) {
+	dir := t.TempDir()
+	for _, id := range []string{"", ".", "..", "../escape", "a/b", `a\\b`, "two words", "é"} {
+		if got := New().ResolveSessionFile(dir, id); got != "" {
+			t.Errorf("ResolveSessionFile(%q) = %q, want empty", id, got)
+		}
+	}
+}
+
+func titleSlotLine(t *testing.T) string {
+	t.Helper()
+	prefix := `{"type":"title","v":1,"title":"Title","updatedAt":"2026-07-26T00:00:00Z","pad":"`
+	suffix := `"}` + "\n"
+	padding := 256 - len(prefix) - len(suffix)
+	if padding < 0 {
+		t.Fatal("title slot fixture exceeds 256 bytes")
+	}
+	line := prefix + strings.Repeat(" ", padding) + suffix
+	if len(line) != 256 {
+		t.Fatalf("title slot fixture = %d bytes", len(line))
+	}
+	return line
+}

--- a/agents/entire-agent-omp/internal/omp/session.go
+++ b/agents/entire-agent-omp/internal/omp/session.go
@@ -1,0 +1,129 @@
+package omp
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+const maxSessionLine = 10 * 1024 * 1024
+
+type sessionEntry struct {
+	Type      string          `json:"type"`
+	ID        string          `json:"id"`
+	ParentID  *string         `json:"parentId"`
+	Timestamp string          `json:"timestamp"`
+	Model     string          `json:"model"`
+	Message   *sessionMessage `json:"message"`
+}
+
+type sessionMessage struct {
+	Role       string          `json:"role"`
+	Content    json.RawMessage `json:"content"`
+	Model      string          `json:"model"`
+	Usage      *sessionUsage   `json:"usage"`
+	ToolCallID string          `json:"toolCallId"`
+	ToolName   string          `json:"toolName"`
+	IsError    bool            `json:"isError"`
+}
+
+type sessionUsage struct {
+	Input  int `json:"input"`
+	Output int `json:"output"`
+}
+
+type contentBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text"`
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+type parsedEntry struct {
+	Line  int
+	Entry sessionEntry
+}
+
+type parsedSession struct {
+	Header  sessionHeader
+	Entries []parsedEntry
+	Active  []parsedEntry
+	Lines   int
+}
+
+func parseFullSession(data []byte) (*parsedSession, error) {
+	header, err := parseSessionHeader(data)
+	if err != nil {
+		return nil, err
+	}
+	return parseSessionEntries(data, header)
+}
+
+func parseSessionEntries(data []byte, header sessionHeader) (*parsedSession, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 64*1024), maxSessionLine+1)
+	result := &parsedSession{Header: header}
+	byID := make(map[string]parsedEntry)
+	var last *parsedEntry
+	for scanner.Scan() {
+		result.Lines++
+		if len(scanner.Bytes()) > maxSessionLine {
+			return nil, fmt.Errorf("scan session: line %d exceeds %d bytes", result.Lines, maxSessionLine)
+		}
+		var kind struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(scanner.Bytes(), &kind) != nil {
+			continue
+		}
+		if kind.Type == "title" || kind.Type == "session" {
+			continue
+		}
+		var entry sessionEntry
+		if json.Unmarshal(scanner.Bytes(), &entry) != nil || entry.ID == "" || entry.Type == "" {
+			continue
+		}
+		record := parsedEntry{Line: result.Lines, Entry: entry}
+		result.Entries = append(result.Entries, record)
+		byID[entry.ID] = record
+		recordCopy := record
+		last = &recordCopy
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan session: %w", err)
+	}
+
+	seen := make(map[string]bool)
+	for last != nil && !seen[last.Entry.ID] {
+		seen[last.Entry.ID] = true
+		result.Active = append(result.Active, *last)
+		if last.Entry.ParentID == nil || *last.Entry.ParentID == "" {
+			break
+		}
+		parent, ok := byID[*last.Entry.ParentID]
+		if !ok {
+			break
+		}
+		parentCopy := parent
+		last = &parentCopy
+	}
+	for left, right := 0, len(result.Active)-1; left < right; left, right = left+1, right-1 {
+		result.Active[left], result.Active[right] = result.Active[right], result.Active[left]
+	}
+	return result, nil
+}
+
+func parseSessionSlice(data []byte) (*parsedSession, error) {
+	line, _, ok := nextJSONLLine(data)
+	if ok {
+		var kind struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(line, &kind) == nil && (kind.Type == "title" || kind.Type == "session") {
+			return parseFullSession(data)
+		}
+	}
+	return parseSessionEntries(data, sessionHeader{})
+}

--- a/agents/entire-agent-omp/internal/omp/session.go
+++ b/agents/entire-agent-omp/internal/omp/session.go
@@ -7,7 +7,10 @@ import (
 	"fmt"
 )
 
-const maxSessionLine = 10 * 1024 * 1024
+const (
+	maxSessionLine = 10 * 1024 * 1024
+	roleAssistant  = "assistant"
+)
 
 type sessionEntry struct {
 	Type      string          `json:"type"`

--- a/agents/entire-agent-omp/internal/omp/transcript.go
+++ b/agents/entire-agent-omp/internal/omp/transcript.go
@@ -154,7 +154,7 @@ func (a *Agent) ExtractSummary(path string) (string, bool, error) {
 	}
 	for i := len(session.Active) - 1; i >= 0; i-- {
 		message := session.Active[i].Entry.Message
-		if message != nil && message.Role == "assistant" {
+		if message != nil && message.Role == roleAssistant {
 			if text := messageText(message.Content); text != "" {
 				return text, true, nil
 			}
@@ -190,7 +190,7 @@ func latestAssistantModel(data []byte) (string, error) {
 	}
 	for i := len(session.Active) - 1; i >= 0; i-- {
 		message := session.Active[i].Entry.Message
-		if message != nil && message.Role == "assistant" && message.Model != "" {
+		if message != nil && message.Role == roleAssistant && message.Model != "" {
 			return message.Model, nil
 		}
 	}
@@ -211,7 +211,7 @@ func modifiedFiles(entries []parsedEntry, offset int) []string {
 	}
 	for _, record := range entries {
 		message := record.Entry.Message
-		if record.Line <= offset || message == nil || message.Role != "assistant" {
+		if record.Line <= offset || message == nil || message.Role != roleAssistant {
 			continue
 		}
 		for _, block := range messageBlocks(message.Content) {

--- a/agents/entire-agent-omp/internal/omp/transcript.go
+++ b/agents/entire-agent-omp/internal/omp/transcript.go
@@ -1,7 +1,6 @@
 package omp
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -14,119 +13,6 @@ import (
 
 	"github.com/entireio/external-agents/agents/entire-agent-omp/internal/protocol"
 )
-
-const maxSessionLine = 10 * 1024 * 1024
-
-type sessionEntry struct {
-	Type      string          `json:"type"`
-	ID        string          `json:"id"`
-	ParentID  *string         `json:"parentId"`
-	Timestamp string          `json:"timestamp"`
-	Model     string          `json:"model"`
-	Message   *sessionMessage `json:"message"`
-}
-
-type sessionMessage struct {
-	Role       string          `json:"role"`
-	Content    json.RawMessage `json:"content"`
-	Model      string          `json:"model"`
-	Usage      *sessionUsage   `json:"usage"`
-	ToolCallID string          `json:"toolCallId"`
-	ToolName   string          `json:"toolName"`
-	IsError    bool            `json:"isError"`
-}
-
-type sessionUsage struct {
-	Input  int `json:"input"`
-	Output int `json:"output"`
-}
-
-type contentBlock struct {
-	Type      string          `json:"type"`
-	Text      string          `json:"text"`
-	ID        string          `json:"id"`
-	Name      string          `json:"name"`
-	Arguments json.RawMessage `json:"arguments"`
-}
-
-type parsedEntry struct {
-	Line  int
-	Entry sessionEntry
-}
-
-type parsedSession struct {
-	Header  sessionHeader
-	Entries []parsedEntry
-	Active  []parsedEntry
-	Lines   int
-}
-
-func parseSession(data []byte) (*parsedSession, error) {
-	header, err := parseSessionHeader(data)
-	if err != nil {
-		return nil, err
-	}
-	return parseSessionEntries(data, header)
-}
-
-func parseSessionEntries(data []byte, header sessionHeader) (*parsedSession, error) {
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-	scanner.Buffer(make([]byte, 64*1024), maxSessionLine+1)
-	result := &parsedSession{Header: header}
-	byID := make(map[string]parsedEntry)
-	var last *parsedEntry
-	for scanner.Scan() {
-		result.Lines++
-		if len(scanner.Bytes()) > maxSessionLine {
-			return nil, fmt.Errorf("scan session: line %d exceeds %d bytes", result.Lines, maxSessionLine)
-		}
-		var kind struct {
-			Type string `json:"type"`
-		}
-		if json.Unmarshal(scanner.Bytes(), &kind) != nil {
-			continue
-		}
-		if kind.Type == "title" || kind.Type == "session" {
-			continue
-		}
-		var entry sessionEntry
-		if json.Unmarshal(scanner.Bytes(), &entry) != nil || entry.ID == "" || entry.Type == "" {
-			continue
-		}
-		record := parsedEntry{Line: result.Lines, Entry: entry}
-		result.Entries = append(result.Entries, record)
-		byID[entry.ID] = record
-		recordCopy := record
-		last = &recordCopy
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan session: %w", err)
-	}
-
-	seen := make(map[string]bool)
-	for last != nil && !seen[last.Entry.ID] {
-		seen[last.Entry.ID] = true
-		result.Active = append(result.Active, *last)
-		if last.Entry.ParentID == nil || *last.Entry.ParentID == "" {
-			break
-		}
-		parent, ok := byID[*last.Entry.ParentID]
-		if !ok {
-			break
-		}
-		parentCopy := parent
-		last = &parentCopy
-	}
-	for left, right := 0, len(result.Active)-1; left < right; left, right = left+1, right-1 {
-		result.Active[left], result.Active[right] = result.Active[right], result.Active[left]
-	}
-	return result, nil
-}
-
-func parseSessionLoose(data []byte) (*parsedSession, error) {
-	header, _ := parseSessionHeader(data)
-	return parseSessionEntries(data, header)
-}
 
 func (a *Agent) ReadSession(input *protocol.HookInputJSON) (protocol.AgentSessionJSON, error) {
 	if input == nil || strings.TrimSpace(input.SessionRef) == "" {
@@ -225,7 +111,7 @@ func (a *Agent) GetTranscriptPosition(path string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	session, err := parseSessionLoose(data)
+	session, err := parseSessionSlice(data)
 	if err != nil {
 		return 0, err
 	}
@@ -237,7 +123,7 @@ func (a *Agent) ExtractModifiedFiles(path string, offset int) ([]string, int, er
 	if err != nil {
 		return nil, 0, err
 	}
-	session, err := parseSessionLoose(data)
+	session, err := parseSessionSlice(data)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -282,7 +168,7 @@ func readParsedSession(path string) (*parsedSession, error) {
 	if err != nil {
 		return nil, err
 	}
-	return parseSessionLoose(data)
+	return parseSessionSlice(data)
 }
 
 func extractModelFromPath(path string) string {
@@ -298,7 +184,7 @@ func extractModelFromPath(path string) string {
 }
 
 func latestAssistantModel(data []byte) (string, error) {
-	session, err := parseSession(data)
+	session, err := parseFullSession(data)
 	if err != nil {
 		return "", err
 	}

--- a/agents/entire-agent-omp/internal/omp/transcript.go
+++ b/agents/entire-agent-omp/internal/omp/transcript.go
@@ -1,0 +1,473 @@
+package omp
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/entireio/external-agents/agents/entire-agent-omp/internal/protocol"
+)
+
+const maxSessionLine = 10 * 1024 * 1024
+
+type sessionEntry struct {
+	Type      string          `json:"type"`
+	ID        string          `json:"id"`
+	ParentID  *string         `json:"parentId"`
+	Timestamp string          `json:"timestamp"`
+	Model     string          `json:"model"`
+	Message   *sessionMessage `json:"message"`
+}
+
+type sessionMessage struct {
+	Role       string          `json:"role"`
+	Content    json.RawMessage `json:"content"`
+	Model      string          `json:"model"`
+	Usage      *sessionUsage   `json:"usage"`
+	ToolCallID string          `json:"toolCallId"`
+	ToolName   string          `json:"toolName"`
+	IsError    bool            `json:"isError"`
+}
+
+type sessionUsage struct {
+	Input  int `json:"input"`
+	Output int `json:"output"`
+}
+
+type contentBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text"`
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+type parsedEntry struct {
+	Line  int
+	Entry sessionEntry
+}
+
+type parsedSession struct {
+	Header  sessionHeader
+	Entries []parsedEntry
+	Active  []parsedEntry
+	Lines   int
+}
+
+func parseSession(data []byte) (*parsedSession, error) {
+	header, err := parseSessionHeader(data)
+	if err != nil {
+		return nil, err
+	}
+	return parseSessionEntries(data, header)
+}
+
+func parseSessionEntries(data []byte, header sessionHeader) (*parsedSession, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 64*1024), maxSessionLine+1)
+	result := &parsedSession{Header: header}
+	byID := make(map[string]parsedEntry)
+	var last *parsedEntry
+	for scanner.Scan() {
+		result.Lines++
+		if len(scanner.Bytes()) > maxSessionLine {
+			return nil, fmt.Errorf("scan session: line %d exceeds %d bytes", result.Lines, maxSessionLine)
+		}
+		var kind struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(scanner.Bytes(), &kind) != nil {
+			continue
+		}
+		if kind.Type == "title" || kind.Type == "session" {
+			continue
+		}
+		var entry sessionEntry
+		if json.Unmarshal(scanner.Bytes(), &entry) != nil || entry.ID == "" || entry.Type == "" {
+			continue
+		}
+		record := parsedEntry{Line: result.Lines, Entry: entry}
+		result.Entries = append(result.Entries, record)
+		byID[entry.ID] = record
+		recordCopy := record
+		last = &recordCopy
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan session: %w", err)
+	}
+
+	seen := make(map[string]bool)
+	for last != nil && !seen[last.Entry.ID] {
+		seen[last.Entry.ID] = true
+		result.Active = append(result.Active, *last)
+		if last.Entry.ParentID == nil || *last.Entry.ParentID == "" {
+			break
+		}
+		parent, ok := byID[*last.Entry.ParentID]
+		if !ok {
+			break
+		}
+		parentCopy := parent
+		last = &parentCopy
+	}
+	for left, right := 0, len(result.Active)-1; left < right; left, right = left+1, right-1 {
+		result.Active[left], result.Active[right] = result.Active[right], result.Active[left]
+	}
+	return result, nil
+}
+
+func parseSessionLoose(data []byte) (*parsedSession, error) {
+	header, _ := parseSessionHeader(data)
+	return parseSessionEntries(data, header)
+}
+
+func (a *Agent) ReadSession(input *protocol.HookInputJSON) (protocol.AgentSessionJSON, error) {
+	if input == nil || strings.TrimSpace(input.SessionRef) == "" {
+		return protocol.AgentSessionJSON{}, errors.New("session_ref is required")
+	}
+	data, err := os.ReadFile(input.SessionRef)
+	if err != nil {
+		return protocol.AgentSessionJSON{}, err
+	}
+	header, headerErr := parseSessionHeader(data)
+	if headerErr == nil {
+		session, err := parseSessionEntries(data, header)
+		if err != nil {
+			return protocol.AgentSessionJSON{}, err
+		}
+		return protocol.AgentSessionJSON{
+			SessionID:     session.Header.ID,
+			AgentName:     "omp",
+			RepoPath:      session.Header.Cwd,
+			SessionRef:    input.SessionRef,
+			StartTime:     session.Header.Timestamp,
+			NativeData:    data,
+			ModifiedFiles: modifiedFiles(session.Active, 0),
+			NewFiles:      []string{},
+			DeletedFiles:  []string{},
+		}, nil
+	}
+	return protocol.AgentSessionJSON{
+		SessionID:     input.SessionID,
+		AgentName:     "omp",
+		RepoPath:      protocol.RepoRoot(),
+		SessionRef:    input.SessionRef,
+		StartTime:     time.Now().UTC().Format(time.RFC3339),
+		NativeData:    data,
+		ModifiedFiles: []string{},
+		NewFiles:      []string{},
+		DeletedFiles:  []string{},
+	}, nil
+}
+
+func (a *Agent) WriteSession(session protocol.AgentSessionJSON) error {
+	if strings.TrimSpace(session.SessionRef) == "" {
+		return errors.New("session_ref is required")
+	}
+	dir := filepath.Dir(session.SessionRef)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".entire-omp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(0o600); err != nil {
+		return errors.Join(err, tmp.Close())
+	}
+	if _, err := tmp.Write(session.NativeData); err != nil {
+		return errors.Join(err, tmp.Close())
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, session.SessionRef); err != nil {
+		return err
+	}
+	return os.Chmod(session.SessionRef, 0o600)
+}
+
+func (a *Agent) ReadTranscript(sessionRef string) ([]byte, error) {
+	return os.ReadFile(sessionRef)
+}
+
+func (a *Agent) ChunkTranscript(content []byte, maxSize int) ([][]byte, error) {
+	if maxSize <= 0 {
+		return nil, fmt.Errorf("max-size must be positive, got %d", maxSize)
+	}
+	var chunks [][]byte
+	for len(content) > 0 {
+		size := min(maxSize, len(content))
+		chunks = append(chunks, content[:size])
+		content = content[size:]
+	}
+	return chunks, nil
+}
+
+func (a *Agent) ReassembleTranscript(chunks [][]byte) ([]byte, error) {
+	return bytes.Join(chunks, nil), nil
+}
+
+func (a *Agent) GetTranscriptPosition(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	session, err := parseSessionLoose(data)
+	if err != nil {
+		return 0, err
+	}
+	return session.Lines, nil
+}
+
+func (a *Agent) ExtractModifiedFiles(path string, offset int) ([]string, int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	session, err := parseSessionLoose(data)
+	if err != nil {
+		return nil, 0, err
+	}
+	return modifiedFiles(session.Active, offset), session.Lines, nil
+}
+
+func (a *Agent) ExtractPrompts(path string, offset int) ([]string, error) {
+	session, err := readParsedSession(path)
+	if err != nil {
+		return nil, err
+	}
+	prompts := []string{}
+	for _, record := range session.Active {
+		if record.Line <= offset || record.Entry.Message == nil || record.Entry.Message.Role != "user" {
+			continue
+		}
+		if text := messageText(record.Entry.Message.Content); text != "" {
+			prompts = append(prompts, text)
+		}
+	}
+	return prompts, nil
+}
+
+func (a *Agent) ExtractSummary(path string) (string, bool, error) {
+	session, err := readParsedSession(path)
+	if err != nil {
+		return "", false, err
+	}
+	for i := len(session.Active) - 1; i >= 0; i-- {
+		message := session.Active[i].Entry.Message
+		if message != nil && message.Role == "assistant" {
+			if text := messageText(message.Content); text != "" {
+				return text, true, nil
+			}
+		}
+	}
+	return "", false, nil
+}
+
+func readParsedSession(path string) (*parsedSession, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return parseSessionLoose(data)
+}
+
+func extractModelFromPath(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	model, err := latestAssistantModel(data)
+	if err != nil {
+		return ""
+	}
+	return model
+}
+
+func latestAssistantModel(data []byte) (string, error) {
+	session, err := parseSession(data)
+	if err != nil {
+		return "", err
+	}
+	for i := len(session.Active) - 1; i >= 0; i-- {
+		message := session.Active[i].Entry.Message
+		if message != nil && message.Role == "assistant" && message.Model != "" {
+			return message.Model, nil
+		}
+	}
+	return "", nil
+}
+
+func modifiedFiles(entries []parsedEntry, offset int) []string {
+	seen := make(map[string]bool)
+	files := []string{}
+	add := func(path string, trim bool) {
+		if trim {
+			path = strings.TrimSpace(path)
+		}
+		if path != "" && !strings.Contains(path, "://") && !seen[path] {
+			seen[path] = true
+			files = append(files, path)
+		}
+	}
+	for _, record := range entries {
+		message := record.Entry.Message
+		if record.Line <= offset || message == nil || message.Role != "assistant" {
+			continue
+		}
+		for _, block := range messageBlocks(message.Content) {
+			if block.Type != "toolCall" || !isWriteTool(block.Name) {
+				continue
+			}
+			var arguments map[string]any
+			if json.Unmarshal(block.Arguments, &arguments) != nil {
+				continue
+			}
+			if normalizeToolName(block.Name) == "apply_patch" {
+				input, _ := arguments["input"].(string)
+				for _, path := range patchPaths(input) {
+					add(path, false)
+				}
+				continue
+			}
+			for _, key := range []string{"path", "file_path", "filePath"} {
+				path, ok := arguments[key].(string)
+				if ok {
+					add(path, true)
+				}
+			}
+		}
+	}
+	return files
+}
+
+func patchPaths(input string) []string {
+	lines := strings.Split(trimECMAScriptSpace(input), "\n")
+	if len(lines) >= 2 {
+		switch lines[0] {
+		case "<<EOF", "<<'EOF'", `<<"EOF"`:
+			if trimECMAScriptSpace(lines[len(lines)-1]) == "EOF" {
+				lines = lines[1 : len(lines)-1]
+			}
+		}
+	}
+	if len(lines) < 3 ||
+		trimECMAScriptSpace(lines[0]) != "*** Begin Patch" ||
+		trimECMAScriptSpace(lines[len(lines)-1]) != "*** End Patch" {
+		return nil
+	}
+
+	var paths []string
+	for remaining := lines[1 : len(lines)-1]; len(remaining) > 0; {
+		if trimECMAScriptSpace(remaining[0]) == "" {
+			remaining = remaining[1:]
+			continue
+		}
+
+		firstLine := trimECMAScriptSpace(remaining[0])
+		switch {
+		case strings.HasPrefix(firstLine, "*** Add File: "):
+			paths = append(paths, firstLine[len("*** Add File: "):])
+			consumed := 1
+			for consumed < len(remaining) && strings.HasPrefix(remaining[consumed], "+") {
+				consumed++
+			}
+			remaining = remaining[consumed:]
+		case strings.HasPrefix(firstLine, "*** Delete File: "):
+			paths = append(paths, firstLine[len("*** Delete File: "):])
+			remaining = remaining[1:]
+		case strings.HasPrefix(firstLine, "*** Update File: "):
+			paths = append(paths, firstLine[len("*** Update File: "):])
+			remaining = remaining[1:]
+
+			if len(remaining) > 0 && strings.HasPrefix(remaining[0], "*** Move to: ") {
+				paths = append(paths, remaining[0][len("*** Move to: "):])
+				remaining = remaining[1:]
+			}
+
+			diffLines := 0
+			for len(remaining) > 0 &&
+				!strings.HasPrefix(remaining[0], "*** Add File:") &&
+				!strings.HasPrefix(remaining[0], "*** Delete File:") &&
+				!strings.HasPrefix(remaining[0], "*** Update File:") {
+				diffLines++
+				remaining = remaining[1:]
+			}
+			if diffLines == 0 {
+				return nil
+			}
+		default:
+			return nil
+		}
+	}
+	return paths
+}
+
+func trimECMAScriptSpace(s string) string {
+	return strings.TrimFunc(s, func(r rune) bool {
+		return unicode.Is(unicode.Zs, r) ||
+			r == '\uFEFF' ||
+			r == '\t' || r == '\v' || r == '\f' ||
+			r == '\n' || r == '\r' || r == '\u2028' || r == '\u2029'
+	})
+}
+
+func isWriteTool(name string) bool {
+	switch normalizeToolName(name) {
+	case "write", "edit", "apply_patch":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeToolName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	name = strings.ReplaceAll(name, "-", "_")
+	if index := strings.LastIndexAny(name, ".:/"); index >= 0 {
+		name = name[index+1:]
+	}
+	return name
+}
+
+func messageText(raw json.RawMessage) string {
+	var text string
+	if json.Unmarshal(raw, &text) == nil {
+		return text
+	}
+	var parts []string
+	for _, block := range messageBlocks(raw) {
+		if block.Type == "text" && block.Text != "" {
+			parts = append(parts, block.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func messageBlocks(raw json.RawMessage) []contentBlock {
+	var encoded []json.RawMessage
+	if json.Unmarshal(raw, &encoded) != nil {
+		return nil
+	}
+	blocks := make([]contentBlock, 0, len(encoded))
+	for _, item := range encoded {
+		var block contentBlock
+		if json.Unmarshal(item, &block) == nil && block.Type != "" {
+			blocks = append(blocks, block)
+		}
+	}
+	return blocks
+}

--- a/agents/entire-agent-omp/internal/omp/transcript_test.go
+++ b/agents/entire-agent-omp/internal/omp/transcript_test.go
@@ -1,0 +1,473 @@
+package omp
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/entireio/external-agents/agents/entire-agent-omp/internal/protocol"
+)
+
+func ompTitleSlot() string {
+	prefix := `{"type":"title","v":1,"title":"test","pad":"`
+	suffix := `"}`
+	return prefix + strings.Repeat(" ", 255-len(prefix)-len(suffix)) + suffix + "\n"
+}
+
+func ompHeader() string {
+	return `{"type":"session","version":3,"id":"session-header","timestamp":"2026-07-26T03:14:06.592Z","cwd":"/repo/from/header"}` + "\n"
+}
+
+func ompBranchFixture() []byte {
+	return []byte(ompTitleSlot() + ompHeader() +
+		`{"type":"model_change","id":"model","parentId":null,"timestamp":"2026-07-26T03:14:07Z","model":"openai/gpt"}` + "\n" +
+		`{"type":"message","id":"excluded","parentId":"model","timestamp":"2026-07-26T03:14:08Z","message":{"role":"user","content":"excluded branch"}}` + "\n" +
+		`{"type":"message","id":"user","parentId":"model","timestamp":"2026-07-26T03:14:09Z","message":{"role":"user","content":[{"type":"text","text":"keep one"},{"type":"image","data":"x"},{"type":"text","text":"keep two"}]}}` + "\n" +
+		`{"type":"message","id":"assistant","parentId":"user","timestamp":"2026-07-26T03:14:10Z","message":{"role":"assistant","model":"openai/gpt-5","content":[{"type":"thinking","thinking":"secret"},{"type":"text","text":"summary"},{"type":"toolCall","id":"write-1","name":"write","arguments":{"path":"a.go"}},{"type":"toolCall","id":"edit-1","name":"Edit","arguments":{"file_path":"b.go"}},{"type":"toolCall","id":"write-2","name":"write","arguments":{"path":"a.go"}},{"type":"toolCall","id":"internal-write","name":"write","arguments":{"path":"xd://report_issue"}}],"usage":{"input":12,"output":7}}}` + "\n" +
+		`{"type":"custom_message","customType":"notice","content":"tail","id":"tail","parentId":"assistant","timestamp":"2026-07-26T03:14:11Z"}` + "\n")
+}
+
+func writeOMPFixture(t *testing.T, data []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestParseSessionTitleHeaderAndActiveLeaf(t *testing.T) {
+	session, err := parseSession(ompBranchFixture())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.Header.ID != "session-header" || session.Header.Cwd != "/repo/from/header" {
+		t.Fatalf("unexpected header: %+v", session.Header)
+	}
+	if session.Lines != 7 {
+		t.Fatalf("lines = %d, want 7", session.Lines)
+	}
+	var ids []string
+	for _, entry := range session.Active {
+		ids = append(ids, entry.Entry.ID)
+	}
+	if want := []string{"model", "user", "assistant", "tail"}; !reflect.DeepEqual(ids, want) {
+		t.Fatalf("active IDs = %v, want %v", ids, want)
+	}
+}
+
+func TestParseSessionWithoutTitleAndMalformedLaterLines(t *testing.T) {
+	data := []byte(ompHeader() +
+		`{"type":"message","id":"user","parentId":null,"message":{"role":"user","content":"hello"}}` + "\n" +
+		"{broken\n" +
+		`{"type":"message","id":"assistant","parentId":"user","message":{"role":"assistant","content":[{"type":"text","text":"ok"}]}}` + "\n" +
+		"not json\n")
+	session, err := parseSession(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.Lines != 5 || len(session.Active) != 2 || session.Active[1].Entry.ID != "assistant" {
+		t.Fatalf("unexpected parse result: lines=%d active=%+v", session.Lines, session.Active)
+	}
+}
+
+func TestParseSessionCycleGuard(t *testing.T) {
+	data := []byte(ompHeader() +
+		`{"type":"custom","id":"a","parentId":"b"}` + "\n" +
+		`{"type":"custom","id":"b","parentId":"a"}` + "\n")
+	session, err := parseSession(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(session.Active) != 2 {
+		t.Fatalf("cycle branch length = %d, want 2", len(session.Active))
+	}
+}
+
+func TestParseSessionRejectsMalformedHeaderAndOversizedLine(t *testing.T) {
+	if _, err := parseSession([]byte(`{"type":"title"}` + "\n" + `{"type":"message"}` + "\n")); err == nil {
+		t.Fatal("expected malformed header error")
+	}
+	prefix := `{"type":"custom","id":"large","parentId":null,"value":"`
+	suffix := `"}`
+	atLimit := ompHeader() + prefix + strings.Repeat("x", maxSessionLine-len(prefix)-len(suffix)) + suffix + "\n"
+	if _, err := parseSession([]byte(atLimit)); err != nil {
+		t.Fatalf("line at limit rejected: %v", err)
+	}
+	oversized := append([]byte(ompHeader()), bytes.Repeat([]byte("x"), maxSessionLine+1)...)
+	if _, err := parseSession(oversized); err == nil {
+		t.Fatal("expected scanner size error")
+	}
+}
+
+func TestAnalyzerUsesPhysicalOffsetsAndActiveBranch(t *testing.T) {
+	path := writeOMPFixture(t, ompBranchFixture())
+	agent := &Agent{}
+	position, err := agent.GetTranscriptPosition(path)
+	if err != nil || position != 7 {
+		t.Fatalf("position = %d, err = %v", position, err)
+	}
+	prompts, err := agent.ExtractPrompts(path, 2)
+	if err != nil || !reflect.DeepEqual(prompts, []string{"keep one\nkeep two"}) {
+		t.Fatalf("prompts = %v, err = %v", prompts, err)
+	}
+	if prompts, err = agent.ExtractPrompts(path, 5); err != nil || len(prompts) != 0 {
+		t.Fatalf("offset prompts = %v, err = %v", prompts, err)
+	}
+	files, current, err := agent.ExtractModifiedFiles(path, 0)
+	if err != nil || current != 7 || !reflect.DeepEqual(files, []string{"a.go", "b.go"}) {
+		t.Fatalf("files = %v, current = %d, err = %v", files, current, err)
+	}
+	if files, _, err = agent.ExtractModifiedFiles(path, 6); err != nil || len(files) != 0 {
+		t.Fatalf("offset files = %v, err = %v", files, err)
+	}
+	summary, ok, err := agent.ExtractSummary(path)
+	if err != nil || !ok || summary != "summary" {
+		t.Fatalf("summary = %q, ok = %v, err = %v", summary, ok, err)
+	}
+	if model := extractModelFromPath(path); model != "openai/gpt-5" {
+		t.Fatalf("model = %q", model)
+	}
+}
+
+func TestModifiedFilesExtractsApplyPatchFreeformPaths(t *testing.T) {
+	patch := "*** Begin Patch\n" +
+		"*** Add File: added.go\n+package added\n" +
+		"*** Update File: old.go\n*** Move to: renamed.go\n@@\n-old\n+new\n" +
+		"*** Delete File: deleted.go\n" +
+		"*** Update File: added.go\n@@\n-old\n+new\n" +
+		"*** Add File: xd://report_issue\n+ignored\n" +
+		"*** End Patch\n"
+	arguments, err := json.Marshal(map[string]string{"input": patch})
+	if err != nil {
+		t.Fatal(err)
+	}
+	content, err := json.Marshal([]contentBlock{{
+		Type:      "toolCall",
+		Name:      "apply_patch",
+		Arguments: arguments,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries := []parsedEntry{{
+		Line: 2,
+		Entry: sessionEntry{Message: &sessionMessage{
+			Role:    "assistant",
+			Content: content,
+		}},
+	}}
+
+	if got, want := modifiedFiles(entries, 0), []string{"added.go", "old.go", "renamed.go", "deleted.go"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("modified files = %v, want %v", got, want)
+	}
+	if got := modifiedFiles(entries, 2); len(got) != 0 {
+		t.Fatalf("offset modified files = %v, want none", got)
+	}
+}
+
+func TestModifiedFilesIgnoresMalformedApplyPatchInput(t *testing.T) {
+	tests := []string{
+		"ordinary text\n*** Update File: ordinary.go\n",
+		"*** Begin Patch\n*** Delete File: missing-end.go\n",
+		"*** Begin Patch\n*** End Patch\ntrailing text",
+		"<<EOF\n*** Begin Patch\n*** Delete File: unclosed.go\n*** End Patch",
+		"<<'EOF'\n*** Begin Patch\n*** Delete File: mismatched.go\n*** End Patch\nNOT_EOF",
+		"<<EOF\n*** Begin Patch\n*** Delete File: mismatched.go\n*** End Patch\n'EOF'",
+		"*** Begin Patch\n*** Move to: orphan.go\n*** End Patch\n",
+		"*** Begin Patch\n*** Update File: \n*** Move to: orphan.go\n*** End Patch\n",
+		"*** Begin Patch\n*** Add File: \n*** Update File:\n*** End Patch\n",
+	}
+	for _, input := range tests {
+		arguments, err := json.Marshal(map[string]string{"input": input})
+		if err != nil {
+			t.Fatal(err)
+		}
+		content, err := json.Marshal([]contentBlock{{
+			Type:      "toolCall",
+			Name:      "apply_patch",
+			Arguments: arguments,
+		}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		entries := []parsedEntry{{
+			Line: 1,
+			Entry: sessionEntry{Message: &sessionMessage{
+				Role:    "assistant",
+				Content: content,
+			}},
+		}}
+		if got := modifiedFiles(entries, 0); len(got) != 0 {
+			t.Errorf("input %q produced modified files %v", input, got)
+		}
+	}
+}
+
+func TestPatchPathsAcceptsOfficialWrappersAndWhitespace(t *testing.T) {
+	bare := "\n \t*** Begin Patch \n\t*** Add File: bare.go \t\n *** End Patch\t\n\n"
+	if got, want := patchPaths(bare), []string{"bare.go"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("bare envelope paths = %v, want %v", got, want)
+	}
+
+	for _, opener := range []string{"<<EOF", "<<'EOF'", `<<"EOF"`} {
+		input := " \t" + opener + "\n" +
+			"  *** Begin Patch \t\n" +
+			"\t*** Add File: added.go  \n" +
+			" \t*** Update File: old.go\t\n" +
+			"*** Move to: renamed.go\n" +
+			"@@\n-old\n+new\n" +
+			"*** Delete File: deleted.go \n" +
+			" *** End Patch\t\n" +
+			" EOF \n"
+		want := []string{"added.go", "old.go", "renamed.go", "deleted.go"}
+		if got := patchPaths(input); !reflect.DeepEqual(got, want) {
+			t.Errorf("opener %q: paths = %v, want %v", opener, got, want)
+		}
+	}
+}
+
+func TestTrimECMAScriptSpace(t *testing.T) {
+	for _, r := range []rune{
+		'\t', '\v', '\f', '\n', '\r',
+		' ', '\u00A0', '\u1680',
+		'\u2000', '\u2001', '\u2002', '\u2003', '\u2004', '\u2005',
+		'\u2006', '\u2007', '\u2008', '\u2009', '\u200A',
+		'\u2028', '\u2029', '\u202F', '\u205F', '\u3000', '\uFEFF',
+	} {
+		if got := trimECMAScriptSpace(string(r) + "value" + string(r)); got != "value" {
+			t.Errorf("U+%04X was not trimmed: %q", r, got)
+		}
+	}
+
+	for _, r := range []rune{'\u0085', '\u180E', '\u200B'} {
+		want := string(r) + "value" + string(r)
+		if got := trimECMAScriptSpace(want); got != want {
+			t.Errorf("U+%04X was trimmed: %q", r, got)
+		}
+	}
+}
+
+func TestPatchPathsUsesECMAScriptTrimCharacters(t *testing.T) {
+	input := "\uFEFF<<EOF\n" +
+		"\uFEFF*** Begin Patch\uFEFF\n" +
+		"\uFEFF\n" +
+		"\uFEFF*** Add File: \uFEFFleading-feff.go\uFEFF\n" +
+		"+package added\n" +
+		"\uFEFF*** End Patch\uFEFF\n" +
+		"\uFEFFEOF\uFEFF"
+	if got, want := patchPaths(input), []string{"\uFEFFleading-feff.go"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("paths = %q, want %q", got, want)
+	}
+
+	for _, input := range []string{
+		"\u0085*** Begin Patch\n*** Delete File: file.go\n*** End Patch",
+		"*** Begin Patch\n\u0085\n*** Delete File: file.go\n*** End Patch",
+		"*** Begin Patch\n\u0085*** Delete File: file.go\n*** End Patch",
+		"*** Begin Patch\n*** Delete File: file.go\n*** End Patch\u0085",
+	} {
+		if got := patchPaths(input); got != nil {
+			t.Errorf("input containing U+0085 produced paths %q, want nil", got)
+		}
+	}
+}
+
+func TestPatchPathsMatchesApplyPatchStateMachine(t *testing.T) {
+	t.Run("body markers and column-zero move", func(t *testing.T) {
+		input := "*** Begin Patch\n" +
+			"*** Update File: old.go\n" +
+			"\t*** Move to: body-marker.go\n" +
+			" *** Add File: body-add.go\n" +
+			" *** End Patch\n" +
+			"*** Update File: next.go\n" +
+			"*** Move to: moved.go\n" +
+			"@@\n-old\n+new\n" +
+			"*** End Patch"
+		want := []string{"old.go", "next.go", "moved.go"}
+		if got := patchPaths(input); !reflect.DeepEqual(got, want) {
+			t.Fatalf("paths = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("leading path space is preserved", func(t *testing.T) {
+		input := "*** Begin Patch\n*** Add File:  spaced.go\n+package spaced\n*** End Patch"
+		if got, want := patchPaths(input), []string{" spaced.go"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("paths = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("malformed trailing hunk is atomic", func(t *testing.T) {
+		input := "*** Begin Patch\n" +
+			"*** Add File: valid.go\n+package valid\n" +
+			"*** Update File: empty.go\n" +
+			"*** Delete File: never-returned.go\n" +
+			"*** End Patch"
+		if got := patchPaths(input); got != nil {
+			t.Fatalf("paths = %q, want nil", got)
+		}
+	})
+
+	t.Run("unknown top-level text is atomic", func(t *testing.T) {
+		input := "*** Begin Patch\n" +
+			"*** Delete File: valid.go\n" +
+			"not a hunk\n" +
+			"*** End Patch"
+		if got := patchPaths(input); got != nil {
+			t.Fatalf("paths = %q, want nil", got)
+		}
+	})
+
+	t.Run("add consumes only plus lines", func(t *testing.T) {
+		input := "*** Begin Patch\n" +
+			"*** Add File: valid.go\n+package valid\n" +
+			"context is not add-file content\n" +
+			"*** Delete File: never-returned.go\n" +
+			"*** End Patch"
+		if got := patchPaths(input); got != nil {
+			t.Fatalf("paths = %q, want nil", got)
+		}
+	})
+}
+
+func TestModifiedFilesPreservesApplyPatchPathButNormalizesWritePath(t *testing.T) {
+	patchArguments, err := json.Marshal(map[string]string{
+		"input": "*** Begin Patch\n*** Add File:  spaced.go\n+package spaced\n*** End Patch",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeArguments, err := json.Marshal(map[string]string{"path": " normalized.go "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	content, err := json.Marshal([]contentBlock{
+		{Type: "toolCall", Name: "apply_patch", Arguments: patchArguments},
+		{Type: "toolCall", Name: "write", Arguments: writeArguments},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries := []parsedEntry{{
+		Line: 1,
+		Entry: sessionEntry{Message: &sessionMessage{
+			Role:    "assistant",
+			Content: content,
+		}},
+	}}
+
+	want := []string{" spaced.go", "normalized.go"}
+	if got := modifiedFiles(entries, 0); !reflect.DeepEqual(got, want) {
+		t.Fatalf("modified files = %q, want %q", got, want)
+	}
+}
+
+func TestAnalyzerAcceptsHeaderlessDataAndMissingPosition(t *testing.T) {
+	agent := &Agent{}
+	path := writeOMPFixture(t, []byte("{}\n"))
+	if position, err := agent.GetTranscriptPosition(path); err != nil || position != 1 {
+		t.Fatalf("position = %d, err = %v", position, err)
+	}
+	if prompts, err := agent.ExtractPrompts(path, 0); err != nil || len(prompts) != 0 {
+		t.Fatalf("prompts = %v, err = %v", prompts, err)
+	}
+	if files, position, err := agent.ExtractModifiedFiles(path, 0); err != nil || position != 1 || len(files) != 0 {
+		t.Fatalf("files = %v, position = %d, err = %v", files, position, err)
+	}
+	if summary, ok, err := agent.ExtractSummary(path); err != nil || ok || summary != "" {
+		t.Fatalf("summary = %q, ok = %v, err = %v", summary, ok, err)
+	}
+	if position, err := agent.GetTranscriptPosition(filepath.Join(t.TempDir(), "missing")); err != nil || position != 0 {
+		t.Fatalf("missing position = %d, err = %v", position, err)
+	}
+}
+
+func TestReadSessionUsesHeaderAuthorityAndOpaqueFallback(t *testing.T) {
+	agent := &Agent{}
+	if _, err := agent.ReadSession(nil); err == nil {
+		t.Fatal("expected nil input error")
+	}
+	path := writeOMPFixture(t, ompBranchFixture())
+	session, err := agent.ReadSession(&protocol.HookInputJSON{SessionID: "wrong", SessionRef: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.SessionID != "session-header" || session.RepoPath != "/repo/from/header" || session.StartTime != "2026-07-26T03:14:06.592Z" {
+		t.Fatalf("header was not authoritative: %+v", session)
+	}
+	if !bytes.Equal(session.NativeData, ompBranchFixture()) || !reflect.DeepEqual(session.ModifiedFiles, []string{"a.go", "b.go"}) {
+		t.Fatalf("unexpected native session: %+v", session)
+	}
+	opaque := writeOMPFixture(t, []byte(`{"test":true}`))
+	session, err = agent.ReadSession(&protocol.HookInputJSON{SessionID: "opaque-id", SessionRef: opaque})
+	if err != nil || session.SessionID != "opaque-id" || len(session.NativeData) == 0 || session.StartTime == "" {
+		t.Fatalf("opaque session = %+v, err = %v", session, err)
+	}
+	if session.ModifiedFiles == nil || session.NewFiles == nil || session.DeletedFiles == nil {
+		t.Fatalf("file slices must be initialized: %+v", session)
+	}
+}
+
+func TestWriteSessionAtomicPrivateAndReadTranscriptOpaque(t *testing.T) {
+	agent := &Agent{}
+	dir := filepath.Join(t.TempDir(), "private")
+	path := filepath.Join(dir, "session.jsonl")
+	if err := agent.WriteSession(protocol.AgentSessionJSON{SessionRef: path, NativeData: []byte(`{"test":true}`)}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := agent.ReadTranscript(path)
+	if err != nil || string(data) != `{"test":true}` {
+		t.Fatalf("data = %q, err = %v", data, err)
+	}
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := dirInfo.Mode().Perm(); mode != 0o700 {
+		t.Fatalf("directory mode = %v", mode)
+	}
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := fileInfo.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("file mode = %v", mode)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.WriteSession(protocol.AgentSessionJSON{SessionRef: path, NativeData: []byte("replacement")}); err != nil {
+		t.Fatal(err)
+	}
+	if data, err = os.ReadFile(path); err != nil || string(data) != "replacement" {
+		t.Fatalf("replacement = %q, err = %v", data, err)
+	}
+	replacementInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := replacementInfo.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("replacement mode = %v", mode)
+	}
+}
+
+func TestChunkAndReassembleBoundaries(t *testing.T) {
+	agent := &Agent{}
+	if chunks, err := agent.ChunkTranscript(nil, 3); err != nil || len(chunks) != 0 {
+		t.Fatalf("empty chunks = %v, err = %v", chunks, err)
+	}
+	if _, err := agent.ChunkTranscript([]byte("x"), 0); err == nil {
+		t.Fatal("expected nonpositive max-size error")
+	}
+	chunks, err := agent.ChunkTranscript([]byte("abcdef"), 3)
+	if err != nil || len(chunks) != 2 || string(chunks[0]) != "abc" || string(chunks[1]) != "def" {
+		t.Fatalf("chunks = %q, err = %v", chunks, err)
+	}
+	data, err := agent.ReassembleTranscript(chunks)
+	if err != nil || string(data) != "abcdef" {
+		t.Fatalf("reassembled = %q, err = %v", data, err)
+	}
+}

--- a/agents/entire-agent-omp/internal/omp/transcript_test.go
+++ b/agents/entire-agent-omp/internal/omp/transcript_test.go
@@ -41,7 +41,7 @@ func writeOMPFixture(t *testing.T, data []byte) string {
 }
 
 func TestParseSessionTitleHeaderAndActiveLeaf(t *testing.T) {
-	session, err := parseSession(ompBranchFixture())
+	session, err := parseFullSession(ompBranchFixture())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestParseSessionWithoutTitleAndMalformedLaterLines(t *testing.T) {
 		"{broken\n" +
 		`{"type":"message","id":"assistant","parentId":"user","message":{"role":"assistant","content":[{"type":"text","text":"ok"}]}}` + "\n" +
 		"not json\n")
-	session, err := parseSession(data)
+	session, err := parseFullSession(data)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestParseSessionCycleGuard(t *testing.T) {
 	data := []byte(ompHeader() +
 		`{"type":"custom","id":"a","parentId":"b"}` + "\n" +
 		`{"type":"custom","id":"b","parentId":"a"}` + "\n")
-	session, err := parseSession(data)
+	session, err := parseFullSession(data)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,18 +89,60 @@ func TestParseSessionCycleGuard(t *testing.T) {
 }
 
 func TestParseSessionRejectsMalformedHeaderAndOversizedLine(t *testing.T) {
-	if _, err := parseSession([]byte(`{"type":"title"}` + "\n" + `{"type":"message"}` + "\n")); err == nil {
+	if _, err := parseFullSession([]byte(`{"type":"title"}` + "\n" + `{"type":"message"}` + "\n")); err == nil {
 		t.Fatal("expected malformed header error")
 	}
 	prefix := `{"type":"custom","id":"large","parentId":null,"value":"`
 	suffix := `"}`
 	atLimit := ompHeader() + prefix + strings.Repeat("x", maxSessionLine-len(prefix)-len(suffix)) + suffix + "\n"
-	if _, err := parseSession([]byte(atLimit)); err != nil {
+	if _, err := parseFullSession([]byte(atLimit)); err != nil {
 		t.Fatalf("line at limit rejected: %v", err)
 	}
 	oversized := append([]byte(ompHeader()), bytes.Repeat([]byte("x"), maxSessionLine+1)...)
-	if _, err := parseSession(oversized); err == nil {
+	if _, err := parseFullSession(oversized); err == nil {
 		t.Fatal("expected scanner size error")
+	}
+}
+
+func TestParseSessionSliceWithoutHeader(t *testing.T) {
+	parts := strings.SplitN(string(ompBranchFixture()), "\n", 3)
+	if len(parts) < 3 {
+		t.Fatal("fixture missing session entries")
+	}
+
+	session, err := parseSessionSlice([]byte(parts[2]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.Header != (sessionHeader{}) {
+		t.Fatalf("header = %+v, want empty", session.Header)
+	}
+	if session.Lines != 5 {
+		t.Fatalf("lines = %d, want 5", session.Lines)
+	}
+	var ids []string
+	for _, entry := range session.Active {
+		ids = append(ids, entry.Entry.ID)
+	}
+	if want := []string{"model", "user", "assistant", "tail"}; !reflect.DeepEqual(ids, want) {
+		t.Fatalf("active IDs = %v, want %v", ids, want)
+	}
+}
+
+func TestParseSessionSliceRejectsMalformedHeader(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"invalid session", `{"type":"session","version":0,"id":"session-header"}` + "\n"},
+		{"title without session", `{"type":"title"}` + "\n" + `{"type":"message","id":"user"}` + "\n"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := parseSessionSlice([]byte(test.data)); err == nil {
+				t.Fatal("expected malformed header error")
+			}
+		})
 	}
 }
 

--- a/agents/entire-agent-omp/internal/protocol/handlers_test.go
+++ b/agents/entire-agent-omp/internal/protocol/handlers_test.go
@@ -1,0 +1,185 @@
+package protocol
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type testResolver struct {
+	dir, file string
+	err       error
+}
+
+func (r testResolver) GetSessionDir(string) (string, error)     { return r.dir, r.err }
+func (r testResolver) ResolveSessionFile(string, string) string { return r.file }
+
+type testProvider struct{}
+
+func (testProvider) GetSessionID(input *HookInputJSON) string { return input.SessionID }
+
+type testReader struct {
+	session AgentSessionJSON
+	err     error
+}
+
+func (r testReader) ReadSession(*HookInputJSON) (AgentSessionJSON, error) { return r.session, r.err }
+
+type testWriter struct{ got AgentSessionJSON }
+
+func (w *testWriter) WriteSession(session AgentSessionJSON) error { w.got = session; return nil }
+
+type testResume struct{}
+
+func (testResume) FormatResumeCommand(id string) string { return "resume " + id }
+
+type testTranscript struct{}
+
+func (testTranscript) ReadTranscript(string) ([]byte, error) { return []byte("transcript"), nil }
+func (testTranscript) ChunkTranscript(data []byte, _ int) ([][]byte, error) {
+	return [][]byte{data}, nil
+}
+func (testTranscript) ReassembleTranscript(chunks [][]byte) ([]byte, error) {
+	return bytes.Join(chunks, nil), nil
+}
+func (testTranscript) CompactTranscript(string) (CompactTranscriptResponse, error) {
+	return CompactTranscriptResponse{Transcript: "encoded"}, nil
+}
+
+type testHooks struct{ event *EventJSON }
+
+func (h testHooks) ParseHook(string, []byte) (*EventJSON, error) { return h.event, nil }
+func (testHooks) InstallHooks(bool, bool) (int, error)           { return 4, nil }
+func (testHooks) UninstallHooks() error                          { return nil }
+func (testHooks) AreHooksInstalled() bool                        { return true }
+
+type testAnalyzer struct{}
+
+func (testAnalyzer) GetTranscriptPosition(string) (int, error) { return 7, nil }
+func (testAnalyzer) ExtractModifiedFiles(string, int) ([]string, int, error) {
+	return []string{"a.go"}, 9, nil
+}
+func (testAnalyzer) ExtractPrompts(string, int) ([]string, error) { return []string{"hello"}, nil }
+func (testAnalyzer) ExtractSummary(string) (string, bool, error)  { return "summary", true, nil }
+
+func TestCoreProtocolHandlers(t *testing.T) {
+	var out bytes.Buffer
+	if err := HandleGetSessionID(strings.NewReader(`{"session_id":"id-1"}`), &out, testProvider{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); got != `{"session_id":"id-1"}`+"\n" {
+		t.Fatalf("get-session-id output = %q", got)
+	}
+
+	out.Reset()
+	if err := HandleGetSessionDir([]string{"--repo-path", "/repo"}, &out, testResolver{dir: "/sessions/-repo"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); got != `{"session_dir":"/sessions/-repo"}`+"\n" {
+		t.Fatalf("get-session-dir output = %q", got)
+	}
+
+	out.Reset()
+	if err := HandleResolveSessionFile([]string{"--session-dir", "/sessions/-repo", "--session-id", "id-1"}, &out, testResolver{file: "/sessions/-repo/file.jsonl"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); got != `{"session_file":"/sessions/-repo/file.jsonl"}`+"\n" {
+		t.Fatalf("resolve-session-file output = %q", got)
+	}
+
+	out.Reset()
+	if err := HandleReadSession(strings.NewReader(`{}`), &out, testReader{session: AgentSessionJSON{SessionID: "id-1", AgentName: "omp"}}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"session_id":"id-1"`) {
+		t.Fatalf("read-session output = %q", out.String())
+	}
+
+	writer := &testWriter{}
+	if err := HandleWriteSession(strings.NewReader(`{"session_id":"id-2","native_data":"YWJj"}`), writer); err != nil {
+		t.Fatal(err)
+	}
+	if writer.got.SessionID != "id-2" || string(writer.got.NativeData) != "abc" {
+		t.Fatalf("write-session input = %#v", writer.got)
+	}
+
+	out.Reset()
+	if err := HandleFormatResumeCommand([]string{"--session-id", "id-1"}, &out, testResume{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); got != `{"command":"resume id-1"}`+"\n" {
+		t.Fatalf("format-resume output = %q", got)
+	}
+}
+
+func TestTranscriptAndAnalyzerHandlers(t *testing.T) {
+	impl := testTranscript{}
+	var out bytes.Buffer
+	if err := HandleReadTranscript([]string{"--session-ref", "file"}, &out, impl); err != nil || out.String() != "transcript" {
+		t.Fatalf("read transcript: %q, %v", out.String(), err)
+	}
+	out.Reset()
+	if err := HandleChunkTranscript([]string{"--max-size", "10"}, strings.NewReader("abc"), &out, impl); err != nil || out.String() != `{"chunks":["YWJj"]}`+"\n" {
+		t.Fatalf("chunk: %q, %v", out.String(), err)
+	}
+	out.Reset()
+	if err := HandleReassembleTranscript(strings.NewReader(`{"chunks":["YQ==","Yg=="]}`), &out, impl); err != nil || out.String() != "ab" {
+		t.Fatalf("reassemble: %q, %v", out.String(), err)
+	}
+	out.Reset()
+	if err := HandleCompactTranscript([]string{"--session-ref", "file"}, &out, impl); err != nil || out.String() != `{"transcript":"encoded"}`+"\n" {
+		t.Fatalf("compact: %q, %v", out.String(), err)
+	}
+
+	analyzer := testAnalyzer{}
+	out.Reset()
+	if err := HandleGetTranscriptPosition([]string{"--path", "file"}, &out, analyzer); err != nil || out.String() != `{"position":7}`+"\n" {
+		t.Fatalf("position: %q, %v", out.String(), err)
+	}
+	out.Reset()
+	if err := HandleExtractModifiedFiles([]string{"--path", "file", "--offset", "2"}, &out, analyzer); err != nil || out.String() != `{"files":["a.go"],"current_position":9}`+"\n" {
+		t.Fatalf("files: %q, %v", out.String(), err)
+	}
+	out.Reset()
+	if err := HandleExtractPrompts([]string{"--session-ref", "file", "--offset", "2"}, &out, analyzer); err != nil || out.String() != `{"prompts":["hello"]}`+"\n" {
+		t.Fatalf("prompts: %q, %v", out.String(), err)
+	}
+	out.Reset()
+	if err := HandleExtractSummary([]string{"--session-ref", "file"}, &out, analyzer); err != nil || out.String() != `{"summary":"summary","has_summary":true}`+"\n" {
+		t.Fatalf("summary: %q, %v", out.String(), err)
+	}
+}
+
+func TestHookHandlersAndErrors(t *testing.T) {
+	var out bytes.Buffer
+	if err := HandleParseHook([]string{"--hook", "agent_end"}, strings.NewReader(`{}`), &out, testHooks{}); err != nil || out.String() != "null\n" {
+		t.Fatalf("nil hook: %q, %v", out.String(), err)
+	}
+	out.Reset()
+	if err := HandleParseHook([]string{"--hook", "session_start"}, strings.NewReader(`{}`), &out, testHooks{event: &EventJSON{Type: 1, SessionID: "id"}}); err != nil || !strings.Contains(out.String(), `"type":1`) {
+		t.Fatalf("hook: %q, %v", out.String(), err)
+	}
+	out.Reset()
+	if err := HandleInstallHooks([]string{"--force"}, &out, testHooks{}); err != nil || out.String() != `{"hooks_installed":4}`+"\n" {
+		t.Fatalf("install: %q, %v", out.String(), err)
+	}
+
+	wantErr := errors.New("resolver failed")
+	if err := HandleGetSessionDir(nil, &out, testResolver{err: wantErr}); !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+	if err := HandleGetSessionDir([]string{"--unknown"}, &out, testResolver{}); err == nil {
+		t.Fatal("unknown flag accepted")
+	}
+}
+
+func TestWriteJSONDoesNotEscapeHTML(t *testing.T) {
+	var out bytes.Buffer
+	if err := WriteJSON(&out, map[string]string{"value": "<omp>&"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); got != `{"value":"<omp>&"}`+"\n" {
+		t.Fatalf("WriteJSON() = %q", got)
+	}
+}

--- a/agents/entire-agent-omp/internal/protocol/info_test.go
+++ b/agents/entire-agent-omp/internal/protocol/info_test.go
@@ -1,0 +1,66 @@
+package protocol_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/entireio/external-agents/agents/entire-agent-omp/internal/omp"
+	"github.com/entireio/external-agents/agents/entire-agent-omp/internal/protocol"
+)
+
+func TestInfoResponseShape(t *testing.T) {
+	info := omp.New().Info()
+	if info.ProtocolVersion != protocol.ProtocolVersion {
+		t.Fatalf("protocol_version = %d", info.ProtocolVersion)
+	}
+	if info.Name != "omp" {
+		t.Fatalf("name = %q, want omp", info.Name)
+	}
+	if info.Type != "Oh My Pi" {
+		t.Fatalf("type = %q, want Oh My Pi", info.Type)
+	}
+	if info.Description == "" {
+		t.Fatal("description is empty")
+	}
+	if !info.IsPreview {
+		t.Fatal("is_preview = false")
+	}
+	if !reflect.DeepEqual(info.ProtectedDirs, []string{".omp"}) {
+		t.Fatalf("protected_dirs = %#v", info.ProtectedDirs)
+	}
+	if !reflect.DeepEqual(info.ProtectedFiles, []string{".omp/extensions/entire/index.ts"}) {
+		t.Fatalf("protected_files = %#v", info.ProtectedFiles)
+	}
+	wantHooks := []string{"session_start", "agent_start", "agent_end", "session_shutdown"}
+	if !reflect.DeepEqual(info.HookNames, wantHooks) {
+		t.Fatalf("hook_names = %#v, want %#v", info.HookNames, wantHooks)
+	}
+
+	if !info.Capabilities.Hooks {
+		t.Fatal("hooks = false")
+	}
+	if !info.Capabilities.TranscriptAnalyzer {
+		t.Fatal("transcript_analyzer = false")
+	}
+	if !info.Capabilities.CompactTranscript {
+		t.Fatal("compact_transcript = false")
+	}
+	if !info.Capabilities.UsesTerminal {
+		t.Fatal("uses_terminal = false")
+	}
+	if info.Capabilities.TranscriptPreparer {
+		t.Fatal("transcript_preparer = true")
+	}
+	if info.Capabilities.TokenCalculator {
+		t.Fatal("token_calculator = true")
+	}
+	if info.Capabilities.TextGenerator {
+		t.Fatal("text_generator = true")
+	}
+	if info.Capabilities.HookResponseWriter {
+		t.Fatal("hook_response_writer = true")
+	}
+	if info.Capabilities.SubagentAwareExtractor {
+		t.Fatal("subagent_aware_extractor = true")
+	}
+}

--- a/agents/entire-agent-omp/internal/protocol/protocol.go
+++ b/agents/entire-agent-omp/internal/protocol/protocol.go
@@ -1,0 +1,305 @@
+package protocol
+
+import (
+	"encoding/json"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type sessionDirResolver interface {
+	GetSessionDir(repoPath string) (string, error)
+}
+type sessionFileResolver interface {
+	ResolveSessionFile(sessionDir, sessionID string) string
+}
+type sessionIDProvider interface{ GetSessionID(*HookInputJSON) string }
+type sessionReader interface {
+	ReadSession(*HookInputJSON) (AgentSessionJSON, error)
+}
+type sessionWriter interface{ WriteSession(AgentSessionJSON) error }
+type transcriptReader interface {
+	ReadTranscript(sessionRef string) ([]byte, error)
+}
+type transcriptChunker interface {
+	ChunkTranscript(content []byte, maxSize int) ([][]byte, error)
+	ReassembleTranscript(chunks [][]byte) ([]byte, error)
+}
+type transcriptCompactor interface {
+	CompactTranscript(sessionRef string) (CompactTranscriptResponse, error)
+}
+type resumeFormatter interface{ FormatResumeCommand(sessionID string) string }
+type hookParser interface {
+	ParseHook(hookName string, input []byte) (*EventJSON, error)
+	InstallHooks(localDev bool, force bool) (int, error)
+	UninstallHooks() error
+	AreHooksInstalled() bool
+}
+type transcriptAnalyzer interface {
+	GetTranscriptPosition(path string) (int, error)
+	ExtractModifiedFiles(path string, offset int) ([]string, int, error)
+	ExtractPrompts(sessionRef string, offset int) ([]string, error)
+	ExtractSummary(sessionRef string) (string, bool, error)
+}
+
+func WriteJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(v)
+}
+
+func ReadJSON[T any](r io.Reader) (*T, error) {
+	var value T
+	if err := json.NewDecoder(r).Decode(&value); err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
+func RepoRoot() string {
+	if root := os.Getenv("ENTIRE_REPO_ROOT"); root != "" {
+		return root
+	}
+	root, _ := os.Getwd()
+	return root
+}
+
+func HandleGetSessionID(stdin io.Reader, stdout io.Writer, provider sessionIDProvider) error {
+	input, err := ReadJSON[HookInputJSON](stdin)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionIDResponse{SessionID: provider.GetSessionID(input)})
+}
+
+func HandleGetSessionDir(args []string, stdout io.Writer, resolver sessionDirResolver) error {
+	fs := flag.NewFlagSet("get-session-dir", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	repoPath := fs.String("repo-path", "", "repo path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	sessionDir, err := resolver.GetSessionDir(*repoPath)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionDirResponse{SessionDir: sessionDir})
+}
+
+func HandleResolveSessionFile(args []string, stdout io.Writer, resolver sessionFileResolver) error {
+	fs := flag.NewFlagSet("resolve-session-file", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionDir := fs.String("session-dir", "", "session dir")
+	sessionID := fs.String("session-id", "", "session id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionFileResponse{SessionFile: resolver.ResolveSessionFile(*sessionDir, *sessionID)})
+}
+
+func HandleReadSession(stdin io.Reader, stdout io.Writer, reader sessionReader) error {
+	input, err := ReadJSON[HookInputJSON](stdin)
+	if err != nil {
+		return err
+	}
+	session, err := reader.ReadSession(input)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, session)
+}
+
+func HandleWriteSession(stdin io.Reader, writer sessionWriter) error {
+	session, err := ReadJSON[AgentSessionJSON](stdin)
+	if err != nil {
+		return err
+	}
+	return writer.WriteSession(*session)
+}
+
+func HandleReadTranscript(args []string, stdout io.Writer, reader transcriptReader) error {
+	fs := flag.NewFlagSet("read-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	data, err := reader.ReadTranscript(*sessionRef)
+	if err != nil {
+		return err
+	}
+	_, err = stdout.Write(data)
+	return err
+}
+
+func HandleChunkTranscript(args []string, stdin io.Reader, stdout io.Writer, chunker transcriptChunker) error {
+	fs := flag.NewFlagSet("chunk-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	maxSize := fs.Int("max-size", 0, "max size")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	content, err := io.ReadAll(stdin)
+	if err != nil {
+		return err
+	}
+	chunks, err := chunker.ChunkTranscript(content, *maxSize)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ChunkResponse{Chunks: chunks})
+}
+
+func HandleReassembleTranscript(stdin io.Reader, stdout io.Writer, chunker transcriptChunker) error {
+	input, err := ReadJSON[ChunkResponse](stdin)
+	if err != nil {
+		return err
+	}
+	data, err := chunker.ReassembleTranscript(input.Chunks)
+	if err != nil {
+		return err
+	}
+	_, err = stdout.Write(data)
+	return err
+}
+
+func HandleCompactTranscript(args []string, stdout io.Writer, compactor transcriptCompactor) error {
+	fs := flag.NewFlagSet("compact-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	compacted, err := compactor.CompactTranscript(*sessionRef)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, compacted)
+}
+
+func HandleFormatResumeCommand(args []string, stdout io.Writer, formatter resumeFormatter) error {
+	fs := flag.NewFlagSet("format-resume-command", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionID := fs.String("session-id", "", "session id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ResumeCommandResponse{Command: formatter.FormatResumeCommand(*sessionID)})
+}
+
+func readStdinWithTimeout(r io.Reader, timeout time.Duration) ([]byte, error) {
+	type result struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() { data, err := io.ReadAll(r); ch <- result{data, err} }()
+	select {
+	case res := <-ch:
+		return res.data, res.err
+	case <-time.After(timeout):
+		return nil, nil
+	}
+}
+
+func HandleParseHook(args []string, stdin io.Reader, stdout io.Writer, parser hookParser) error {
+	fs := flag.NewFlagSet("parse-hook", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	hook := fs.String("hook", "", "hook name")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	input, err := readStdinWithTimeout(stdin, 100*time.Millisecond)
+	if err != nil {
+		return err
+	}
+	event, err := parser.ParseHook(*hook, input)
+	if err != nil {
+		return err
+	}
+	if event == nil {
+		_, err = io.WriteString(stdout, "null\n")
+		return err
+	}
+	return WriteJSON(stdout, event)
+}
+
+func HandleInstallHooks(args []string, stdout io.Writer, parser hookParser) error {
+	fs := flag.NewFlagSet("install-hooks", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	localDev := fs.Bool("local-dev", false, "local dev")
+	force := fs.Bool("force", false, "force")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	count, err := parser.InstallHooks(*localDev, *force)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, HooksInstalledCountResponse{HooksInstalled: count})
+}
+
+func HandleGetTranscriptPosition(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("get-transcript-position", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	path := fs.String("path", "", "path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	position, err := analyzer.GetTranscriptPosition(*path)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, TranscriptPositionResponse{Position: position})
+}
+
+func HandleExtractModifiedFiles(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-modified-files", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	path := fs.String("path", "", "path")
+	offset := fs.Int("offset", 0, "offset")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	files, currentPosition, err := analyzer.ExtractModifiedFiles(*path, *offset)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractFilesResponse{Files: files, CurrentPosition: currentPosition})
+}
+
+func HandleExtractPrompts(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-prompts", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	offset := fs.Int("offset", 0, "offset")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	prompts, err := analyzer.ExtractPrompts(*sessionRef, *offset)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractPromptsResponse{Prompts: prompts})
+}
+
+func HandleExtractSummary(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-summary", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	summary, hasSummary, err := analyzer.ExtractSummary(*sessionRef)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractSummaryResponse{Summary: summary, HasSummary: hasSummary})
+}
+
+func DefaultSessionDir(repoPath string) string { return filepath.Join(repoPath, ".entire", "tmp") }
+func ResolveSessionFile(sessionDir, sessionID string) string {
+	return filepath.Join(sessionDir, sessionID+".json")
+}

--- a/agents/entire-agent-omp/internal/protocol/types.go
+++ b/agents/entire-agent-omp/internal/protocol/types.go
@@ -1,0 +1,123 @@
+package protocol
+
+import "encoding/json"
+
+const ProtocolVersion = 1
+
+type DeclaredCapabilities struct {
+	Hooks                  bool `json:"hooks"`
+	TranscriptAnalyzer     bool `json:"transcript_analyzer"`
+	TranscriptPreparer     bool `json:"transcript_preparer"`
+	TokenCalculator        bool `json:"token_calculator"`
+	CompactTranscript      bool `json:"compact_transcript"`
+	TextGenerator          bool `json:"text_generator"`
+	HookResponseWriter     bool `json:"hook_response_writer"`
+	SubagentAwareExtractor bool `json:"subagent_aware_extractor"`
+	UsesTerminal           bool `json:"uses_terminal"`
+}
+
+type InfoResponse struct {
+	ProtocolVersion int                  `json:"protocol_version"`
+	Name            string               `json:"name"`
+	Type            string               `json:"type"`
+	Description     string               `json:"description"`
+	IsPreview       bool                 `json:"is_preview"`
+	ProtectedDirs   []string             `json:"protected_dirs"`
+	ProtectedFiles  []string             `json:"protected_files,omitempty"`
+	HookNames       []string             `json:"hook_names"`
+	Capabilities    DeclaredCapabilities `json:"capabilities"`
+}
+
+type DetectResponse struct {
+	Present bool `json:"present"`
+}
+type SessionIDResponse struct {
+	SessionID string `json:"session_id"`
+}
+type SessionDirResponse struct {
+	SessionDir string `json:"session_dir"`
+}
+type SessionFileResponse struct {
+	SessionFile string `json:"session_file"`
+}
+type ChunkResponse struct {
+	Chunks [][]byte `json:"chunks"`
+}
+type ResumeCommandResponse struct {
+	Command string `json:"command"`
+}
+type HooksInstalledCountResponse struct {
+	HooksInstalled int `json:"hooks_installed"`
+}
+type AreHooksInstalledResponse struct {
+	Installed bool `json:"installed"`
+}
+type TranscriptPositionResponse struct {
+	Position int `json:"position"`
+}
+
+type ExtractFilesResponse struct {
+	Files           []string `json:"files"`
+	CurrentPosition int      `json:"current_position"`
+}
+
+type ExtractPromptsResponse struct {
+	Prompts []string `json:"prompts"`
+}
+
+type ExtractSummaryResponse struct {
+	Summary    string `json:"summary"`
+	HasSummary bool   `json:"has_summary"`
+}
+
+type CompactTranscriptResponse struct {
+	Transcript string                       `json:"transcript"`
+	Assets     []CompactTranscriptAssetJSON `json:"assets,omitempty"`
+}
+
+type CompactTranscriptAssetJSON struct {
+	Name      string `json:"name"`
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
+}
+
+type AgentSessionJSON struct {
+	SessionID     string   `json:"session_id"`
+	AgentName     string   `json:"agent_name"`
+	RepoPath      string   `json:"repo_path"`
+	SessionRef    string   `json:"session_ref"`
+	StartTime     string   `json:"start_time"`
+	NativeData    []byte   `json:"native_data"`
+	ModifiedFiles []string `json:"modified_files"`
+	NewFiles      []string `json:"new_files"`
+	DeletedFiles  []string `json:"deleted_files"`
+}
+
+type HookInputJSON struct {
+	HookType   string                 `json:"hook_type"`
+	SessionID  string                 `json:"session_id"`
+	SessionRef string                 `json:"session_ref"`
+	Timestamp  string                 `json:"timestamp"`
+	UserPrompt string                 `json:"user_prompt,omitempty"`
+	ToolName   string                 `json:"tool_name,omitempty"`
+	ToolUseID  string                 `json:"tool_use_id,omitempty"`
+	ToolInput  json.RawMessage        `json:"tool_input,omitempty"`
+	RawData    map[string]interface{} `json:"raw_data,omitempty"`
+}
+
+type EventJSON struct {
+	Type              int               `json:"type"`
+	SessionID         string            `json:"session_id"`
+	PreviousSessionID string            `json:"previous_session_id,omitempty"`
+	SessionRef        string            `json:"session_ref,omitempty"`
+	Prompt            string            `json:"prompt,omitempty"`
+	Model             string            `json:"model,omitempty"`
+	Timestamp         string            `json:"timestamp,omitempty"`
+	ToolUseID         string            `json:"tool_use_id,omitempty"`
+	SubagentID        string            `json:"subagent_id,omitempty"`
+	ToolInput         json.RawMessage   `json:"tool_input,omitempty"`
+	SubagentType      string            `json:"subagent_type,omitempty"`
+	TaskDescription   string            `json:"task_description,omitempty"`
+	ResponseMessage   string            `json:"response_message,omitempty"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+}

--- a/agents/entire-agent-omp/mise.toml
+++ b/agents/entire-agent-omp/mise.toml
@@ -1,0 +1,11 @@
+[tasks.build]
+description = "Build the binary"
+run = "GOCACHE=/tmp/go-build-cache go build -o entire-agent-omp ./cmd/entire-agent-omp"
+
+[tasks.test]
+description = "Run unit tests"
+run = "GOCACHE=/tmp/go-build-cache go test ./..."
+
+[tasks.clean]
+description = "Remove built binary"
+run = "rm -f entire-agent-omp"

--- a/e2e/agents/omp.go
+++ b/e2e/agents/omp.go
@@ -1,0 +1,134 @@
+package agents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	ompTimeoutMultiplier = 2.0
+	ompBusyPattern       = `(?m)^[\t ]*(?:[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏] [^\r\n]*(?:⟦esc⟧|⟨esc⟩)|[-\\|/] [^\r\n]*\[esc\])[\t ]*$`
+)
+
+func init() {
+	if env := os.Getenv("E2E_AGENT"); env != "" && env != "omp" {
+		return
+	}
+	Register(&OMP{})
+	RegisterGate("omp", 1)
+}
+
+type OMP struct{}
+
+type ompSession struct {
+	*TmuxSession
+}
+
+func (s *ompSession) WaitFor(pattern string, timeout time.Duration) (string, error) {
+	return s.TmuxSession.WaitFor(pattern, time.Duration(float64(timeout)*ompTimeoutMultiplier))
+}
+
+func (o *OMP) Name() string               { return "omp" }
+func (o *OMP) Binary() string             { return "omp" }
+func (o *OMP) EntireAgent() string        { return "omp" }
+func (o *OMP) PromptPattern() string      { return `╭──` }
+func (o *OMP) TimeoutMultiplier() float64 { return ompTimeoutMultiplier }
+func (o *OMP) IsExternalAgent() bool      { return true }
+
+func (o *OMP) IsTransientError(out Output, _ error) bool {
+	combined := strings.ToLower(out.Stdout + out.Stderr)
+	patterns := []string{
+		"overloaded",
+		"rate limit",
+		"429",
+		"503",
+		"econnreset",
+		"etimedout",
+		"timeout",
+	}
+	for _, pattern := range patterns {
+		if strings.Contains(combined, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func (o *OMP) Bootstrap() error {
+	return nil
+}
+
+func (o *OMP) RunPrompt(ctx context.Context, dir string, prompt string, _ ...Option) (Output, error) {
+	bin, err := exec.LookPath(o.Binary())
+	if err != nil {
+		return Output{}, fmt.Errorf("%s not in PATH: %w", o.Binary(), err)
+	}
+
+	args := []string{"-p", prompt, "--approval-mode=yolo", "--no-skills", "--no-rules", "--thinking=off", "--tools=write"}
+	displayArgs := []string{"-p", fmt.Sprintf("%q", prompt), "--approval-mode=yolo", "--no-skills", "--no-rules", "--thinking=off", "--tools=write"}
+
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Dir = dir
+	cmd.Env = filterEnv(os.Environ(), "ENTIRE_TEST_TTY")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	cmd.WaitDelay = 5 * time.Second
+
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+	exitCode := 0
+	if err != nil {
+		exitErr := &exec.ExitError{}
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = -1
+		}
+	}
+
+	return Output{
+		Command:  o.Binary() + " " + strings.Join(displayArgs, " "),
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+		ExitCode: exitCode,
+	}, err
+}
+
+func (o *OMP) StartSession(_ context.Context, dir string) (Session, error) {
+	name := fmt.Sprintf("omp-test-%d", time.Now().UnixNano())
+	s, err := NewTmuxSession(
+		name,
+		dir,
+		[]string{"ENTIRE_TEST_TTY"},
+		o.Binary(),
+		"--approval-mode=yolo",
+		"--no-skills",
+		"--no-rules",
+		"--thinking=off",
+		"--tools=write",
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.SetBusyPattern(ompBusyPattern); err != nil {
+		_ = s.Close()
+		return nil, fmt.Errorf("compile omp busy pattern: %w", err)
+	}
+	if _, err := s.WaitFor(o.PromptPattern(), 30*time.Second); err != nil {
+		_ = s.Close()
+		return nil, fmt.Errorf("waiting for initial prompt: %w", err)
+	}
+	s.stableAtSend = ""
+	return &ompSession{TmuxSession: s}, nil
+}

--- a/e2e/agents/omp_test.go
+++ b/e2e/agents/omp_test.go
@@ -1,0 +1,59 @@
+package agents
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestOMPBusyPattern(t *testing.T) {
+	t.Parallel()
+
+	re := regexp.MustCompile(ompBusyPattern)
+	presets := []struct {
+		name   string
+		frames []string
+		hint   string
+	}{
+		{"unicode", []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}, "⟦esc⟧"},
+		{"nerd", []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}, "⟨esc⟩"},
+		{"ascii", []string{"-", `\`, "|", "/"}, "[esc]"},
+	}
+	for _, preset := range presets {
+		for _, frame := range preset.frames {
+			t.Run(preset.name+"/"+frame, func(t *testing.T) {
+				t.Parallel()
+
+				line := "\t" + frame + " Working… " + preset.hint + "  "
+				if !re.MatchString(line) {
+					t.Fatalf("MatchString(%q) = false, want true", line)
+				}
+			})
+		}
+	}
+
+	tests := []struct {
+		name string
+		line string
+		busy bool
+	}{
+		{"unicode hint in body", "The user typed ⟦esc⟧", false},
+		{"nerd hint in body", "The assistant typed ⟨esc⟩", false},
+		{"ascii hint in body", "The user typed [esc]", false},
+		{"bare unicode hint", "⟦esc⟧", false},
+		{"bare nerd hint", "⟨esc⟩", false},
+		{"bare ascii hint", "[esc]", false},
+		{"prompt", "╭── [esc]", false},
+		{"spinner without hint", "⠋ Working…", false},
+		{"text after hint", "⠋ Working… ⟦esc⟧ still ordinary text", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := re.MatchString(tt.line); got != tt.busy {
+				t.Fatalf("MatchString(%q) = %t, want %t", tt.line, got, tt.busy)
+			}
+		})
+	}
+}

--- a/e2e/agents/tmux.go
+++ b/e2e/agents/tmux.go
@@ -12,13 +12,25 @@ import (
 // TmuxSession implements Session using tmux for PTY-based interactive agents.
 type TmuxSession struct {
 	name         string
-	stableAtSend string   // stable content snapshot when Send was last called
+	socket       string
+	stableAtSend string // stable content snapshot when Send was last called
+	busyPattern  *regexp.Regexp
 	cleanups     []func() // run on Close
 }
 
 // OnClose registers a function to run when the session is closed.
 func (s *TmuxSession) OnClose(fn func()) {
 	s.cleanups = append(s.cleanups, fn)
+}
+
+// SetBusyPattern prevents WaitFor from treating a matching pane as settled.
+func (s *TmuxSession) SetBusyPattern(pattern string) error {
+	compiled, err := regexp.Compile(pattern)
+	if err != nil {
+		return err
+	}
+	s.busyPattern = compiled
+	return nil
 }
 
 // NewTmuxSession creates a new tmux session running the given command in dir.
@@ -28,7 +40,7 @@ func (s *TmuxSession) OnClose(fn func()) {
 // tmux sessions inherit the tmux server's environment (not the client's), so
 // without this, binaries added to PATH by the test runner would not be found.
 func NewTmuxSession(name string, dir string, unsetEnv []string, command string, args ...string) (*TmuxSession, error) {
-	s := &TmuxSession{name: name}
+	s := &TmuxSession{name: name, socket: name}
 
 	tmuxArgs := []string{"new-session", "-d", "-s", name, "-c", dir}
 	var parts []string
@@ -44,12 +56,12 @@ func NewTmuxSession(name string, dir string, unsetEnv []string, command string, 
 	}
 	tmuxArgs = append(tmuxArgs, strings.Join(parts, " "))
 
-	cmd := exec.Command("tmux", tmuxArgs...)
+	cmd := s.command(tmuxArgs...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return nil, fmt.Errorf("tmux new-session: %w\n%s", err, out)
 	}
 	// Keep the pane around after the command exits so we can capture error output.
-	setCmd := exec.Command("tmux", "set-option", "-t", name, "remain-on-exit", "on")
+	setCmd := s.command("set-option", "-t", name, "remain-on-exit", "on")
 	_ = setCmd.Run()
 	return s, nil
 }
@@ -80,10 +92,25 @@ func (s *TmuxSession) Send(input string) error {
 	return nil
 }
 
+// SendAndWait sends input and waits for the resulting settled screen. Unlike
+// Send followed by WaitFor, it keeps the pre-send screen as the change baseline
+// so commands that finish during the input echo delay can still be observed.
+func (s *TmuxSession) SendAndWait(input, pattern string, timeout time.Duration) (string, error) {
+	s.stableAtSend = stableContent(s.Capture())
+	if err := s.SendKeys(input); err != nil {
+		return "", err
+	}
+	time.Sleep(200 * time.Millisecond)
+	if err := s.SendKeys("Enter"); err != nil {
+		return "", err
+	}
+	return s.WaitFor(pattern, timeout)
+}
+
 // SendKeys sends raw tmux key names without appending Enter.
 func (s *TmuxSession) SendKeys(keys ...string) error {
 	args := append([]string{"send-keys", "-t", s.name}, keys...)
-	cmd := exec.Command("tmux", args...)
+	cmd := s.command(args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("tmux send-keys: %w\n%s", err, out)
@@ -122,7 +149,7 @@ func (s *TmuxSession) WaitFor(pattern string, timeout time.Duration) (string, er
 		stable := stableContent(content)
 
 		// Bail early if the process has exited and the pattern doesn't match.
-		if !re.MatchString(content) {
+		if !re.MatchString(content) || (s.busyPattern != nil && s.busyPattern.MatchString(content)) {
 			if s.IsPaneDead() {
 				return content, fmt.Errorf("process exited while waiting for %q\n--- pane content ---\n%s\n--- end pane content ---", pattern, content)
 			}
@@ -155,7 +182,7 @@ func (s *TmuxSession) WaitFor(pattern string, timeout time.Duration) (string, er
 
 // IsPaneDead returns true if the process inside the tmux pane has exited.
 func (s *TmuxSession) IsPaneDead() bool {
-	cmd := exec.Command("tmux", "display-message", "-t", s.name, "-p", "#{pane_dead}")
+	cmd := s.command("display-message", "-t", s.name, "-p", "#{pane_dead}")
 	out, err := cmd.Output()
 	if err != nil {
 		return true
@@ -164,7 +191,7 @@ func (s *TmuxSession) IsPaneDead() bool {
 }
 
 func (s *TmuxSession) Capture() string {
-	cmd := exec.Command("tmux", "capture-pane", "-t", s.name, "-p")
+	cmd := s.command("capture-pane", "-t", s.name, "-p")
 	out, _ := cmd.Output()
 	return strings.TrimRight(string(out), "\n")
 }
@@ -173,12 +200,16 @@ func (s *TmuxSession) Close() error {
 	for _, fn := range s.cleanups {
 		fn()
 	}
-	cmd := exec.Command("tmux", "kill-session", "-t", s.name)
+	cmd := s.command("kill-session", "-t", s.name)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("tmux kill-session: %w\n%s", err, out)
 	}
 	return nil
+}
+
+func (s *TmuxSession) command(args ...string) *exec.Cmd {
+	return exec.Command("tmux", append([]string{"-L", s.socket}, args...)...)
 }
 
 // shellQuote wraps s in single quotes with proper escaping for POSIX shells.

--- a/e2e/lifecycle_test.go
+++ b/e2e/lifecycle_test.go
@@ -191,7 +191,8 @@ func TestLifecycle_SessionPersistence(t *testing.T) {
 
 		hasSession := false
 		for _, entry := range entries {
-			if filepath.Ext(entry.Name()) != ".json" {
+			extension := filepath.Ext(entry.Name())
+			if extension != ".json" && extension != ".jsonl" {
 				continue
 			}
 			info, err := entry.Info()
@@ -203,7 +204,7 @@ func TestLifecycle_SessionPersistence(t *testing.T) {
 				break
 			}
 		}
-		assert.True(t, hasSession, "expected a fresh .json session file in %s", sessionDir)
+		assert.True(t, hasSession, "expected a fresh session file in %s", sessionDir)
 	})
 }
 

--- a/e2e/omp_session_switch_test.go
+++ b/e2e/omp_session_switch_test.go
@@ -1,0 +1,123 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/entireio/external-agents/e2e/entire"
+	"github.com/entireio/external-agents/e2e/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOMP_InProcessNewSessionLifecycle(t *testing.T) {
+	testutil.ForEachAgent(t, 4*time.Minute, func(t *testing.T, s *testutil.RepoState, ctx context.Context) {
+		if s.Agent.Name() != "omp" {
+			t.Skip("omp-specific lifecycle test")
+		}
+
+		session := s.StartSession(t, ctx)
+		require.NotNil(t, session, "omp must support interactive sessions")
+
+		const firstPrompt = "Create omp-first.txt containing exactly 'first session'. Do not ask for confirmation."
+		s.Send(t, session, firstPrompt)
+		s.WaitFor(t, session, s.Agent.PromptPattern(), 60*time.Second)
+		testutil.WaitForFileExists(t, s.Dir, "omp-first.txt", 10*time.Second)
+		testutil.WaitForSessionIdle(t, s.Dir, 10*time.Second)
+
+		firstEvents := ompLifecycleEvents(t, s.Dir)
+		require.Len(t, firstEvents, 3)
+		firstSessionID := firstEvents[0].SessionID
+		require.NotEmpty(t, firstSessionID)
+		require.Equal(t, []ompLifecycleEvent{
+			{Event: "SessionStart", SessionID: firstSessionID, SessionRef: firstEvents[0].SessionRef},
+			{Event: "TurnStart", SessionID: firstSessionID, SessionRef: firstEvents[1].SessionRef},
+			{Event: "TurnEnd", SessionID: firstSessionID, SessionRef: firstEvents[2].SessionRef},
+		}, firstEvents)
+		require.NotEmpty(t, firstEvents[0].SessionRef)
+
+		firstCheckpoint := ompCheckpointForSession(t, entire.RewindList(t, s.Dir), firstSessionID)
+
+		commandSession, ok := session.(interface {
+			SendAndWait(string, string, time.Duration) (string, error)
+		})
+		require.True(t, ok, "omp interactive session must expose SendAndWait")
+		pane, err := commandSession.SendAndWait("/new", s.Agent.PromptPattern(), 30*time.Second)
+		require.NoError(t, err, "wait for omp /new prompt\npane:\n%s", pane)
+
+		switchEvents := ompLifecycleEvents(t, s.Dir)
+		require.Len(t, switchEvents, 4, "/new must emit exactly one new SessionStart")
+		secondSessionID := switchEvents[3].SessionID
+		require.Equal(t, "SessionStart", switchEvents[3].Event)
+		require.NotEmpty(t, secondSessionID)
+		require.NotEqual(t, firstSessionID, secondSessionID)
+		require.NotEmpty(t, switchEvents[3].SessionRef)
+		require.NotEqual(t, firstEvents[0].SessionRef, switchEvents[3].SessionRef)
+
+		const secondPrompt = "Create omp-second.txt containing exactly 'second session'. Do not ask for confirmation."
+		s.Send(t, session, secondPrompt)
+		s.WaitFor(t, session, s.Agent.PromptPattern(), 60*time.Second)
+		testutil.WaitForFileExists(t, s.Dir, "omp-second.txt", 10*time.Second)
+		testutil.WaitForSessionIdle(t, s.Dir, 10*time.Second)
+
+		events := ompLifecycleEvents(t, s.Dir)
+		require.Len(t, events, 6)
+		require.Equal(t, []ompLifecycleEvent{
+			firstEvents[0],
+			firstEvents[1],
+			firstEvents[2],
+			switchEvents[3],
+			{Event: "TurnStart", SessionID: secondSessionID, SessionRef: events[4].SessionRef},
+			{Event: "TurnEnd", SessionID: secondSessionID, SessionRef: events[5].SessionRef},
+		}, events, "the old turn must end before /new starts the new lifecycle")
+
+		points := entire.RewindList(t, s.Dir)
+		require.Contains(t, points, firstCheckpoint, "the old session checkpoint must remain addressable")
+		secondCheckpoint := ompCheckpointForSession(t, points, secondSessionID)
+		require.NotEqual(t, firstCheckpoint.ID, secondCheckpoint.ID, "the new session needs an independent checkpoint")
+	})
+}
+
+type ompLifecycleEvent struct {
+	Event      string `json:"event"`
+	SessionID  string `json:"session_id"`
+	SessionRef string `json:"session_ref"`
+}
+
+func ompLifecycleEvents(t *testing.T, repoDir string) []ompLifecycleEvent {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(repoDir, ".entire", "logs", "entire.log"))
+	require.NoError(t, err)
+
+	var events []ompLifecycleEvent
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		var record struct {
+			ompLifecycleEvent
+			Component string `json:"component"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(line), &record), "invalid Entire JSON log line")
+		if record.Component == "lifecycle" && record.Event != "" {
+			events = append(events, record.ompLifecycleEvent)
+		}
+	}
+	return events
+}
+
+func ompCheckpointForSession(t *testing.T, points []entire.RewindPoint, sessionID string) entire.RewindPoint {
+	t.Helper()
+
+	for _, point := range points {
+		if point.SessionID == sessionID && !point.IsLogsOnly {
+			return point
+		}
+	}
+	t.Fatalf("no live checkpoint for omp session %s; rewind points: %+v", sessionID, points)
+	return entire.RewindPoint{}
+}


### PR DESCRIPTION
## Summary

Adds Oh My Pi support through a native Go external-agent binary, `entire-agent-omp`.

Closes entireio/cli#1857.

## What changed

- Adds `agents/entire-agent-omp` with hook, transcript analysis, and compact transcript support.
- Installs a project extension at `.omp/extensions/entire/index.ts` and maps initial loads, session switches and branches, and agent turns to Entire lifecycle events.
- Resolves `PI_CONFIG_DIR`, `PI_CODING_AGENT_DIR`, `OMP_PROFILE`, and active XDG session roots, then snapshots native JSONL transcripts for stable checkpoints.
- Reads the active parent chain and extracts prompts, assistant text, and paths from `write`, `edit`, and `apply_patch`.
- Adds lifecycle harness coverage, including an in-process `/new` transition, plus setup and compatibility documentation.

## Validation

- `go test -count=1 ./...` and `go build ./...` in `agents/entire-agent-omp`
- `golangci-lint run ./...` in `agents/entire-agent-omp` and `e2e` (0 issues)
- External-agent protocol compliance: hooks, mandatory, and transcript suites pass
- Real `omp` 17.1.1 / Entire 0.8.42 lifecycle E2E on Linux: all eight shared scenarios and the in-process `/new` scenario pass