### PR TITLE
feat(devin): add Devin CLI external agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ External agents communicate with Entire CLI via subcommands that accept and retu
 | [Qwen Code](agents/entire-agent-qwen/) | `agents/entire-agent-qwen/` | Implemented — hooks + transcript analysis + compact transcripts |
 | [Oh My Pi](agents/entire-agent-omp/) | `agents/entire-agent-omp/` | Implemented — hooks + transcript analysis + compact transcripts |
 | [Kilo](agents/entire-agent-kilo/) | `agents/entire-agent-kilo/` | Implemented (preview) — hooks + transcript analysis + token calculation + compact transcripts |
+| [Devin CLI](agents/entire-agent-devin/) | `agents/entire-agent-devin/` | Implemented — hooks + transcript analysis + token calculation |
 
 See each agent's own README for setup and usage instructions.
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ External agents communicate with Entire CLI via subcommands that accept and retu
 | [Kiro](agents/entire-agent-kiro/) | `agents/entire-agent-kiro/` | Implemented — hooks + transcript analysis |
 | [Amp](agents/entire-agent-amp/) | `agents/entire-agent-amp/` | Implemented — hooks + transcript analysis + token calculation + compact transcripts |
 | [Qwen Code](agents/entire-agent-qwen/) | `agents/entire-agent-qwen/` | Implemented — hooks + transcript analysis + compact transcripts |
-| [Oh My Pi](agents/entire-agent-omp/) | `agents/entire-agent-omp/` | Implemented — hooks + transcript analysis + compact transcripts |
-| [Kilo](agents/entire-agent-kilo/) | `agents/entire-agent-kilo/` | Implemented (preview) — hooks + transcript analysis + token calculation + compact transcripts |
-| [Devin CLI](agents/entire-agent-devin/) | `agents/entire-agent-devin/` | Implemented — hooks + transcript analysis + token calculation |
+| [Devin CLI](agents/entire-agent-devin/) | `agents/entire-agent-devin/` | Implemented — hooks + transcript analysis + token calculation + compact transcripts |
 
 See each agent's own README for setup and usage instructions.
 

--- a/agents/entire-agent-devin/.gitignore
+++ b/agents/entire-agent-devin/.gitignore
@@ -1,0 +1,1 @@
+entire-agent-devin

--- a/agents/entire-agent-devin/AGENT.md
+++ b/agents/entire-agent-devin/AGENT.md
@@ -1,0 +1,166 @@
+# Devin CLI External Agent
+
+Integration notes for Devin CLI ("Devin for Terminal", Cognition), implemented
+as an Entire external agent (`entire-agent-devin`). All facts below were
+verified live against `devin 3000.2.17` on macOS (2026-07-27) unless marked
+otherwise. This research was originally done for entireio/cli#1864 and ported
+here at the maintainers' request.
+
+## Protocol mapping
+
+| Devin hook (Claude Code format) | `entire hooks devin <verb>` | Event |
+|---|---|---|
+| `SessionStart` | `session-start` | SessionStart (1) |
+| `UserPromptSubmit` | `user-prompt-submit` | TurnStart (2) with prompt |
+| `Stop` | `stop` | TurnEnd (3) |
+| `SessionEnd` | `session-end` | SessionEnd (5) |
+
+Payloads carry no `transcript_path`, so `session_ref` is derived from the
+session ID: `<transcripts-dir>/<session_id>.json`.
+
+Capabilities: `hooks`, `transcript_analyzer`, `transcript_preparer`,
+`token_calculator`, `uses_terminal`. `PostToolUse` live file tracking (used by
+the in-tree prototype) is NOT ported: the external protocol's Event object
+does not carry `modified_files`, so per-tool ToolUse events cannot deliver
+their payload. File detection falls back to Entire's git-status detection at
+TurnEnd plus ATIF `tool_calls` extraction at condensation — both verified
+working end-to-end.
+
+## Hook surface
+
+Devin CLI supports Claude Code-format hooks loaded from `.devin/hooks.v1.json`
+(the hooks object is the entire file — no `{"hooks": ...}` wrapper), from
+`.devin/config[.local].json` under a `"hooks"` key, and from
+`.claude/settings[.local].json` (gated by `read_config_from.claude`,
+default on). Entire installs into `.devin/hooks.v1.json` only.
+
+Events (verified firing in print mode): `SessionStart`, `UserPromptSubmit`,
+`PostToolUse`, `Stop`, `SessionEnd`. Also documented: `PreToolUse`,
+`PermissionRequest`, `PostCompaction`. There is no `SubagentStop` and no
+`PreCompact`. The `matcher` field is a regex over `tool_name`.
+
+Verified payloads (note: **no `transcript_path`, no `cwd`** — unlike Claude Code):
+
+```json
+{"hook_event_name":"SessionStart","source":"startup","session_id":"snowy-efraasia"}
+{"hook_event_name":"UserPromptSubmit","prompt":"...","session_id":"snowy-efraasia","prompt_id":"<uuid>"}
+{"hook_event_name":"PostToolUse","tool_name":"write","tool_input":{"file_path":"/abs/path","content":"..."},"tool_use_id":"write_0","tool_response":{"success":true,"output":"...","error":null},"session_id":"...","prompt_id":"<uuid>"}
+{"hook_event_name":"Stop","stop_hook_active":false,"session_id":"...","prompt_id":"<uuid>"}
+{"hook_event_name":"SessionEnd","reason":"session_complete","session_id":"...","prompt_id":"<uuid>"}
+```
+
+- `session_id` is a word-pair (e.g. `snowy-efraasia`) — the same ID
+  `devin -r <id>` accepts and `devin list` shows.
+- `prompt_id` is a per-turn UUID, absent before the first prompt.
+- Hook processes get exactly one Devin-set env var: `DEVIN_PROJECT_DIR`
+  (project root).
+
+## Cross-fire hazard (verified live)
+
+Devin loads `.claude/settings.json` hooks by default, so in a repo where
+Entire is enabled for Claude Code, Devin sessions invoke
+`entire hooks claude-code <verb>` with Devin payloads (no transcript_path).
+The transcript-path ownership guard in the CLI fails open for these (no
+SessionRef), so a claude-code session-start can claim the Devin session. A
+reliable CLI-side guard exists: a claude-code hook invocation with
+`DEVIN_PROJECT_DIR` set and `CLAUDE_PROJECT_DIR` unset is Devin-origin.
+This needs a small entireio/cli change (it cannot live in an external
+agent); until then, avoid enabling claude-code and running Devin in the
+same repo, or set `read_config_from.claude=false` in `.devin/config.json`.
+
+## Session storage and transcripts
+
+- Live session store: SQLite at `~/.local/share/devin/cli/sessions.db`
+  (message-node forest). Not read by this integration.
+- Canonical transcript: **ATIF** (`schema_version: "ATIF-v1.7"`) JSON written
+  to `~/.local/share/devin/cli/transcripts/<session_id>.json`
+  (`%APPDATA%\devin\cli\transcripts` on Windows; `$XDG_DATA_HOME` honored).
+  The directory is flat — not per-project. `devin --export [PATH]` writes the
+  identical document.
+- **Flush timing (important):** the transcript file is written on session
+  exit, not per turn. In print mode it is written between the `Stop` and
+  `SessionEnd` hooks (Devin awaits Stop hooks before proceeding — a Stop
+  hook that waits ~2s observes the file landing right after it gives up).
+  In interactive mode it is only written when the session ends (`/exit`),
+  verified via pty-driven multi-turn run. The framework hard-requires the
+  transcript file to exist at TurnEnd, so `PrepareTranscript` polls briefly
+  and then MATERIALIZES a minimal valid ATIF stub when the file is still
+  missing (the sanctioned OpenCode pattern — lazily created transcripts).
+  Devin overwrites the file with the complete transcript at session exit,
+  and the eager condensation at SessionEnd (endSessionNow) captures that
+  full version. Mid-session checkpoints may therefore carry a stub or a
+  previous run's transcript — the documented graceful degradation for v1.
+- Resumed sessions append to the same transcript file (verified: 11 steps →
+  14 steps after `devin -r`), so every checkpoint stores the full history.
+
+## ATIF format (verified)
+
+```json
+{
+  "schema_version": "ATIF-v1.7",
+  "session_id": "almond-cylinder",
+  "agent": {"name":"devin","version":"3000.2.17","model_name":"SWE-1.7","extra":{...}},
+  "steps": [
+    {"step_id":7,"timestamp":"...","source":"user","message":"<prompt>","extra":{...}},
+    {"step_id":9,"source":"agent","message":"","model_name":"SWE-1.7",
+     "reasoning_content":"...",
+     "tool_calls":[{"tool_call_id":"read_0","function_name":"read","arguments":{"file_path":"/abs"}}],
+     "metrics":{"prompt_tokens":12896,"completion_tokens":254,"cached_tokens":12430}}
+  ],
+  "final_metrics": {"total_prompt_tokens":65296,"total_completion_tokens":769,"total_cached_tokens":62771,"total_steps":14}
+}
+```
+
+- Token mapping: `prompt_tokens` includes cache reads, so
+  `InputTokens = prompt_tokens - cached_tokens`,
+  `CacheReadTokens = cached_tokens`, `OutputTokens = completion_tokens`.
+- File modifications appear as `tool_calls` with `function_name` `write`,
+  `edit`, or `notebook_edit` and an `arguments.file_path` (absolute).
+  PostToolUse hooks carry the same data live (used for ToolUse events).
+  Caveat: when hooks.v1.json contains multiple PostToolUse matcher groups,
+  Devin has been observed to run secondary groups' commands without piping
+  the payload — post-tool-use parsing is therefore fully best-effort and
+  never returns an error.
+
+## Resume
+
+`devin -r <session_id>` resumes a session (same session ID fires in
+SessionStart), `devin -c` continues the most recent one in the cwd.
+Session IDs are word-pairs and pass `validation.ValidateSessionID`.
+
+## Verified end-to-end (clean repo, devin 3000.2.17, in-tree prototype)
+
+- `entire enable --agent devin` installs hooks into `.devin/hooks.v1.json`,
+  preserving pre-existing user hooks.
+- Interactive session: per-turn Stop checkpoint creates the shadow branch
+  mid-session; a mid-session `git commit` received the `Entire-Checkpoint`
+  trailer.
+- Commit-after-exit flow: condensation re-reads the canonical transcript at
+  condense time, so `entire/checkpoints/v1` gets the complete ATIF document
+  with real token usage (verified: 10 steps, input/cache/output tokens and
+  API call count extracted from per-step `metrics`).
+- `entire checkpoint explain`, `entire session list` (agent, model, tokens),
+  `entire session resume` and `entire checkpoint rewind --to` all verified.
+
+## Known v1 limitations
+
+- Rewind restores the ATIF transcript file, but Devin resumes conversations
+  from its SQLite store — a rewound transcript does not truncate Devin's own
+  conversation memory, and cross-machine resume requires the session to exist
+  in the local `sessions.db`. (Devin has an internal node-import used for
+  cloud handoff; no public import command existed at integration time.)
+- Interactive-mode checkpoints lag the live turn (see flush timing above).
+  Consequence: a commit made mid-session condenses with the stub (or a
+  previous run's) transcript for that checkpoint entry; the complete
+  transcript lands in v1 with the next condensation that happens after the
+  session run ends (each checkpoint stores the full session, so a later
+  checkpoint heals the history). A session that only ever condenses
+  mid-session keeps the stub for its final entry — a candidate framework
+  follow-up is refreshing the cached transcript at SessionEnd before the
+  eager condense.
+- No subagent hooks (`SubagentStop` does not exist in Devin).
+- No live per-tool file tracking (see Protocol mapping above — the external
+  protocol Event object carries no modified_files).
+- Context injection (`hookSpecificOutput.additionalContext`) and
+  `systemMessage` display are parsed by Devin's Claude-compat layer per
+  binary inspection, but not yet verified live — not wired in v1.

--- a/agents/entire-agent-devin/README.md
+++ b/agents/entire-agent-devin/README.md
@@ -1,0 +1,54 @@
+# entire-agent-devin
+
+Entire external agent for [Devin CLI](https://docs.devin.ai/cli) ("Devin for
+Terminal", Cognition). Lets Entire capture checkpoints, transcripts, prompts,
+and token usage from Devin CLI sessions.
+
+## Capabilities
+
+- **Hooks** — installs Claude Code-format lifecycle hooks into
+  `.devin/hooks.v1.json` (`SessionStart`, `UserPromptSubmit`, `Stop`,
+  `SessionEnd`)
+- **Transcript analysis** — parses Devin's canonical ATIF transcript
+  (`~/.local/share/devin/cli/transcripts/<session_id>.json`): step positions,
+  modified files from `write`/`edit`/`notebook_edit` tool calls, user prompts
+- **Transcript preparer** — Devin writes its transcript when a session run
+  ends, so the preparer polls for the post-Stop flush and materializes a
+  minimal ATIF stub for mid-session checkpoints (the complete transcript is
+  captured by the first condensation after the session ends)
+- **Token calculation** — per-step `metrics` (prompt/completion/cached
+  tokens; fresh input = prompt − cached)
+
+See [AGENT.md](AGENT.md) for the live-verified behavior notes.
+
+## Setup
+
+```bash
+cd agents/entire-agent-devin
+mise run build
+cp entire-agent-devin /usr/local/bin/
+```
+
+Enable external agent discovery and Devin in your repo:
+
+```bash
+cd /path/to/your/repo
+# .entire/settings.json needs: {"external_agents": true}
+entire enable --agent devin --telemetry=false
+devin -p "Create hello.txt with hello world" --permission-mode accept-edits
+```
+
+Resume a captured session with `devin -r <session_id>` (session IDs are
+word-pairs like `snowy-efraasia`).
+
+## Known limitations
+
+- Devin resumes conversations from its own SQLite store, so `entire rewind`
+  restores the transcript file but not Devin's conversation memory;
+  cross-machine resume requires the session to exist locally.
+- Checkpoints condensed mid-session carry a stub or previous-run transcript;
+  the first condensation after the session run ends captures the complete one.
+- Devin loads `.claude/settings.json` hooks by default. If Entire is enabled
+  for Claude Code in the same repo, Devin sessions will also fire the
+  claude-code hooks; set `read_config_from.claude` to `false` in
+  `.devin/config.json` to avoid this until the CLI-side guard lands.

--- a/agents/entire-agent-devin/README.md
+++ b/agents/entire-agent-devin/README.md
@@ -18,6 +18,8 @@ and token usage from Devin CLI sessions.
   captured by the first condensation after the session ends)
 - **Token calculation** — per-step `metrics` (prompt/completion/cached
   tokens; fresh input = prompt − cached)
+- **Compact transcripts** — converts ATIF steps (messages, tool calls, and
+  observation results) into Entire Transcript Format for `transcript.jsonl`
 
 See [AGENT.md](AGENT.md) for the live-verified behavior notes.
 

--- a/agents/entire-agent-devin/go.mod
+++ b/agents/entire-agent-devin/go.mod
@@ -1,0 +1,3 @@
+module github.com/entireio/external-agents/agents/entire-agent-devin
+
+go 1.26.0

--- a/agents/entire-agent-devin/internal/devin/agent.go
+++ b/agents/entire-agent-devin/internal/devin/agent.go
@@ -50,6 +50,7 @@ func (a *Agent) Info() protocol.InfoResponse {
 			TranscriptAnalyzer: true,
 			TranscriptPreparer: true,
 			TokenCalculator:    true,
+			CompactTranscript:  true,
 			UsesTerminal:       true,
 		},
 	}

--- a/agents/entire-agent-devin/internal/devin/agent.go
+++ b/agents/entire-agent-devin/internal/devin/agent.go
@@ -1,0 +1,147 @@
+// Package devin implements the Entire external agent protocol for Devin CLI
+// ("Devin for Terminal", Cognition). Devin uses Claude Code-format lifecycle
+// hooks installed in .devin/hooks.v1.json and stores its canonical transcript
+// as an ATIF JSON document keyed by session ID. See AGENT.md for the verified
+// behavior this integration is built on.
+package devin
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/entireio/external-agents/agents/entire-agent-devin/internal/protocol"
+)
+
+// AgentName is the Entire registry name (derived from entire-agent-devin).
+const AgentName = "devin"
+
+// AgentType is the display name stored in checkpoint metadata.
+const AgentType = "Devin"
+
+// Agent implements the external agent protocol for Devin CLI.
+type Agent struct{}
+
+// New creates a new Devin agent instance.
+func New() *Agent {
+	return &Agent{}
+}
+
+// Info returns agent metadata and declared capabilities.
+func (a *Agent) Info() protocol.InfoResponse {
+	return protocol.InfoResponse{
+		ProtocolVersion: protocol.ProtocolVersion,
+		Name:            AgentName,
+		Type:            AgentType,
+		Description:     "Devin CLI - Cognition's terminal coding agent",
+		IsPreview:       true,
+		ProtectedDirs:   []string{".devin"},
+		HookNames: []string{
+			HookNameSessionStart,
+			HookNameSessionEnd,
+			HookNameStop,
+			HookNameUserPromptSubmit,
+		},
+		Capabilities: protocol.DeclaredCapabilities{
+			Hooks:              true,
+			TranscriptAnalyzer: true,
+			TranscriptPreparer: true,
+			TokenCalculator:    true,
+			UsesTerminal:       true,
+		},
+	}
+}
+
+// Detect reports whether Devin CLI is usable in the current environment.
+func (a *Agent) Detect() protocol.DetectResponse {
+	if _, err := exec.LookPath("devin"); err == nil {
+		return protocol.DetectResponse{Present: true}
+	}
+	if _, err := os.Stat(filepath.Join(protocol.RepoRoot(), ".devin")); err == nil {
+		return protocol.DetectResponse{Present: true}
+	}
+	return protocol.DetectResponse{Present: false}
+}
+
+// GetSessionID extracts the session ID from hook input.
+func (a *Agent) GetSessionID(input *protocol.HookInputJSON) string {
+	if input == nil {
+		return ""
+	}
+	return input.SessionID
+}
+
+// FormatResumeCommand returns the command to resume a Devin session.
+func (a *Agent) FormatResumeCommand(sessionID string) string {
+	if strings.TrimSpace(sessionID) == "" {
+		return "devin -c"
+	}
+	return "devin -r " + sessionID
+}
+
+// ReadSession reads a session from Devin's storage (ATIF transcript file).
+func (a *Agent) ReadSession(input *protocol.HookInputJSON) (protocol.AgentSessionJSON, error) {
+	if input == nil || input.SessionRef == "" {
+		return protocol.AgentSessionJSON{}, errors.New("session reference (transcript path) is required")
+	}
+
+	data, err := os.ReadFile(input.SessionRef)
+	if err != nil {
+		return protocol.AgentSessionJSON{}, fmt.Errorf("failed to read transcript: %w", err)
+	}
+
+	// Non-fatal when the file isn't ATIF (e.g. protocol round-trip data):
+	// the session is still usable without the file list.
+	modifiedFiles, _ := extractModifiedFiles(data)
+	if modifiedFiles == nil {
+		modifiedFiles = []string{}
+	}
+
+	return protocol.AgentSessionJSON{
+		SessionID:     input.SessionID,
+		AgentName:     AgentName,
+		RepoPath:      protocol.RepoRoot(),
+		SessionRef:    input.SessionRef,
+		NativeData:    data,
+		ModifiedFiles: modifiedFiles,
+		NewFiles:      []string{},
+		DeletedFiles:  []string{},
+	}, nil
+}
+
+// WriteSession writes a session back to Devin's transcript location.
+//
+// Limitation (see AGENT.md): Devin resumes conversations from its SQLite
+// store, not this file, so restoring the transcript preserves it for
+// explain/analysis but does not rewrite Devin's own conversation memory.
+func (a *Agent) WriteSession(session protocol.AgentSessionJSON) error {
+	if session.AgentName != "" && session.AgentName != AgentName {
+		return fmt.Errorf("session belongs to agent %q, not %q", session.AgentName, AgentName)
+	}
+	if session.SessionRef == "" {
+		return errors.New("session reference (transcript path) is required")
+	}
+	if len(session.NativeData) == 0 {
+		return errors.New("session has no native data to write")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(session.SessionRef), 0o750); err != nil {
+		return fmt.Errorf("failed to create transcript directory: %w", err)
+	}
+	if err := os.WriteFile(session.SessionRef, session.NativeData, 0o600); err != nil {
+		return fmt.Errorf("failed to write transcript: %w", err)
+	}
+	return nil
+}
+
+// ReadTranscript reads the raw ATIF transcript bytes for a session.
+func (a *Agent) ReadTranscript(sessionRef string) ([]byte, error) {
+	data, err := os.ReadFile(sessionRef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read transcript: %w", err)
+	}
+	return data, nil
+}

--- a/agents/entire-agent-devin/internal/devin/compact.go
+++ b/agents/entire-agent-devin/internal/devin/compact.go
@@ -1,0 +1,188 @@
+package devin
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/entireio/external-agents/agents/entire-agent-devin/internal/protocol"
+)
+
+const compactCLIVersion = "unknown"
+
+type compactLine struct {
+	V          int    `json:"v"`
+	Agent      string `json:"agent"`
+	CLIVersion string `json:"cli_version"`
+	Type       string `json:"type"`
+	TS         string `json:"ts,omitempty"`
+	ID         string `json:"id,omitempty"`
+	Content    any    `json:"content"`
+}
+
+type compactUserTextBlock struct {
+	Text string `json:"text"`
+}
+
+type compactAssistantTextBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type compactToolUseBlock struct {
+	Type   string             `json:"type"`
+	ID     string             `json:"id,omitempty"`
+	Name   string             `json:"name"`
+	Input  any                `json:"input,omitempty"`
+	Result *compactToolResult `json:"result,omitempty"`
+}
+
+type compactToolResult struct {
+	Output string `json:"output"`
+	Status string `json:"status"`
+}
+
+// compactStep is the ATIF step subset the compactor reads: message text,
+// tool calls, and the observation block that carries tool results keyed by
+// source_call_id.
+type compactStep struct {
+	Timestamp   string              `json:"timestamp"`
+	Source      string              `json:"source"`
+	Message     string              `json:"message"`
+	ToolCalls   []compactToolCall   `json:"tool_calls,omitempty"`
+	Observation *compactObservation `json:"observation,omitempty"`
+}
+
+type compactToolCall struct {
+	ToolCallID   string          `json:"tool_call_id"`
+	FunctionName string          `json:"function_name"`
+	Arguments    json.RawMessage `json:"arguments"`
+}
+
+type compactObservation struct {
+	Results []compactObservationResult `json:"results"`
+}
+
+type compactObservationResult struct {
+	SourceCallID string `json:"source_call_id"`
+	Content      string `json:"content"`
+}
+
+// CompactTranscript converts Devin's ATIF transcript into Entire Transcript
+// Format (JSONL of user/assistant lines with text and tool_use blocks).
+func (a *Agent) CompactTranscript(sessionRef string) (protocol.CompactTranscriptResponse, error) {
+	data, err := os.ReadFile(sessionRef)
+	if err != nil {
+		return protocol.CompactTranscriptResponse{}, err
+	}
+	compacted, err := compactTranscriptBytes(data)
+	if err != nil {
+		return protocol.CompactTranscriptResponse{}, err
+	}
+	return protocol.CompactTranscriptResponse{Transcript: base64.StdEncoding.EncodeToString(compacted)}, nil
+}
+
+func compactTranscriptBytes(data []byte) ([]byte, error) {
+	t, err := parseTranscript(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse ATIF transcript: %w", err)
+	}
+
+	var buf bytes.Buffer
+	for _, raw := range t.Steps {
+		var step compactStep
+		if err := json.Unmarshal(raw, &step); err != nil {
+			continue // Skip malformed steps
+		}
+		switch step.Source {
+		case "user":
+			if step.Message == "" {
+				continue
+			}
+			if err := writeCompactLine(&buf, compactLine{
+				V:          1,
+				Agent:      AgentName,
+				CLIVersion: compactCLIVersion,
+				Type:       "user",
+				TS:         step.Timestamp,
+				Content:    []compactUserTextBlock{{Text: step.Message}},
+			}); err != nil {
+				return nil, err
+			}
+		case "agent":
+			content := assistantBlocks(step)
+			if len(content) == 0 {
+				continue
+			}
+			if err := writeCompactLine(&buf, compactLine{
+				V:          1,
+				Agent:      AgentName,
+				CLIVersion: compactCLIVersion,
+				Type:       "assistant",
+				TS:         step.Timestamp,
+				Content:    content,
+			}); err != nil {
+				return nil, err
+			}
+		default:
+			// system and other sources carry no conversation content
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// assistantBlocks converts an agent step into compact content blocks: the
+// response text (if any) followed by one tool_use block per tool call, with
+// results joined from the step's observation by source_call_id.
+func assistantBlocks(step compactStep) []any {
+	var content []any
+	if step.Message != "" {
+		content = append(content, compactAssistantTextBlock{Type: "text", Text: step.Message})
+	}
+
+	resultsByCall := make(map[string]string)
+	if step.Observation != nil {
+		for _, result := range step.Observation.Results {
+			resultsByCall[result.SourceCallID] = result.Content
+		}
+	}
+
+	for _, call := range step.ToolCalls {
+		block := compactToolUseBlock{
+			Type:  "tool_use",
+			ID:    call.ToolCallID,
+			Name:  call.FunctionName,
+			Input: decodeRawObject(call.Arguments),
+		}
+		if output, ok := resultsByCall[call.ToolCallID]; ok {
+			block.Result = &compactToolResult{Output: output, Status: "success"}
+		}
+		content = append(content, block)
+	}
+	return content
+}
+
+// decodeRawObject decodes raw JSON into a generic value for re-marshaling,
+// falling back to the raw string when it isn't valid JSON.
+func decodeRawObject(raw json.RawMessage) any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return string(raw)
+	}
+	return value
+}
+
+func writeCompactLine(buf *bytes.Buffer, line compactLine) error {
+	data, err := json.Marshal(line)
+	if err != nil {
+		return fmt.Errorf("marshal compact line: %w", err)
+	}
+	buf.Write(data)
+	buf.WriteByte('\n')
+	return nil
+}

--- a/agents/entire-agent-devin/internal/devin/compact_test.go
+++ b/agents/entire-agent-devin/internal/devin/compact_test.go
@@ -1,0 +1,102 @@
+package devin
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// compactSample mirrors the live-captured ATIF shape including the
+// observation block that carries tool results (see AGENT.md).
+const compactSample = `{
+  "schema_version": "ATIF-v1.7",
+  "session_id": "almond-cylinder",
+  "agent": {"name": "devin", "model_name": "SWE-1.7"},
+  "steps": [
+    {"step_id": 1, "timestamp": "2026-07-27T11:59:51Z", "source": "system", "message": "system prompt"},
+    {"step_id": 2, "timestamp": "2026-07-27T11:59:52Z", "source": "user", "message": "Append a line to hello.txt"},
+    {"step_id": 3, "timestamp": "2026-07-27T12:01:40Z", "source": "agent", "message": "", "model_name": "SWE-1.7",
+     "tool_calls": [{"tool_call_id": "read_0", "function_name": "read", "arguments": {"file_path": "/repo/hello.txt"}}],
+     "observation": {"results": [{"source_call_id": "read_0", "content": "1|hook test ok"}]},
+     "metrics": {"prompt_tokens": 10, "completion_tokens": 5, "cached_tokens": 2}},
+    {"step_id": 4, "timestamp": "2026-07-27T12:01:50Z", "source": "agent", "message": "Done.", "model_name": "SWE-1.7",
+     "metrics": {"prompt_tokens": 12, "completion_tokens": 3, "cached_tokens": 10}}
+  ]
+}`
+
+func TestCompactTranscriptBytes(t *testing.T) {
+	t.Parallel()
+
+	out, err := compactTranscriptBytes([]byte(compactSample))
+	if err != nil {
+		t.Fatalf("compactTranscriptBytes: %v", err)
+	}
+
+	var lines []compactLine
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for scanner.Scan() {
+		var line compactLine
+		if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
+			t.Fatalf("invalid compact line %q: %v", scanner.Text(), err)
+		}
+		lines = append(lines, line)
+	}
+
+	// system step skipped; user + two agent steps remain.
+	if len(lines) != 3 {
+		t.Fatalf("lines = %d, want 3", len(lines))
+	}
+	if lines[0].Type != "user" || lines[1].Type != "assistant" || lines[2].Type != "assistant" {
+		t.Errorf("line types = %s/%s/%s", lines[0].Type, lines[1].Type, lines[2].Type)
+	}
+	for i, line := range lines {
+		if line.V != 1 || line.Agent != AgentName {
+			t.Errorf("line %d envelope = v%d agent %q", i, line.V, line.Agent)
+		}
+	}
+
+	// The tool_use block must carry the joined observation result.
+	blocks, ok := lines[1].Content.([]any)
+	if !ok || len(blocks) != 1 {
+		t.Fatalf("assistant content = %#v, want 1 block", lines[1].Content)
+	}
+	block, ok := blocks[0].(map[string]any)
+	if !ok {
+		t.Fatalf("block = %#v", blocks[0])
+	}
+	if block["type"] != "tool_use" || block["name"] != "read" || block["id"] != "read_0" {
+		t.Errorf("tool_use block = %v", block)
+	}
+	result, ok := block["result"].(map[string]any)
+	if !ok || result["output"] != "1|hook test ok" || result["status"] != "success" {
+		t.Errorf("tool result = %v", block["result"])
+	}
+}
+
+func TestCompactTranscriptBytes_TextAndEmpty(t *testing.T) {
+	t.Parallel()
+
+	out, err := compactTranscriptBytes([]byte(compactSample))
+	if err != nil {
+		t.Fatalf("compactTranscriptBytes: %v", err)
+	}
+	if !bytes.Contains(out, []byte(`"text":"Done."`)) {
+		t.Error("final assistant text block missing")
+	}
+
+	// Non-ATIF content errors rather than fabricating an empty transcript.
+	if _, err := compactTranscriptBytes([]byte("not json")); err == nil {
+		t.Error("expected error for non-ATIF content")
+	}
+
+	// Empty steps produce an empty (but valid) compact transcript.
+	empty := `{"schema_version":"ATIF-v1.7","session_id":"x","steps":[]}`
+	out, err = compactTranscriptBytes([]byte(empty))
+	if err != nil {
+		t.Fatalf("empty transcript: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("empty transcript output = %q, want empty", out)
+	}
+}

--- a/agents/entire-agent-devin/internal/devin/hooks.go
+++ b/agents/entire-agent-devin/internal/devin/hooks.go
@@ -1,0 +1,332 @@
+package devin
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/entireio/external-agents/agents/entire-agent-devin/internal/protocol"
+)
+
+// HooksFileName is the standalone hooks file used by Devin CLI. Unlike
+// .claude/settings.json, the hooks object is the entire file — event names
+// are top-level keys with no "hooks" wrapper.
+const HooksFileName = "hooks.v1.json"
+
+// Devin hook names - these become subcommands under `entire hooks devin`.
+const (
+	HookNameSessionStart     = "session-start"
+	HookNameSessionEnd       = "session-end"
+	HookNameStop             = "stop"
+	HookNameUserPromptSubmit = "user-prompt-submit"
+)
+
+// Event type values from the external agent protocol.
+const (
+	eventSessionStart = 1
+	eventTurnStart    = 2
+	eventTurnEnd      = 3
+	eventSessionEnd   = 5
+)
+
+// ParseHook translates a Devin hook payload into a normalized lifecycle
+// event. Devin payloads carry no transcript_path, so SessionRef is derived
+// from the session ID via the canonical transcript location.
+func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, error) {
+	if len(input) == 0 {
+		return nil, nil // No payload — nothing to parse (protocol contract)
+	}
+	switch hookName {
+	case HookNameSessionStart:
+		return parseSessionInfoEvent(input, eventSessionStart)
+	case HookNameUserPromptSubmit:
+		return parseTurnStart(input)
+	case HookNameStop:
+		return parseSessionInfoEvent(input, eventTurnEnd)
+	case HookNameSessionEnd:
+		return parseSessionInfoEvent(input, eventSessionEnd)
+	default:
+		return nil, nil // Unknown hooks have no lifecycle action
+	}
+}
+
+func parseSessionInfoEvent(input []byte, eventType int) (*protocol.EventJSON, error) {
+	var raw sessionInfoRaw
+	if err := json.Unmarshal(input, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse hook input: %w", err)
+	}
+	if raw.SessionID == "" {
+		return nil, nil // No session — nothing to track
+	}
+	return &protocol.EventJSON{
+		Type:       eventType,
+		SessionID:  raw.SessionID,
+		SessionRef: sessionRefForID(raw.SessionID),
+		Timestamp:  time.Now().UTC().Format(time.RFC3339),
+	}, nil
+}
+
+func parseTurnStart(input []byte) (*protocol.EventJSON, error) {
+	var raw userPromptSubmitRaw
+	if err := json.Unmarshal(input, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse hook input: %w", err)
+	}
+	if raw.SessionID == "" {
+		return nil, nil
+	}
+	return &protocol.EventJSON{
+		Type:       eventTurnStart,
+		SessionID:  raw.SessionID,
+		SessionRef: sessionRefForID(raw.SessionID),
+		Prompt:     raw.Prompt,
+		Timestamp:  time.Now().UTC().Format(time.RFC3339),
+	}, nil
+}
+
+// --- Hook installation ---
+
+// hooksFilePath returns the absolute path of .devin/hooks.v1.json for the repo.
+func hooksFilePath() string {
+	return filepath.Join(protocol.RepoRoot(), ".devin", HooksFileName)
+}
+
+// hookCommand builds the command installed for a hook verb. The entire binary
+// is resolved at install time so hooks work even when the agent's PATH
+// differs; failures are swallowed (`|| true`) so a hook error never blocks
+// Devin's turn.
+func hookCommand(hookName string) string {
+	entire := "entire"
+	if path, err := exec.LookPath("entire"); err == nil && strings.TrimSpace(path) != "" {
+		entire = path
+	}
+	return fmt.Sprintf("sh -c 'if command -v %s >/dev/null 2>&1; then %s hooks devin %s >/dev/null 2>&1 || true; fi'", shellQuote(entire), shellQuote(entire), hookName)
+}
+
+// shellQuote makes a string safe for single-quoted sh interpolation.
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if !strings.ContainsAny(s, " \t\n'\"\\$`&|;<>()*?[]#~%") {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// InstallHooks installs Devin hooks in .devin/hooks.v1.json.
+// If force is true, removes existing Entire hooks before installing.
+// Returns the number of hooks installed.
+func (a *Agent) InstallHooks(_ bool, force bool) (int, error) {
+	hooksPath := hooksFilePath()
+
+	// The whole file is the hooks object; use a raw map to preserve unknown
+	// event types on round-trip.
+	rawHooks := make(map[string]json.RawMessage)
+	if existingData, readErr := os.ReadFile(hooksPath); readErr == nil {
+		if err := json.Unmarshal(existingData, &rawHooks); err != nil {
+			return 0, fmt.Errorf("failed to parse existing %s: %w", HooksFileName, err)
+		}
+	}
+
+	// Parse only the hook types we manage
+	var sessionStart, sessionEnd, stop, userPromptSubmit []HookMatcher
+	parseHookType(rawHooks, "SessionStart", &sessionStart)
+	parseHookType(rawHooks, "SessionEnd", &sessionEnd)
+	parseHookType(rawHooks, "Stop", &stop)
+	parseHookType(rawHooks, "UserPromptSubmit", &userPromptSubmit)
+
+	// If force is true, remove all existing Entire hooks first
+	if force {
+		sessionStart = removeEntireHooks(sessionStart)
+		sessionEnd = removeEntireHooks(sessionEnd)
+		stop = removeEntireHooks(stop)
+		userPromptSubmit = removeEntireHooks(userPromptSubmit)
+	}
+
+	// Define hook commands
+	sessionStartCmd := hookCommand(HookNameSessionStart)
+	sessionEndCmd := hookCommand(HookNameSessionEnd)
+	stopCmd := hookCommand(HookNameStop)
+	userPromptSubmitCmd := hookCommand(HookNameUserPromptSubmit)
+
+	count := 0
+
+	// Add hooks if they don't exist
+	if !hookCommandExists(sessionStart, sessionStartCmd) {
+		sessionStart = addHookToMatcher(sessionStart, sessionStartCmd)
+		count++
+	}
+	if !hookCommandExists(sessionEnd, sessionEndCmd) {
+		sessionEnd = addHookToMatcher(sessionEnd, sessionEndCmd)
+		count++
+	}
+	if !hookCommandExists(stop, stopCmd) {
+		stop = addHookToMatcher(stop, stopCmd)
+		count++
+	}
+	if !hookCommandExists(userPromptSubmit, userPromptSubmitCmd) {
+		userPromptSubmit = addHookToMatcher(userPromptSubmit, userPromptSubmitCmd)
+		count++
+	}
+
+	if count == 0 {
+		return 0, nil // All hooks already installed
+	}
+
+	// Marshal modified hook types back to rawHooks
+	marshalHookType(rawHooks, "SessionStart", sessionStart)
+	marshalHookType(rawHooks, "SessionEnd", sessionEnd)
+	marshalHookType(rawHooks, "Stop", stop)
+	marshalHookType(rawHooks, "UserPromptSubmit", userPromptSubmit)
+
+	// Write back to file
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o750); err != nil {
+		return 0, fmt.Errorf("failed to create .devin directory: %w", err)
+	}
+	output, err := json.MarshalIndent(rawHooks, "", "  ")
+	if err != nil {
+		return 0, fmt.Errorf("failed to marshal hooks: %w", err)
+	}
+	output = append(output, '\n')
+	if err := os.WriteFile(hooksPath, output, 0o600); err != nil {
+		return 0, fmt.Errorf("failed to write %s: %w", HooksFileName, err)
+	}
+	return count, nil
+}
+
+// UninstallHooks removes Entire hooks from .devin/hooks.v1.json.
+func (a *Agent) UninstallHooks() error {
+	hooksPath := hooksFilePath()
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		return nil //nolint:nilerr // No hooks file means nothing to uninstall
+	}
+
+	rawHooks := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(data, &rawHooks); err != nil {
+		return fmt.Errorf("failed to parse %s: %w", HooksFileName, err)
+	}
+
+	// Parse only the hook types we need to modify
+	var sessionStart, sessionEnd, stop, userPromptSubmit []HookMatcher
+	parseHookType(rawHooks, "SessionStart", &sessionStart)
+	parseHookType(rawHooks, "SessionEnd", &sessionEnd)
+	parseHookType(rawHooks, "Stop", &stop)
+	parseHookType(rawHooks, "UserPromptSubmit", &userPromptSubmit)
+
+	// Remove Entire hooks from all hook types
+	marshalHookType(rawHooks, "SessionStart", removeEntireHooks(sessionStart))
+	marshalHookType(rawHooks, "SessionEnd", removeEntireHooks(sessionEnd))
+	marshalHookType(rawHooks, "Stop", removeEntireHooks(stop))
+	marshalHookType(rawHooks, "UserPromptSubmit", removeEntireHooks(userPromptSubmit))
+
+	output, err := json.MarshalIndent(rawHooks, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal hooks: %w", err)
+	}
+	output = append(output, '\n')
+	if err := os.WriteFile(hooksPath, output, 0o600); err != nil {
+		return fmt.Errorf("failed to write %s: %w", HooksFileName, err)
+	}
+	return nil
+}
+
+// AreHooksInstalled checks if Entire hooks are installed.
+func (a *Agent) AreHooksInstalled() bool {
+	data, err := os.ReadFile(hooksFilePath())
+	if err != nil {
+		return false
+	}
+
+	rawHooks := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(data, &rawHooks); err != nil {
+		return false
+	}
+
+	// Check for at least one of our hooks
+	var stop []HookMatcher
+	parseHookType(rawHooks, "Stop", &stop)
+	for _, matcher := range stop {
+		for _, hook := range matcher.Hooks {
+			if isEntireHook(hook.Command) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Helper functions for hook management
+
+// parseHookType parses a specific hook type from rawHooks into the target slice.
+// Silently ignores parse errors (leaves target unchanged).
+func parseHookType(rawHooks map[string]json.RawMessage, hookType string, target *[]HookMatcher) {
+	if data, ok := rawHooks[hookType]; ok {
+		_ = json.Unmarshal(data, target)
+	}
+}
+
+// marshalHookType marshals a hook type back to rawHooks.
+// If the slice is empty, removes the key from rawHooks.
+func marshalHookType(rawHooks map[string]json.RawMessage, hookType string, matchers []HookMatcher) {
+	if len(matchers) == 0 {
+		delete(rawHooks, hookType)
+		return
+	}
+	data, err := json.Marshal(matchers)
+	if err == nil {
+		rawHooks[hookType] = data
+	}
+}
+
+func hookCommandExists(matchers []HookMatcher, command string) bool {
+	for _, matcher := range matchers {
+		for _, hook := range matcher.Hooks {
+			if hook.Command == command {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// addHookToMatcher appends the command to the empty-string matcher group,
+// creating it if needed. All Devin lifecycle hooks use the empty matcher.
+func addHookToMatcher(matchers []HookMatcher, command string) []HookMatcher {
+	entry := HookEntry{Type: "command", Command: command}
+	for i, matcher := range matchers {
+		if matcher.Matcher == "" {
+			matchers[i].Hooks = append(matchers[i].Hooks, entry)
+			return matchers
+		}
+	}
+	return append(matchers, HookMatcher{Matcher: "", Hooks: []HookEntry{entry}})
+}
+
+// isEntireHook checks if a command is an Entire hook installed by this agent.
+func isEntireHook(command string) bool {
+	return strings.Contains(command, " hooks devin ") || strings.HasPrefix(command, "entire ")
+}
+
+// removeEntireHooks removes all Entire hooks from a list of matchers.
+func removeEntireHooks(matchers []HookMatcher) []HookMatcher {
+	result := make([]HookMatcher, 0, len(matchers))
+	for _, matcher := range matchers {
+		filteredHooks := make([]HookEntry, 0, len(matcher.Hooks))
+		for _, hook := range matcher.Hooks {
+			if !isEntireHook(hook.Command) {
+				filteredHooks = append(filteredHooks, hook)
+			}
+		}
+		// Only keep the matcher if it has hooks remaining
+		if len(filteredHooks) > 0 {
+			matcher.Hooks = filteredHooks
+			result = append(result, matcher)
+		}
+	}
+	return result
+}

--- a/agents/entire-agent-devin/internal/devin/hooks_test.go
+++ b/agents/entire-agent-devin/internal/devin/hooks_test.go
@@ -1,0 +1,286 @@
+package devin
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// liveSessionID is the word-pair session ID captured from a live devin run.
+const liveSessionID = "snowy-efraasia"
+
+// Payloads below are verbatim captures from devin 3000.2.17 (see AGENT.md).
+
+func TestParseHook_SessionStart(t *testing.T) {
+	transcriptDir := t.TempDir()
+	t.Setenv("ENTIRE_TEST_DEVIN_TRANSCRIPT_DIR", transcriptDir)
+
+	a := New()
+	payload := []byte(`{"hook_event_name":"SessionStart","source":"startup","session_id":"snowy-efraasia"}`)
+	event, err := a.ParseHook(HookNameSessionStart, payload)
+	if err != nil {
+		t.Fatalf("ParseHook: %v", err)
+	}
+	if event.Type != eventSessionStart {
+		t.Errorf("Type = %d, want %d", event.Type, eventSessionStart)
+	}
+	if event.SessionID != liveSessionID {
+		t.Errorf("SessionID = %q, want %q", event.SessionID, liveSessionID)
+	}
+	want := filepath.Join(transcriptDir, liveSessionID+".json")
+	if event.SessionRef != want {
+		t.Errorf("SessionRef = %q, want %q", event.SessionRef, want)
+	}
+}
+
+func TestParseHook_UserPromptSubmit(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_DEVIN_TRANSCRIPT_DIR", t.TempDir())
+
+	a := New()
+	payload := []byte(`{"hook_event_name":"UserPromptSubmit","prompt":"Create a file named hello.txt","session_id":"snowy-efraasia","prompt_id":"54697fcd-fbea-4b60-b718-f3abcf9375fc"}`)
+	event, err := a.ParseHook(HookNameUserPromptSubmit, payload)
+	if err != nil {
+		t.Fatalf("ParseHook: %v", err)
+	}
+	if event.Type != eventTurnStart {
+		t.Errorf("Type = %d, want %d", event.Type, eventTurnStart)
+	}
+	if event.Prompt != "Create a file named hello.txt" {
+		t.Errorf("Prompt = %q", event.Prompt)
+	}
+	if event.SessionRef == "" {
+		t.Error("SessionRef is empty, want derived transcript path")
+	}
+}
+
+func TestParseHook_StopAndSessionEnd(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_DEVIN_TRANSCRIPT_DIR", t.TempDir())
+	a := New()
+
+	stop := []byte(`{"hook_event_name":"Stop","stop_hook_active":false,"session_id":"snowy-efraasia","prompt_id":"54697fcd-fbea-4b60-b718-f3abcf9375fc"}`)
+	event, err := a.ParseHook(HookNameStop, stop)
+	if err != nil {
+		t.Fatalf("ParseHook stop: %v", err)
+	}
+	if event.Type != eventTurnEnd {
+		t.Errorf("stop Type = %d, want %d", event.Type, eventTurnEnd)
+	}
+
+	end := []byte(`{"hook_event_name":"SessionEnd","reason":"session_complete","session_id":"snowy-efraasia","prompt_id":"54697fcd-fbea-4b60-b718-f3abcf9375fc"}`)
+	event, err = a.ParseHook(HookNameSessionEnd, end)
+	if err != nil {
+		t.Fatalf("ParseHook session-end: %v", err)
+	}
+	if event.Type != eventSessionEnd {
+		t.Errorf("session-end Type = %d, want %d", event.Type, eventSessionEnd)
+	}
+}
+
+func TestParseHook_Edges(t *testing.T) {
+	t.Parallel()
+	a := New()
+
+	if event, err := a.ParseHook("unknown-hook", []byte(`{}`)); err != nil || event != nil {
+		t.Errorf("unknown hook: event=%v err=%v, want nil,nil", event, err)
+	}
+	if event, err := a.ParseHook(HookNameStop, []byte(`{"hook_event_name":"Stop"}`)); err != nil || event != nil {
+		t.Errorf("missing session_id: event=%v err=%v, want nil,nil", event, err)
+	}
+	if _, err := a.ParseHook(HookNameStop, []byte(`{not json`)); err == nil {
+		t.Error("expected error for malformed JSON")
+	}
+}
+
+func setupHooksTestRepo(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmpDir)
+	return tmpDir
+}
+
+func readHooksFile(t *testing.T, repoDir string) map[string]json.RawMessage {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(repoDir, ".devin", HooksFileName))
+	if err != nil {
+		t.Fatalf("read hooks file: %v", err)
+	}
+	rawHooks := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(data, &rawHooks); err != nil {
+		t.Fatalf("parse hooks file: %v", err)
+	}
+	return rawHooks
+}
+
+func TestInstallHooks_FreshInstall(t *testing.T) {
+	repoDir := setupHooksTestRepo(t)
+	a := New()
+
+	count, err := a.InstallHooks(false, false)
+	if err != nil {
+		t.Fatalf("InstallHooks: %v", err)
+	}
+	if count != 4 {
+		t.Errorf("count = %d, want 4", count)
+	}
+
+	rawHooks := readHooksFile(t, repoDir)
+	for _, event := range []string{"SessionStart", "SessionEnd", "Stop", "UserPromptSubmit"} {
+		if _, ok := rawHooks[event]; !ok {
+			t.Errorf("hooks file missing event %q", event)
+		}
+	}
+
+	var stop []HookMatcher
+	if err := json.Unmarshal(rawHooks["Stop"], &stop); err != nil {
+		t.Fatalf("parse Stop: %v", err)
+	}
+	if len(stop) != 1 || len(stop[0].Hooks) != 1 {
+		t.Fatalf("Stop matchers = %+v", stop)
+	}
+	if !strings.Contains(stop[0].Hooks[0].Command, "hooks devin stop") {
+		t.Errorf("Stop command = %q, want it to invoke 'hooks devin stop'", stop[0].Hooks[0].Command)
+	}
+
+	if !a.AreHooksInstalled() {
+		t.Error("AreHooksInstalled = false after install")
+	}
+}
+
+func TestInstallHooks_Idempotent(t *testing.T) {
+	setupHooksTestRepo(t)
+	a := New()
+
+	if _, err := a.InstallHooks(false, false); err != nil {
+		t.Fatalf("first InstallHooks: %v", err)
+	}
+	count, err := a.InstallHooks(false, false)
+	if err != nil {
+		t.Fatalf("second InstallHooks: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("second install count = %d, want 0", count)
+	}
+}
+
+func TestInstallHooks_PreservesForeignHooks(t *testing.T) {
+	repoDir := setupHooksTestRepo(t)
+	a := New()
+
+	existing := `{
+  "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "./my-hook.sh"}]}],
+  "PreToolUse": [{"matcher": "exec", "hooks": [{"type": "command", "command": "./validate.sh"}]}]
+}`
+	if err := os.MkdirAll(filepath.Join(repoDir, ".devin"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, ".devin", HooksFileName), []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := a.InstallHooks(false, false); err != nil {
+		t.Fatalf("InstallHooks: %v", err)
+	}
+
+	rawHooks := readHooksFile(t, repoDir)
+
+	var preToolUse []HookMatcher
+	if err := json.Unmarshal(rawHooks["PreToolUse"], &preToolUse); err != nil {
+		t.Fatalf("parse PreToolUse: %v", err)
+	}
+	if len(preToolUse) != 1 || preToolUse[0].Hooks[0].Command != "./validate.sh" {
+		t.Errorf("foreign PreToolUse hook not preserved: %+v", preToolUse)
+	}
+
+	var stop []HookMatcher
+	if err := json.Unmarshal(rawHooks["Stop"], &stop); err != nil {
+		t.Fatalf("parse Stop: %v", err)
+	}
+	foundForeign, foundEntire := false, false
+	for _, m := range stop {
+		for _, h := range m.Hooks {
+			if h.Command == "./my-hook.sh" {
+				foundForeign = true
+			}
+			if isEntireHook(h.Command) {
+				foundEntire = true
+			}
+		}
+	}
+	if !foundForeign || !foundEntire {
+		t.Errorf("Stop hooks foreign=%v entire=%v, want both true: %+v", foundForeign, foundEntire, stop)
+	}
+}
+
+func TestUninstallHooks_RemovesOnlyEntireHooks(t *testing.T) {
+	repoDir := setupHooksTestRepo(t)
+	a := New()
+
+	existing := `{"Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "./my-hook.sh"}]}]}`
+	if err := os.MkdirAll(filepath.Join(repoDir, ".devin"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, ".devin", HooksFileName), []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := a.InstallHooks(false, false); err != nil {
+		t.Fatalf("InstallHooks: %v", err)
+	}
+	if err := a.UninstallHooks(); err != nil {
+		t.Fatalf("UninstallHooks: %v", err)
+	}
+
+	if a.AreHooksInstalled() {
+		t.Error("AreHooksInstalled = true after uninstall")
+	}
+
+	rawHooks := readHooksFile(t, repoDir)
+	var stop []HookMatcher
+	if err := json.Unmarshal(rawHooks["Stop"], &stop); err != nil {
+		t.Fatalf("parse Stop: %v", err)
+	}
+	if len(stop) != 1 || stop[0].Hooks[0].Command != "./my-hook.sh" {
+		t.Errorf("foreign Stop hook not preserved after uninstall: %+v", stop)
+	}
+	if _, ok := rawHooks["SessionStart"]; ok {
+		t.Error("SessionStart still present after uninstall (should be removed when empty)")
+	}
+}
+
+func TestInstallHooks_Force(t *testing.T) {
+	repoDir := setupHooksTestRepo(t)
+	a := New()
+
+	if _, err := a.InstallHooks(false, false); err != nil {
+		t.Fatalf("InstallHooks: %v", err)
+	}
+	count, err := a.InstallHooks(false, true)
+	if err != nil {
+		t.Fatalf("force InstallHooks: %v", err)
+	}
+	if count != 4 {
+		t.Errorf("force install count = %d, want 4", count)
+	}
+
+	rawHooks := readHooksFile(t, repoDir)
+	var stop []HookMatcher
+	if err := json.Unmarshal(rawHooks["Stop"], &stop); err != nil {
+		t.Fatalf("parse Stop: %v", err)
+	}
+	total := 0
+	for _, m := range stop {
+		total += len(m.Hooks)
+	}
+	if total != 1 {
+		t.Errorf("Stop hook count after force = %d, want 1 (no duplicates)", total)
+	}
+}
+
+func TestAreHooksInstalled_NoFile(t *testing.T) {
+	setupHooksTestRepo(t)
+	if New().AreHooksInstalled() {
+		t.Error("AreHooksInstalled = true with no hooks file")
+	}
+}

--- a/agents/entire-agent-devin/internal/devin/paths.go
+++ b/agents/entire-agent-devin/internal/devin/paths.go
@@ -1,0 +1,69 @@
+package devin
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// TranscriptsDir returns the directory where Devin CLI stores canonical
+// session transcripts: <data-dir>/cli/transcripts. The directory is flat —
+// one <session_id>.json per session, not per-project.
+func TranscriptsDir() (string, error) {
+	if override := os.Getenv("ENTIRE_TEST_DEVIN_TRANSCRIPT_DIR"); override != "" {
+		return override, nil
+	}
+	dataDir, err := devinDataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dataDir, "cli", "transcripts"), nil
+}
+
+// devinDataDir returns Devin's per-user data directory
+// (~/.local/share/devin on Unix, %APPDATA%\devin on Windows).
+func devinDataDir() (string, error) {
+	if runtime.GOOS == "windows" {
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			return "", errors.New("APPDATA environment variable not set")
+		}
+		return filepath.Join(appData, "devin"), nil
+	}
+	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
+		return filepath.Join(xdg, "devin"), nil
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(homeDir, ".local", "share", "devin"), nil
+}
+
+// GetSessionDir returns the directory where Devin stores session transcripts.
+// Devin's transcript directory is flat, so repoPath is unused.
+func (a *Agent) GetSessionDir(_ string) (string, error) {
+	return TranscriptsDir()
+}
+
+// ResolveSessionFile returns the path to a Devin transcript file.
+// Devin names transcripts directly as <session_id>.json.
+func (a *Agent) ResolveSessionFile(sessionDir, sessionID string) string {
+	return filepath.Join(sessionDir, sessionID+".json")
+}
+
+// sessionRefForID computes the canonical transcript path for a session ID.
+// Returns "" when the transcript directory cannot be resolved (home dir /
+// APPDATA unavailable — pathological).
+func sessionRefForID(sessionID string) string {
+	if sessionID == "" {
+		return ""
+	}
+	dir, err := TranscriptsDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, sessionID+".json")
+}

--- a/agents/entire-agent-devin/internal/devin/transcript.go
+++ b/agents/entire-agent-devin/internal/devin/transcript.go
@@ -1,0 +1,365 @@
+package devin
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/entireio/external-agents/agents/entire-agent-devin/internal/protocol"
+)
+
+// parseTranscript unmarshals an ATIF document.
+func parseTranscript(data []byte) (*ATIFTranscript, error) {
+	var t ATIFTranscript
+	if err := json.Unmarshal(data, &t); err != nil {
+		return nil, fmt.Errorf("failed to parse ATIF transcript: %w", err)
+	}
+	return &t, nil
+}
+
+// PrepareTranscript materializes or waits for Devin's transcript. Devin
+// writes the canonical transcript only when a session run ends — so at
+// TurnEnd time the file is either absent (first run, mid-session) or stale
+// (resumed session). Entire requires the transcript file to exist before it
+// saves a checkpoint, so:
+//   - fresh file: return immediately
+//   - stale file: keep it — real data from the previous run beats a stub;
+//     no flush is coming mid-session
+//   - missing file: poll briefly (print mode writes it shortly after Stop
+//     fires), then materialize a minimal valid ATIF stub so the turn's code
+//     checkpoint can proceed. Devin overwrites the file with the complete
+//     transcript when the session ends (see AGENT.md, flush timing).
+func (a *Agent) PrepareTranscript(sessionRef string) error {
+	if sessionRef == "" {
+		return nil
+	}
+	const (
+		maxWait      = 2 * time.Second
+		pollInterval = 50 * time.Millisecond
+		maxSkew      = 2 * time.Second
+		// staleThreshold: a transcript that hasn't been touched in minutes
+		// belongs to a previous session run and no flush is coming.
+		staleThreshold = 2 * time.Minute
+	)
+
+	hookStart := time.Now()
+	if info, err := os.Stat(sessionRef); err == nil {
+		age := time.Since(info.ModTime())
+		if age < maxSkew {
+			return nil // Already fresh
+		}
+		if age > staleThreshold {
+			return nil // Previous run's transcript; no flush coming mid-session
+		}
+	}
+
+	deadline := hookStart.Add(maxWait)
+	for time.Now().Before(deadline) {
+		if info, err := os.Stat(sessionRef); err == nil && info.ModTime().After(hookStart.Add(-maxSkew)) {
+			return nil
+		}
+		time.Sleep(pollInterval)
+	}
+
+	if _, err := os.Stat(sessionRef); os.IsNotExist(err) {
+		return writeStubTranscript(sessionRef)
+	}
+	return nil // Stale file left in place: best-effort
+}
+
+// writeStubTranscript writes a minimal valid ATIF document for a session
+// whose canonical transcript has not been flushed yet. Never overwrites an
+// existing file. Devin regenerates transcripts from its session store on
+// exit, so the stub's lifetime ends with the session run.
+func writeStubTranscript(sessionRef string) error {
+	sessionID := strings.TrimSuffix(filepath.Base(sessionRef), ".json")
+	stub := ATIFTranscript{
+		SchemaVersion: "ATIF-v1.7",
+		SessionID:     sessionID,
+		Steps:         []ATIFStep{},
+	}
+	data, err := json.Marshal(stub)
+	if err != nil {
+		return fmt.Errorf("failed to marshal stub transcript: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(sessionRef), 0o750); err != nil {
+		return fmt.Errorf("failed to create transcript directory: %w", err)
+	}
+	f, err := os.OpenFile(sessionRef, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		if os.IsExist(err) {
+			return nil // Real transcript landed in the meantime — keep it
+		}
+		return fmt.Errorf("failed to create stub transcript: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("failed to write stub transcript: %w", err)
+	}
+	return nil
+}
+
+// GetTranscriptPosition returns the current step count of a Devin transcript.
+// Devin uses a JSON document with a steps array, so position is the number of
+// steps. Returns 0 if the file doesn't exist or is empty.
+func (a *Agent) GetTranscriptPosition(path string) (int, error) {
+	if path == "" {
+		return 0, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to read transcript file: %w", err)
+	}
+	if len(data) == 0 {
+		return 0, nil
+	}
+	t, err := parseTranscript(data)
+	if err != nil {
+		return 0, err
+	}
+	return len(t.Steps), nil
+}
+
+// ExtractModifiedFiles extracts files modified since a given step index.
+func (a *Agent) ExtractModifiedFiles(path string, offset int) ([]string, int, error) {
+	if path == "" {
+		return nil, 0, nil
+	}
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		if os.IsNotExist(readErr) {
+			return nil, 0, nil
+		}
+		return nil, 0, fmt.Errorf("failed to read transcript file: %w", readErr)
+	}
+	t, parseErr := parseTranscript(data)
+	if parseErr != nil {
+		return nil, 0, parseErr
+	}
+	return extractModifiedFilesFromSteps(t.Steps, offset), len(t.Steps), nil
+}
+
+// extractModifiedFiles extracts all modified file paths from a raw transcript.
+func extractModifiedFiles(data []byte) ([]string, error) {
+	t, err := parseTranscript(data)
+	if err != nil {
+		return nil, err
+	}
+	return extractModifiedFilesFromSteps(t.Steps, 0), nil
+}
+
+// extractModifiedFilesFromSteps collects file paths from write/edit tool
+// calls on agent steps, starting at the given step index, deduplicated in
+// first-seen order.
+func extractModifiedFilesFromSteps(steps []ATIFStep, startOffset int) []string {
+	if startOffset < 0 {
+		startOffset = 0
+	}
+	seen := make(map[string]struct{})
+	var files []string
+	for i := startOffset; i < len(steps); i++ {
+		var info atifStepInfo
+		if err := json.Unmarshal(steps[i], &info); err != nil {
+			continue // Skip malformed steps
+		}
+		for _, call := range info.ToolCalls {
+			if !isFileModificationTool(call.FunctionName) {
+				continue
+			}
+			var input fileToolInput
+			if err := json.Unmarshal(call.Arguments, &input); err != nil || input.FilePath == "" {
+				continue
+			}
+			if _, ok := seen[input.FilePath]; !ok {
+				seen[input.FilePath] = struct{}{}
+				files = append(files, input.FilePath)
+			}
+		}
+	}
+	return files
+}
+
+// ExtractPrompts returns user prompts from the transcript starting at the
+// given step index.
+func (a *Agent) ExtractPrompts(sessionRef string, offset int) ([]string, error) {
+	data, err := os.ReadFile(sessionRef)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read transcript file: %w", err)
+	}
+	t, err := parseTranscript(data)
+	if err != nil {
+		return nil, err
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	var prompts []string
+	for i := offset; i < len(t.Steps); i++ {
+		var info atifStepInfo
+		if err := json.Unmarshal(t.Steps[i], &info); err != nil {
+			continue
+		}
+		if info.Source == "user" && info.Message != "" {
+			prompts = append(prompts, info.Message)
+		}
+	}
+	return prompts, nil
+}
+
+// ExtractSummary reports that Devin transcripts carry no native summary.
+func (a *Agent) ExtractSummary(_ string) (string, bool, error) {
+	return "", false, nil
+}
+
+// CalculateTokens computes token usage from the transcript starting at the
+// given step offset. Devin's per-step metrics report prompt_tokens inclusive
+// of cache reads, so fresh input is prompt_tokens - cached_tokens.
+func (a *Agent) CalculateTokens(data []byte, offset int) (protocol.TokenUsageResponse, error) {
+	t, err := parseTranscript(data)
+	if err != nil {
+		return protocol.TokenUsageResponse{}, err
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	usage := protocol.TokenUsageResponse{}
+	for i := offset; i < len(t.Steps); i++ {
+		var info atifStepInfo
+		if err := json.Unmarshal(t.Steps[i], &info); err != nil || info.Metrics == nil {
+			continue
+		}
+		fresh := info.Metrics.PromptTokens - info.Metrics.CachedTokens
+		if fresh < 0 {
+			fresh = 0
+		}
+		usage.InputTokens += fresh
+		usage.CacheReadTokens += info.Metrics.CachedTokens
+		usage.OutputTokens += info.Metrics.CompletionTokens
+		usage.APICallCount++
+	}
+	return usage, nil
+}
+
+// ChunkTranscript splits an ATIF transcript by distributing steps across
+// chunks, preserving the envelope (schema_version, session_id, agent,
+// final_metrics) in each chunk so every chunk is independently parseable.
+func (a *Agent) ChunkTranscript(content []byte, maxSize int) ([][]byte, error) {
+	if maxSize <= 0 {
+		return nil, fmt.Errorf("invalid max size %d", maxSize)
+	}
+	t, err := parseTranscript(content)
+	if err != nil {
+		// Not an ATIF document (e.g. protocol round-trip data): chunk by raw
+		// size so the content still survives storage limits losslessly.
+		return chunkBytes(content, maxSize), nil //nolint:nilerr // fallback path, not an error
+	}
+	if len(t.Steps) == 0 || len(content) <= maxSize {
+		return [][]byte{content}, nil
+	}
+
+	envelope := ATIFTranscript{
+		SchemaVersion: t.SchemaVersion,
+		SessionID:     t.SessionID,
+		Agent:         t.Agent,
+		FinalMetrics:  t.FinalMetrics,
+	}
+	envelopeBytes, err := json.Marshal(envelope)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal envelope for chunking: %w", err)
+	}
+	baseSize := len(envelopeBytes) + len(`,"steps":[]`)
+
+	var chunks [][]byte
+	var current []ATIFStep
+	currentSize := baseSize
+
+	flush := func() error {
+		if len(current) == 0 {
+			return nil
+		}
+		chunk := envelope
+		chunk.Steps = current
+		data, err := json.Marshal(chunk)
+		if err != nil {
+			return fmt.Errorf("failed to marshal chunk: %w", err)
+		}
+		chunks = append(chunks, data)
+		current = nil
+		currentSize = baseSize
+		return nil
+	}
+
+	for _, step := range t.Steps {
+		stepSize := len(step) + 1 // +1 for comma separator
+		if currentSize+stepSize > maxSize && len(current) > 0 {
+			if err := flush(); err != nil {
+				return nil, err
+			}
+		}
+		current = append(current, step)
+		currentSize += stepSize
+	}
+	if err := flush(); err != nil {
+		return nil, err
+	}
+	if len(chunks) == 0 {
+		return nil, errors.New("failed to create any chunks")
+	}
+	return chunks, nil
+}
+
+// chunkBytes splits content into maxSize-byte chunks (non-ATIF fallback).
+func chunkBytes(content []byte, maxSize int) [][]byte {
+	if len(content) <= maxSize {
+		return [][]byte{content}
+	}
+	var chunks [][]byte
+	for len(content) > maxSize {
+		chunks = append(chunks, content[:maxSize])
+		content = content[maxSize:]
+	}
+	return append(chunks, content)
+}
+
+// ReassembleTranscript merges ATIF chunks by concatenating their step arrays.
+// The envelope is taken from the first chunk.
+func (a *Agent) ReassembleTranscript(chunks [][]byte) ([]byte, error) {
+	if len(chunks) == 0 {
+		return nil, errors.New("no chunks to reassemble")
+	}
+	if _, err := parseTranscript(chunks[0]); err != nil {
+		// Raw-size chunks from the non-ATIF fallback: concatenate.
+		var out []byte
+		for _, chunk := range chunks {
+			out = append(out, chunk...)
+		}
+		return out, nil
+	}
+	var result *ATIFTranscript
+	for i, chunk := range chunks {
+		t, err := parseTranscript(chunk)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse chunk %d: %w", i, err)
+		}
+		if i == 0 {
+			result = t
+			continue
+		}
+		result.Steps = append(result.Steps, t.Steps...)
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal reassembled transcript: %w", err)
+	}
+	return data, nil
+}

--- a/agents/entire-agent-devin/internal/devin/transcript_test.go
+++ b/agents/entire-agent-devin/internal/devin/transcript_test.go
@@ -1,0 +1,269 @@
+package devin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// sampleTranscript mirrors the live-captured ATIF-v1.7 shape (see AGENT.md):
+// system/user/agent steps, tool_calls on agent steps, per-step metrics.
+const sampleTranscript = `{
+  "schema_version": "ATIF-v1.7",
+  "session_id": "almond-cylinder",
+  "agent": {"name": "devin", "version": "3000.2.17", "model_name": "SWE-1.7", "extra": {"backend": "Windsurf"}},
+  "steps": [
+    {"step_id": 1, "timestamp": "2026-07-27T11:59:51Z", "source": "system", "message": "system prompt"},
+    {"step_id": 2, "timestamp": "2026-07-27T11:59:51Z", "source": "user", "message": "Append a line to hello.txt"},
+    {"step_id": 3, "timestamp": "2026-07-27T12:01:40Z", "source": "agent", "message": "", "model_name": "SWE-1.7",
+     "tool_calls": [{"tool_call_id": "read_0", "function_name": "read", "arguments": {"file_path": "/repo/hello.txt"}}],
+     "metrics": {"prompt_tokens": 12431, "completion_tokens": 393, "cached_tokens": 10917}},
+    {"step_id": 4, "timestamp": "2026-07-27T12:01:45Z", "source": "agent", "message": "", "model_name": "SWE-1.7",
+     "tool_calls": [{"tool_call_id": "edit_0", "function_name": "edit", "arguments": {"file_path": "/repo/hello.txt", "old_string": "a", "new_string": "b"}},
+                    {"tool_call_id": "write_0", "function_name": "write", "arguments": {"file_path": "/repo/new.txt", "content": "x"}}],
+     "metrics": {"prompt_tokens": 12896, "completion_tokens": 254, "cached_tokens": 12430}},
+    {"step_id": 5, "timestamp": "2026-07-27T12:01:50Z", "source": "agent", "message": "Done.", "model_name": "SWE-1.7",
+     "metrics": {"prompt_tokens": 13231, "completion_tokens": 49, "cached_tokens": 12895}}
+  ],
+  "final_metrics": {"total_prompt_tokens": 38558, "total_completion_tokens": 696, "total_cached_tokens": 36242, "total_steps": 5}
+}`
+
+func writeSampleTranscript(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "almond-cylinder.json")
+	if err := os.WriteFile(path, []byte(sampleTranscript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestGetTranscriptPosition(t *testing.T) {
+	t.Parallel()
+	d := New()
+
+	path := writeSampleTranscript(t)
+	pos, err := d.GetTranscriptPosition(path)
+	if err != nil {
+		t.Fatalf("GetTranscriptPosition: %v", err)
+	}
+	if pos != 5 {
+		t.Errorf("position = %d, want 5", pos)
+	}
+
+	if pos, err := d.GetTranscriptPosition(filepath.Join(t.TempDir(), "missing.json")); err != nil || pos != 0 {
+		t.Errorf("missing file: pos = %d, err = %v; want 0, nil", pos, err)
+	}
+	if pos, err := d.GetTranscriptPosition(""); err != nil || pos != 0 {
+		t.Errorf("empty path: pos = %d, err = %v; want 0, nil", pos, err)
+	}
+}
+
+func TestExtractModifiedFiles_Offsets(t *testing.T) {
+	t.Parallel()
+	d := New()
+	path := writeSampleTranscript(t)
+
+	// From the start: edit + write files, deduplicated; read is not a modification.
+	files, pos, err := d.ExtractModifiedFiles(path, 0)
+	if err != nil {
+		t.Fatalf("ExtractModifiedFilesFromOffset: %v", err)
+	}
+	if pos != 5 {
+		t.Errorf("position = %d, want 5", pos)
+	}
+	want := []string{"/repo/hello.txt", "/repo/new.txt"}
+	if len(files) != len(want) || files[0] != want[0] || files[1] != want[1] {
+		t.Errorf("files = %v, want %v", files, want)
+	}
+
+	// From offset 4: only the final step, which has no tool calls.
+	files, _, err = d.ExtractModifiedFiles(path, 4)
+	if err != nil {
+		t.Fatalf("ExtractModifiedFilesFromOffset offset 4: %v", err)
+	}
+	if len(files) != 0 {
+		t.Errorf("files from offset 4 = %v, want none", files)
+	}
+}
+
+func TestCalculateTokens(t *testing.T) {
+	t.Parallel()
+	d := New()
+
+	usage, err := d.CalculateTokens([]byte(sampleTranscript), 0)
+	if err != nil {
+		t.Fatalf("CalculateTokenUsage: %v", err)
+	}
+	// InputTokens = sum(prompt - cached): (12431-10917)+(12896-12430)+(13231-12895) = 1514+466+336
+	if usage.InputTokens != 2316 {
+		t.Errorf("InputTokens = %d, want 2316", usage.InputTokens)
+	}
+	if usage.CacheReadTokens != 10917+12430+12895 {
+		t.Errorf("CacheReadTokens = %d, want %d", usage.CacheReadTokens, 10917+12430+12895)
+	}
+	if usage.OutputTokens != 393+254+49 {
+		t.Errorf("OutputTokens = %d, want %d", usage.OutputTokens, 393+254+49)
+	}
+	if usage.APICallCount != 3 {
+		t.Errorf("APICallCount = %d, want 3", usage.APICallCount)
+	}
+
+	// Offset past the first agent step scopes the sums.
+	usage, err = d.CalculateTokens([]byte(sampleTranscript), 3)
+	if err != nil {
+		t.Fatalf("CalculateTokenUsage offset 3: %v", err)
+	}
+	if usage.APICallCount != 2 || usage.OutputTokens != 254+49 {
+		t.Errorf("offset usage = %+v, want 2 calls, %d output", usage, 254+49)
+	}
+}
+
+func TestChunkAndReassembleTranscript(t *testing.T) {
+	t.Parallel()
+	d := New()
+	// Small maxSize forces one step per chunk.
+	chunks, err := d.ChunkTranscript([]byte(sampleTranscript), 900)
+	if err != nil {
+		t.Fatalf("ChunkTranscript: %v", err)
+	}
+	if len(chunks) < 2 {
+		t.Fatalf("chunks = %d, want >= 2", len(chunks))
+	}
+
+	reassembled, err := d.ReassembleTranscript(chunks)
+	if err != nil {
+		t.Fatalf("ReassembleTranscript: %v", err)
+	}
+	rt, err := parseTranscript(reassembled)
+	if err != nil {
+		t.Fatalf("parse reassembled: %v", err)
+	}
+	if len(rt.Steps) != 5 {
+		t.Errorf("reassembled steps = %d, want 5", len(rt.Steps))
+	}
+	if rt.SessionID != "almond-cylinder" || rt.SchemaVersion != "ATIF-v1.7" {
+		t.Errorf("envelope lost: %q %q", rt.SessionID, rt.SchemaVersion)
+	}
+
+	// Reassembled transcript must still yield the same analysis results.
+	files, err := extractModifiedFiles(reassembled)
+	if err != nil {
+		t.Fatalf("ExtractModifiedFiles: %v", err)
+	}
+	if len(files) != 2 {
+		t.Errorf("files after reassembly = %v, want 2 entries", files)
+	}
+}
+
+func TestChunkTranscript_FitsInOneChunk(t *testing.T) {
+	t.Parallel()
+	d := New()
+	chunks, err := d.ChunkTranscript([]byte(sampleTranscript), 1<<20)
+	if err != nil {
+		t.Fatalf("ChunkTranscript: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Errorf("chunks = %d, want 1", len(chunks))
+	}
+	if string(chunks[0]) != sampleTranscript {
+		t.Error("single chunk should be the original content, unmodified")
+	}
+}
+
+func TestReassembleTranscript_Empty(t *testing.T) {
+	t.Parallel()
+	d := New()
+	if _, err := d.ReassembleTranscript(nil); err == nil {
+		t.Error("expected error for empty chunks")
+	}
+}
+
+func TestPrepareTranscript_FastPaths(t *testing.T) {
+	t.Parallel()
+	d := New()
+	// Fresh file: returns immediately.
+	fresh := writeSampleTranscript(t)
+	start := time.Now()
+	if err := d.PrepareTranscript(fresh); err != nil {
+		t.Fatalf("PrepareTranscript fresh: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("fresh file took %v, want immediate return", elapsed)
+	}
+
+	// Stale file (old mtime): returns immediately, no flush is coming.
+	stale := writeSampleTranscript(t)
+	old := time.Now().Add(-10 * time.Minute)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatal(err)
+	}
+	start = time.Now()
+	if err := d.PrepareTranscript(stale); err != nil {
+		t.Fatalf("PrepareTranscript stale: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("stale file took %v, want immediate return", elapsed)
+	}
+
+	// Empty ref: no-op.
+	if err := d.PrepareTranscript(""); err != nil {
+		t.Fatalf("PrepareTranscript empty ref: %v", err)
+	}
+}
+
+func TestPrepareTranscript_MaterializesStubWhenMissing(t *testing.T) {
+	t.Parallel()
+	d := New()
+	path := filepath.Join(t.TempDir(), "brisk-otter.json")
+
+	if err := d.PrepareTranscript(path); err != nil {
+		t.Fatalf("PrepareTranscript: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("stub transcript was not materialized: %v", err)
+	}
+	stub, err := parseTranscript(data)
+	if err != nil {
+		t.Fatalf("stub is not valid ATIF: %v", err)
+	}
+	if stub.SessionID != "brisk-otter" {
+		t.Errorf("stub session_id = %q, want brisk-otter", stub.SessionID)
+	}
+	if len(stub.Steps) != 0 {
+		t.Errorf("stub steps = %d, want 0", len(stub.Steps))
+	}
+
+	// The stub must satisfy the analyzer surface too.
+	pos, err := d.GetTranscriptPosition(path)
+	if err != nil || pos != 0 {
+		t.Errorf("stub position = %d, %v; want 0, nil", pos, err)
+	}
+}
+
+func TestPrepareTranscript_WaitsForFlush(t *testing.T) {
+	t.Parallel()
+	d := New()
+	path := filepath.Join(t.TempDir(), "late.json")
+
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		if err := os.WriteFile(path, []byte(sampleTranscript), 0o600); err != nil {
+			panic(err)
+		}
+	}()
+
+	start := time.Now()
+	if err := d.PrepareTranscript(path); err != nil {
+		t.Fatalf("PrepareTranscript: %v", err)
+	}
+	elapsed := time.Since(start)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatal("file was not written by the goroutine")
+	}
+	if elapsed >= 2*time.Second {
+		t.Errorf("waited full timeout (%v) despite flush landing at 150ms", elapsed)
+	}
+}

--- a/agents/entire-agent-devin/internal/devin/types.go
+++ b/agents/entire-agent-devin/internal/devin/types.go
@@ -1,0 +1,95 @@
+package devin
+
+import "encoding/json"
+
+// HookMatcher matches hooks to tool-name regex patterns.
+// Same shape as Claude Code's matcher config — Devin's hooks.v1.json uses the
+// Claude Code hook format, where matcher is a regex over tool_name.
+type HookMatcher struct {
+	Matcher string      `json:"matcher"`
+	Hooks   []HookEntry `json:"hooks"`
+}
+
+// HookEntry represents a single hook command.
+type HookEntry struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+}
+
+// sessionInfoRaw is the JSON payload of SessionStart/Stop/SessionEnd hooks.
+// Devin payloads carry no transcript_path or cwd (verified live, 3000.2.17);
+// the transcript location is derived from session_id instead.
+type sessionInfoRaw struct {
+	SessionID string `json:"session_id"`
+	// Source is how the session started (SessionStart only, e.g. "startup").
+	Source string `json:"source,omitempty"`
+	// Reason is why the session ended (SessionEnd only, e.g. "session_complete").
+	Reason string `json:"reason,omitempty"`
+}
+
+// userPromptSubmitRaw is the JSON payload of UserPromptSubmit hooks.
+type userPromptSubmitRaw struct {
+	SessionID string `json:"session_id"`
+	Prompt    string `json:"prompt"`
+	PromptID  string `json:"prompt_id"`
+}
+
+// Devin tool names that create or modify files. Devin uses lowercase tool
+// names (write/edit), unlike Claude Code's Write/Edit.
+const (
+	ToolWrite        = "write"
+	ToolEdit         = "edit"
+	ToolNotebookEdit = "notebook_edit"
+)
+
+// isFileModificationTool reports whether a Devin tool name modifies files.
+func isFileModificationTool(name string) bool {
+	return name == ToolWrite || name == ToolEdit || name == ToolNotebookEdit
+}
+
+// --- ATIF transcript format (schema_version ATIF-v1.7) ---
+
+// ATIFTranscript is Devin's native transcript document, written to
+// <data-dir>/cli/transcripts/<session_id>.json when a session run ends and by
+// `devin --export`.
+type ATIFTranscript struct {
+	SchemaVersion string          `json:"schema_version"`
+	SessionID     string          `json:"session_id"`
+	Agent         json.RawMessage `json:"agent,omitempty"`
+	Steps         []ATIFStep      `json:"steps"`
+	FinalMetrics  json.RawMessage `json:"final_metrics,omitempty"`
+}
+
+// ATIFStep is a single trajectory step, kept raw so chunking and reassembly
+// are lossless.
+type ATIFStep = json.RawMessage
+
+// atifStepInfo is the subset of step fields this integration reads.
+type atifStepInfo struct {
+	Source    string         `json:"source"`
+	Message   string         `json:"message"`
+	ModelName string         `json:"model_name,omitempty"`
+	ToolCalls []atifToolCall `json:"tool_calls,omitempty"`
+	Metrics   *atifMetrics   `json:"metrics,omitempty"`
+}
+
+// atifToolCall is a tool invocation recorded on an agent step.
+type atifToolCall struct {
+	FunctionName string          `json:"function_name"`
+	Arguments    json.RawMessage `json:"arguments"`
+}
+
+// fileToolInput is the tool_calls arguments shape shared by Devin's
+// file-modification tools: an absolute file_path plus tool-specific fields
+// this integration doesn't need.
+type fileToolInput struct {
+	FilePath string `json:"file_path"`
+}
+
+// atifMetrics is per-step token accounting. prompt_tokens includes cache
+// reads (verified: cached_tokens ≈ prompt_tokens of the previous step).
+type atifMetrics struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	CachedTokens     int `json:"cached_tokens"`
+}

--- a/agents/entire-agent-devin/internal/protocol/protocol.go
+++ b/agents/entire-agent-devin/internal/protocol/protocol.go
@@ -1,0 +1,363 @@
+package protocol
+
+import (
+	"encoding/json"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type sessionDirResolver interface {
+	GetSessionDir(repoPath string) (string, error)
+}
+
+type sessionFileResolver interface {
+	ResolveSessionFile(sessionDir, sessionID string) string
+}
+
+type sessionIDProvider interface {
+	GetSessionID(*HookInputJSON) string
+}
+
+type sessionReader interface {
+	ReadSession(*HookInputJSON) (AgentSessionJSON, error)
+}
+
+type sessionWriter interface {
+	WriteSession(AgentSessionJSON) error
+}
+
+type transcriptReader interface {
+	ReadTranscript(sessionRef string) ([]byte, error)
+}
+
+type transcriptChunker interface {
+	ChunkTranscript(content []byte, maxSize int) ([][]byte, error)
+	ReassembleTranscript(chunks [][]byte) ([]byte, error)
+}
+
+type transcriptCompactor interface {
+	CompactTranscript(sessionRef string) (CompactTranscriptResponse, error)
+}
+
+type transcriptPreparer interface {
+	PrepareTranscript(sessionRef string) error
+}
+
+type resumeFormatter interface {
+	FormatResumeCommand(sessionID string) string
+}
+
+type hookParser interface {
+	ParseHook(hookName string, input []byte) (*EventJSON, error)
+	InstallHooks(localDev bool, force bool) (int, error)
+	UninstallHooks() error
+	AreHooksInstalled() bool
+}
+
+type transcriptAnalyzer interface {
+	GetTranscriptPosition(path string) (int, error)
+	ExtractModifiedFiles(path string, offset int) ([]string, int, error)
+	ExtractPrompts(sessionRef string, offset int) ([]string, error)
+	ExtractSummary(sessionRef string) (string, bool, error)
+}
+
+type tokenCalculator interface {
+	CalculateTokens(data []byte, offset int) (TokenUsageResponse, error)
+}
+
+func WriteJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(v)
+}
+
+func ReadJSON[T any](r io.Reader) (*T, error) {
+	var value T
+	if err := json.NewDecoder(r).Decode(&value); err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
+func RepoRoot() string {
+	if root := os.Getenv("ENTIRE_REPO_ROOT"); root != "" {
+		return root
+	}
+	root, _ := os.Getwd()
+	return root
+}
+
+func HandleGetSessionID(stdin io.Reader, stdout io.Writer, provider sessionIDProvider) error {
+	input, err := ReadJSON[HookInputJSON](stdin)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionIDResponse{SessionID: provider.GetSessionID(input)})
+}
+
+func HandleGetSessionDir(args []string, stdout io.Writer, resolver sessionDirResolver) error {
+	fs := flag.NewFlagSet("get-session-dir", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	repoPath := fs.String("repo-path", "", "repo path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	sessionDir, err := resolver.GetSessionDir(*repoPath)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionDirResponse{SessionDir: sessionDir})
+}
+
+func HandleResolveSessionFile(args []string, stdout io.Writer, resolver sessionFileResolver) error {
+	fs := flag.NewFlagSet("resolve-session-file", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionDir := fs.String("session-dir", "", "session dir")
+	sessionID := fs.String("session-id", "", "session id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionFileResponse{SessionFile: resolver.ResolveSessionFile(*sessionDir, *sessionID)})
+}
+
+func HandleReadSession(stdin io.Reader, stdout io.Writer, reader sessionReader) error {
+	input, err := ReadJSON[HookInputJSON](stdin)
+	if err != nil {
+		return err
+	}
+	session, err := reader.ReadSession(input)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, session)
+}
+
+func HandleWriteSession(stdin io.Reader, writer sessionWriter) error {
+	session, err := ReadJSON[AgentSessionJSON](stdin)
+	if err != nil {
+		return err
+	}
+	return writer.WriteSession(*session)
+}
+
+func HandleReadTranscript(args []string, stdout io.Writer, reader transcriptReader) error {
+	fs := flag.NewFlagSet("read-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	data, err := reader.ReadTranscript(*sessionRef)
+	if err != nil {
+		return err
+	}
+	_, err = stdout.Write(data)
+	return err
+}
+
+func HandleChunkTranscript(args []string, stdin io.Reader, stdout io.Writer, chunker transcriptChunker) error {
+	fs := flag.NewFlagSet("chunk-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	maxSize := fs.Int("max-size", 0, "max size")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	content, err := io.ReadAll(stdin)
+	if err != nil {
+		return err
+	}
+	chunks, err := chunker.ChunkTranscript(content, *maxSize)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ChunkResponse{Chunks: chunks})
+}
+
+func HandleReassembleTranscript(stdin io.Reader, stdout io.Writer, chunker transcriptChunker) error {
+	input, err := ReadJSON[ChunkResponse](stdin)
+	if err != nil {
+		return err
+	}
+	data, err := chunker.ReassembleTranscript(input.Chunks)
+	if err != nil {
+		return err
+	}
+	_, err = stdout.Write(data)
+	return err
+}
+
+func HandleCompactTranscript(args []string, stdout io.Writer, compactor transcriptCompactor) error {
+	fs := flag.NewFlagSet("compact-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	compacted, err := compactor.CompactTranscript(*sessionRef)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, compacted)
+}
+
+func HandlePrepareTranscript(args []string, preparer transcriptPreparer) error {
+	fs := flag.NewFlagSet("prepare-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return preparer.PrepareTranscript(*sessionRef)
+}
+
+func HandleFormatResumeCommand(args []string, stdout io.Writer, formatter resumeFormatter) error {
+	fs := flag.NewFlagSet("format-resume-command", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionID := fs.String("session-id", "", "session id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ResumeCommandResponse{Command: formatter.FormatResumeCommand(*sessionID)})
+}
+
+func readStdinWithTimeout(r io.Reader, timeout time.Duration) ([]byte, error) {
+	type result struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		data, err := io.ReadAll(r)
+		ch <- result{data, err}
+	}()
+	select {
+	case res := <-ch:
+		return res.data, res.err
+	case <-time.After(timeout):
+		return nil, nil
+	}
+}
+
+func HandleParseHook(args []string, stdin io.Reader, stdout io.Writer, parser hookParser) error {
+	fs := flag.NewFlagSet("parse-hook", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	hook := fs.String("hook", "", "hook name")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	input, err := readStdinWithTimeout(stdin, 100*time.Millisecond)
+	if err != nil {
+		return err
+	}
+	event, err := parser.ParseHook(*hook, input)
+	if err != nil {
+		return err
+	}
+	if event == nil {
+		_, err = io.WriteString(stdout, "null\n")
+		return err
+	}
+	return WriteJSON(stdout, event)
+}
+
+func HandleInstallHooks(args []string, stdout io.Writer, parser hookParser) error {
+	fs := flag.NewFlagSet("install-hooks", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	localDev := fs.Bool("local-dev", false, "local dev")
+	force := fs.Bool("force", false, "force")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	count, err := parser.InstallHooks(*localDev, *force)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, HooksInstalledCountResponse{HooksInstalled: count})
+}
+
+func HandleGetTranscriptPosition(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("get-transcript-position", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	path := fs.String("path", "", "path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	position, err := analyzer.GetTranscriptPosition(*path)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, TranscriptPositionResponse{Position: position})
+}
+
+func HandleExtractModifiedFiles(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-modified-files", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	path := fs.String("path", "", "path")
+	offset := fs.Int("offset", 0, "offset")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	files, currentPosition, err := analyzer.ExtractModifiedFiles(*path, *offset)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractFilesResponse{Files: files, CurrentPosition: currentPosition})
+}
+
+func HandleExtractPrompts(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-prompts", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	offset := fs.Int("offset", 0, "offset")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	prompts, err := analyzer.ExtractPrompts(*sessionRef, *offset)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractPromptsResponse{Prompts: prompts})
+}
+
+func HandleExtractSummary(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-summary", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	summary, hasSummary, err := analyzer.ExtractSummary(*sessionRef)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractSummaryResponse{Summary: summary, HasSummary: hasSummary})
+}
+
+func HandleCalculateTokens(args []string, stdin io.Reader, stdout io.Writer, calculator tokenCalculator) error {
+	fs := flag.NewFlagSet("calculate-tokens", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	offset := fs.Int("offset", 0, "offset")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	data, err := io.ReadAll(stdin)
+	if err != nil {
+		return err
+	}
+	usage, err := calculator.CalculateTokens(data, *offset)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, usage)
+}
+
+func DefaultSessionDir(repoPath string) string {
+	return filepath.Join(repoPath, ".entire", "tmp")
+}
+
+func ResolveSessionFile(sessionDir, sessionID string) string {
+	return filepath.Join(sessionDir, sessionID+".json")
+}

--- a/agents/entire-agent-devin/internal/protocol/types.go
+++ b/agents/entire-agent-devin/internal/protocol/types.go
@@ -1,0 +1,139 @@
+package protocol
+
+import "encoding/json"
+
+const ProtocolVersion = 1
+
+type DeclaredCapabilities struct {
+	Hooks                  bool `json:"hooks"`
+	TranscriptAnalyzer     bool `json:"transcript_analyzer"`
+	TranscriptPreparer     bool `json:"transcript_preparer"`
+	TokenCalculator        bool `json:"token_calculator"`
+	CompactTranscript      bool `json:"compact_transcript"`
+	TextGenerator          bool `json:"text_generator"`
+	HookResponseWriter     bool `json:"hook_response_writer"`
+	SubagentAwareExtractor bool `json:"subagent_aware_extractor"`
+	UsesTerminal           bool `json:"uses_terminal"`
+}
+
+type InfoResponse struct {
+	ProtocolVersion int                  `json:"protocol_version"`
+	Name            string               `json:"name"`
+	Type            string               `json:"type"`
+	Description     string               `json:"description"`
+	IsPreview       bool                 `json:"is_preview"`
+	ProtectedDirs   []string             `json:"protected_dirs"`
+	ProtectedFiles  []string             `json:"protected_files,omitempty"`
+	HookNames       []string             `json:"hook_names"`
+	Capabilities    DeclaredCapabilities `json:"capabilities"`
+}
+
+type DetectResponse struct {
+	Present bool `json:"present"`
+}
+
+type SessionIDResponse struct {
+	SessionID string `json:"session_id"`
+}
+
+type SessionDirResponse struct {
+	SessionDir string `json:"session_dir"`
+}
+
+type SessionFileResponse struct {
+	SessionFile string `json:"session_file"`
+}
+
+type ChunkResponse struct {
+	Chunks [][]byte `json:"chunks"`
+}
+
+type ResumeCommandResponse struct {
+	Command string `json:"command"`
+}
+
+type HooksInstalledCountResponse struct {
+	HooksInstalled int `json:"hooks_installed"`
+}
+
+type AreHooksInstalledResponse struct {
+	Installed bool `json:"installed"`
+}
+
+type TranscriptPositionResponse struct {
+	Position int `json:"position"`
+}
+
+type ExtractFilesResponse struct {
+	Files           []string `json:"files"`
+	CurrentPosition int      `json:"current_position"`
+}
+
+type ExtractPromptsResponse struct {
+	Prompts []string `json:"prompts"`
+}
+
+type ExtractSummaryResponse struct {
+	Summary    string `json:"summary"`
+	HasSummary bool   `json:"has_summary"`
+}
+
+type TokenUsageResponse struct {
+	InputTokens         int `json:"input_tokens"`
+	CacheCreationTokens int `json:"cache_creation_tokens"`
+	CacheReadTokens     int `json:"cache_read_tokens"`
+	OutputTokens        int `json:"output_tokens"`
+	APICallCount        int `json:"api_call_count"`
+}
+
+type CompactTranscriptResponse struct {
+	Transcript string                       `json:"transcript"`
+	Assets     []CompactTranscriptAssetJSON `json:"assets,omitempty"`
+}
+
+type CompactTranscriptAssetJSON struct {
+	Name      string `json:"name"`
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
+}
+
+type AgentSessionJSON struct {
+	SessionID     string   `json:"session_id"`
+	AgentName     string   `json:"agent_name"`
+	RepoPath      string   `json:"repo_path"`
+	SessionRef    string   `json:"session_ref"`
+	StartTime     string   `json:"start_time"`
+	NativeData    []byte   `json:"native_data"`
+	ModifiedFiles []string `json:"modified_files"`
+	NewFiles      []string `json:"new_files"`
+	DeletedFiles  []string `json:"deleted_files"`
+}
+
+type HookInputJSON struct {
+	HookType   string                 `json:"hook_type"`
+	SessionID  string                 `json:"session_id"`
+	SessionRef string                 `json:"session_ref"`
+	Timestamp  string                 `json:"timestamp"`
+	UserPrompt string                 `json:"user_prompt,omitempty"`
+	ToolName   string                 `json:"tool_name,omitempty"`
+	ToolUseID  string                 `json:"tool_use_id,omitempty"`
+	ToolInput  json.RawMessage        `json:"tool_input,omitempty"`
+	RawData    map[string]interface{} `json:"raw_data,omitempty"`
+}
+
+type EventJSON struct {
+	Type              int               `json:"type"`
+	SessionID         string            `json:"session_id"`
+	PreviousSessionID string            `json:"previous_session_id,omitempty"`
+	SessionRef        string            `json:"session_ref,omitempty"`
+	Prompt            string            `json:"prompt,omitempty"`
+	Model             string            `json:"model,omitempty"`
+	Timestamp         string            `json:"timestamp,omitempty"`
+	ToolUseID         string            `json:"tool_use_id,omitempty"`
+	SubagentID        string            `json:"subagent_id,omitempty"`
+	ToolInput         json.RawMessage   `json:"tool_input,omitempty"`
+	SubagentType      string            `json:"subagent_type,omitempty"`
+	TaskDescription   string            `json:"task_description,omitempty"`
+	ResponseMessage   string            `json:"response_message,omitempty"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+}

--- a/agents/entire-agent-devin/mise.toml
+++ b/agents/entire-agent-devin/mise.toml
@@ -1,0 +1,10 @@
+[tools]
+go = "1.26.0"
+
+[tasks.build]
+description = "Build the entire-agent-devin binary"
+run = "go build -o entire-agent-devin ./cmd/entire-agent-devin"
+
+[tasks.test]
+description = "Run unit tests"
+run = "go test ./..."

--- a/e2e/agents/devin.go
+++ b/e2e/agents/devin.go
@@ -1,0 +1,113 @@
+package agents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func init() {
+	if os.Getenv("DEVIN_E2E") != "1" || os.Getenv("E2E_AGENT") != "devin" {
+		return
+	}
+	Register(&Devin{})
+	RegisterGate("devin", 1)
+}
+
+// Devin drives the Devin CLI ("Devin for Terminal", Cognition) for lifecycle
+// tests. Requires an authenticated `devin` binary (`devin auth login`).
+type Devin struct{}
+
+func (d *Devin) Name() string               { return "devin" }
+func (d *Devin) Binary() string             { return "devin" }
+func (d *Devin) EntireAgent() string        { return "devin" }
+func (d *Devin) PromptPattern() string      { return `>` }
+func (d *Devin) TimeoutMultiplier() float64 { return 2.0 }
+func (d *Devin) IsExternalAgent() bool      { return true }
+
+func (d *Devin) IsTransientError(out Output, _ error) bool {
+	combined := strings.ToLower(out.Stdout + out.Stderr)
+	patterns := []string{
+		"overloaded",
+		"rate limit",
+		"429",
+		"500",
+		"503",
+		"econnreset",
+		"etimedout",
+		"timeout",
+	}
+	for _, pattern := range patterns {
+		if strings.Contains(combined, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *Devin) Bootstrap() error {
+	return nil
+}
+
+func (d *Devin) RunPrompt(ctx context.Context, dir string, prompt string, opts ...Option) (Output, error) {
+	cfg := &runConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	bin, err := exec.LookPath(d.Binary())
+	if err != nil {
+		return Output{}, fmt.Errorf("%s not in PATH: %w", d.Binary(), err)
+	}
+
+	// Print mode: Devin awaits Stop hooks, writes the canonical transcript,
+	// then fires SessionEnd before exiting. Workspace trust is disabled so
+	// fresh test repos don't hang on the trust prompt.
+	args := []string{"-p", prompt, "--permission-mode", "accept-edits", "--respect-workspace-trust", "false"}
+	displayArgs := []string{"-p", fmt.Sprintf("%q", prompt), "--permission-mode", "accept-edits", "--respect-workspace-trust", "false"}
+	if cfg.Model != "" {
+		args = append(args, "--model", cfg.Model)
+		displayArgs = append(displayArgs, "--model", cfg.Model)
+	}
+
+	timeout := 3 * time.Minute
+	if cfg.PromptTimeout > 0 {
+		timeout = cfg.PromptTimeout
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	env := filterEnv(os.Environ(), "ENTIRE_TEST_TTY")
+	cmd := exec.CommandContext(runCtx, bin, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+	out := Output{
+		Command:  d.Binary() + " " + strings.Join(displayArgs, " "),
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+		ExitCode: cmd.ProcessState.ExitCode(),
+	}
+	if runErr != nil && errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+		return out, fmt.Errorf("devin prompt timed out after %s", timeout)
+	}
+	return out, runErr
+}
+
+func (d *Devin) StartSession(context.Context, string) (Session, error) {
+	return nil, nil
+}


### PR DESCRIPTION
## Summary

Adds **`entire-agent-devin`** — Devin CLI ("Devin for Terminal", Cognition) support via the external agent protocol. This is the external-agent port of entireio/cli#1864, moved here per @blackgirlbytes' suggestion on that PR. The behavioral research behind it was verified live against `devin 3000.2.17` (hook payload captures, transcript format, flush timing, resume semantics) and is documented in [`agents/entire-agent-devin/AGENT.md`](agents/entire-agent-devin/AGENT.md).

## How it works

- **Hooks** — Devin natively supports Claude Code-format hooks; the agent installs `SessionStart` / `UserPromptSubmit` / `Stop` / `SessionEnd` entries into `.devin/hooks.v1.json` (the hooks object is the whole file), preserving user hook entries on round-trip.
- **Sessions** — Devin's hook payloads carry **no `transcript_path`**, so `session_ref` is derived from the word-pair session ID (`snowy-efraasia` style, the same ID `devin -r` accepts) to the canonical ATIF transcript at `~/.local/share/devin/cli/transcripts/<session_id>.json` (`%APPDATA%\devin\cli\transcripts` on Windows, XDG honored).
- **Transcript analysis** — ATIF-v1.7 `steps` drive position, modified-file extraction (`write`/`edit`/`notebook_edit` tool calls), user prompts, and token usage from per-step `metrics` (`prompt_tokens` includes cache reads, so fresh input = prompt − cached).
- **Flush timing** — Devin writes its transcript when a session run ends, not per turn. `prepare-transcript` polls for the post-Stop flush (print mode) and otherwise materializes a minimal valid ATIF stub so mid-session checkpoints proceed; the first condensation after the session ends captures the complete transcript.
- **Capabilities**: `hooks`, `transcript_analyzer`, `transcript_preparer`, `token_calculator`, `uses_terminal`.

## Verification

- **Protocol compliance**: `external-agents-tests verify` — all five suites pass (mandatory, hooks, transcript, optional, subagent).
- **Unit tests**: hook install/uninstall round-trip and idempotency, live-captured payload parsing, ATIF analysis/token math, chunk/reassemble round-trip, stub materialization. `golangci-lint` clean with the repo config.
- **Live lifecycle** (stock mainline `entire` + authenticated `devin 3000.2.17`): discovery via `external_agents: true` → `entire enable --agent devin` installs hooks → real print-mode session → session tracked as `Devin` with prompt and derived transcript path → `git commit` receives the `Entire-Checkpoint` trailer → `entire/checkpoints/v1` holds the complete 10-step ATIF transcript, `files_touched: [proof.py]`, and real token usage (input 2468 / cache-read 22656 / output 246 / 2 API calls).
- **e2e adapter**: `e2e/agents/devin.go` drives `devin -p` (gated behind `DEVIN_E2E=1`; needs an authenticated `devin` binary, so it can't run in shared CI without a secret).

## Notes for maintainers

- Devin loads `.claude/settings.json` hooks by default, so in a repo where Entire is enabled for **claude-code**, Devin sessions cross-fire `entire hooks claude-code …` with Devin payloads (no transcript_path → the ownership guard fails open). A reliable guard is possible in entireio/cli (`DEVIN_PROJECT_DIR` set + `CLAUDE_PROJECT_DIR` unset ⇒ Devin-origin); that can't live in an external agent. Happy to send that as a small cli PR if wanted — until then the README documents `read_config_from.claude=false` as the workaround.
- The in-tree prototype delivered live per-tool file tracking via Devin's `PostToolUse` hook (`ToolUse` events with `ModifiedFiles`). The external protocol's Event object doesn't carry `modified_files`, so that feature isn't portable — file detection falls back to git-status + ATIF extraction, which the live test shows is sufficient. Extending the protocol's Event with `modified_files` would restore parity for all external agents.

Closes the intent of entireio/cli#1864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)