### PR TITLE
feat: add entire-agent-gemini for Gemini CLI integration

### DIFF
--- a/agents/entire-agent-gemini/.gitignore
+++ b/agents/entire-agent-gemini/.gitignore
@@ -1,0 +1,4 @@
+entire-agent-gemini
+entire-agent-gemini.exe
+*.test
+*.out

--- a/agents/entire-agent-gemini/AGENT.md
+++ b/agents/entire-agent-gemini/AGENT.md
@@ -1,0 +1,22 @@
+# entire-agent-gemini
+
+External agent for Gemini CLI integration with Entire.
+
+## Build
+
+```bash
+go build -o entire-agent-gemini ./cmd/entire-agent-gemini
+```
+
+## Test
+
+```bash
+go test ./...
+```
+
+## Protocol
+
+Implements the Entire external agent protocol v1 with:
+- Hooks (8 events: SessionStart, BeforeAgent, AfterAgent, BeforeTool, AfterTool, PreCompress, Notification, SessionEnd)
+- Transcript analysis (sidecar JSONL)
+- Compact transcript generation

--- a/agents/entire-agent-gemini/README.md
+++ b/agents/entire-agent-gemini/README.md
@@ -1,0 +1,104 @@
+# entire-agent-gemini
+
+External agent binary that teaches the Entire CLI how to work with [Gemini CLI](https://github.com/google-gemini/gemini-cli).
+
+## Capabilities
+
+| Capability          | Status                                                        |
+| ------------------- | ------------------------------------------------------------ |
+| hooks               | Yes, command hooks in `.gemini/settings.json`                |
+| transcript_analyzer | Yes, via Entire sidecar JSONL                                |
+| compact_transcript  | Yes, emits Entire compact transcript JSONL                   |
+| transcript_preparer | No                                                           |
+| token_calculator    | No                                                           |
+
+## Installation
+
+```bash
+cd agents/entire-agent-gemini
+go build -o entire-agent-gemini ./cmd/entire-agent-gemini
+cp entire-agent-gemini /usr/local/bin/
+```
+
+Or use mise:
+
+```bash
+cd agents/entire-agent-gemini
+mise run build
+```
+
+## Prerequisites
+
+- [Gemini CLI](https://github.com/google-gemini/gemini-cli) installed as `gemini` on `PATH`.
+- Gemini CLI v0.26.0+ (hooks support required).
+- `GEMINI_API_KEY` or Google account authentication configured for Gemini CLI.
+
+```bash
+npm install -g @anthropic-ai/gemini-cli
+# or
+npm install -g @google/gemini-cli
+```
+
+Set your API key:
+```bash
+export GEMINI_API_KEY=your-api-key-here
+```
+
+## Enable In A Repo
+
+```bash
+cd /path/to/repo
+entire enable --agent gemini --telemetry=false
+```
+
+This writes command hooks to `.gemini/settings.json`. Hooks call:
+
+```bash
+entire hooks gemini <hook-name>
+```
+
+The hook commands are wrapped so a missing `entire` binary never breaks a Gemini session. Existing user hook fields are preserved when Entire installs or uninstalls its entries.
+
+## Hook Events
+
+| Gemini CLI Event | Protocol Event     | Type | Description                         |
+| ---------------- | ------------------ | ---- | ----------------------------------- |
+| SessionStart     | SessionStart       | 1    | Session begins (startup, resume)    |
+| BeforeAgent      | TurnStart          | 2    | User submits prompt, before planning |
+| AfterAgent       | TurnEnd            | 3    | Agent loop ends                     |
+| BeforeTool       | (recorded)         | -    | Before a tool executes              |
+| AfterTool        | (recorded)         | -    | After a tool executes               |
+| PreCompress      | PreCompact         | 4    | Before context compression          |
+| Notification     | (recorded)         | -    | System notification                 |
+| SessionEnd       | SessionEnd         | 5    | Session ends                        |
+
+## Usage
+
+```bash
+gemini "Create hello.txt with hello world"
+git add .
+git commit -m "gemini checkpoint test"
+entire checkpoint list
+```
+
+Entire stores Gemini sidecar transcripts in a repo-scoped OS temp directory such as `/tmp/entire-gemini/<repo-hash>/<session_id>.jsonl`. A small `.entire/tmp/<session_id>.json` marker is also written so Entire's shared session persistence tooling can discover the session.
+
+## Development
+
+```bash
+mise run build
+mise run test
+external-agents-tests verify ./entire-agent-gemini
+
+cd ../../
+E2E_AGENT=gemini mise run test:e2e:lifecycle
+```
+
+## Environment Variables
+
+| Variable             | Description                                              |
+| -------------------- | -------------------------------------------------------- |
+| `GEMINI_API_KEY`     | API key for Gemini (set by user for Gemini CLI)          |
+| `GEMINI_SESSION_ID`  | Session ID (provided by Gemini CLI to hooks)             |
+| `GEMINI_CWD`         | Current working directory (provided by Gemini CLI)      |
+| `GEMINI_PROJECT_DIR` | Project root directory (provided by Gemini CLI)          |

--- a/agents/entire-agent-gemini/go.mod
+++ b/agents/entire-agent-gemini/go.mod
@@ -1,0 +1,3 @@
+module github.com/entireio/external-agents/agents/entire-agent-gemini
+
+go 1.24.0

--- a/agents/entire-agent-gemini/internal/gemini/agent.go
+++ b/agents/entire-agent-gemini/internal/gemini/agent.go
@@ -1,0 +1,135 @@
+package gemini
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/entireio/external-agents/agents/entire-agent-gemini/internal/protocol"
+)
+
+type Agent struct {
+	LookPath func(string) (string, error)
+}
+
+func New() *Agent {
+	return &Agent{LookPath: exec.LookPath}
+}
+
+func (a *Agent) Info() protocol.InfoResponse {
+	return protocol.InfoResponse{
+		ProtocolVersion: protocol.ProtocolVersion,
+		Name:            AgentName,
+		Type:            AgentType,
+		Description:     "Gemini CLI external agent integration for Entire",
+		IsPreview:       true,
+		ProtectedDirs:   []string{".gemini"},
+		HookNames: []string{
+			HookNameSessionStart,
+			HookNameBeforeAgent,
+			HookNameAfterAgent,
+			HookNameBeforeTool,
+			HookNameAfterTool,
+			HookNamePreCompress,
+			HookNameNotification,
+			HookNameSessionEnd,
+		},
+		Capabilities: protocol.DeclaredCapabilities{
+			Hooks:              true,
+			TranscriptAnalyzer: true,
+			CompactTranscript:  true,
+			UsesTerminal:       true,
+		},
+	}
+}
+
+func (a *Agent) Detect() protocol.DetectResponse {
+	lookPath := a.LookPath
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	_, err := lookPath(geminiBinary)
+	return protocol.DetectResponse{Present: err == nil}
+}
+
+func (a *Agent) GetSessionID(input *protocol.HookInputJSON) string {
+	if input != nil && strings.TrimSpace(input.SessionID) != "" {
+		return input.SessionID
+	}
+	// Gemini CLI exposes session ID via env var
+	if sid := os.Getenv("GEMINI_SESSION_ID"); sid != "" {
+		return sid
+	}
+	return stubSessionID
+}
+
+func (a *Agent) GetSessionDir(repoPath string) (string, error) {
+	if strings.TrimSpace(repoPath) == "" {
+		repoPath = protocol.RepoRoot()
+	}
+	if resolved, err := filepath.EvalSymlinks(repoPath); err == nil {
+		repoPath = resolved
+	}
+	sum := sha256.Sum256([]byte(repoPath))
+	key := hex.EncodeToString(sum[:])[:16]
+	return filepath.Join(os.TempDir(), "entire-gemini", key), nil
+}
+
+func (a *Agent) ResolveSessionFile(sessionDir, sessionID string) string {
+	if strings.TrimSpace(sessionDir) == "" {
+		sessionDir, _ = a.GetSessionDir(protocol.RepoRoot())
+	}
+	if strings.TrimSpace(sessionID) == "" {
+		sessionID = stubSessionID
+	}
+	return filepath.Join(sessionDir, safeFilename(sessionID)+".jsonl")
+}
+
+func (a *Agent) FormatResumeCommand(sessionID string) string {
+	if strings.TrimSpace(sessionID) == "" {
+		return "gemini --continue"
+	}
+	return "gemini --resume " + shellQuote(sessionID)
+}
+
+func safeFilename(s string) string {
+	r := []rune(s)
+	for i, c := range r {
+		if !isSafeFilenameRune(c) {
+			r[i] = '_'
+		}
+	}
+	return string(r)
+}
+
+func isSafeFilenameRune(r rune) bool {
+	return r == '-' || r == '_' || r == '.' ||
+		(r >= '0' && r <= '9') ||
+		(r >= 'a' && r <= 'z') ||
+		(r >= 'A' && r <= 'Z')
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	if strings.IndexFunc(value, func(r rune) bool {
+		return !isSafeShellQuoteRune(r)
+	}) == -1 {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}
+
+func isSafeShellQuoteRune(r rune) bool {
+	return r == '-' || r == '_' || r == '.' || r == ':' ||
+		(r >= '0' && r <= '9') ||
+		(r >= 'a' && r <= 'z') ||
+		(r >= 'A' && r <= 'Z')
+}
+
+var errMissingSessionRef = errors.New("session_ref or session_id is required")

--- a/agents/entire-agent-gemini/internal/gemini/agent_test.go
+++ b/agents/entire-agent-gemini/internal/gemini/agent_test.go
@@ -1,0 +1,155 @@
+package gemini
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/external-agents/agents/entire-agent-gemini/internal/protocol"
+)
+
+func TestInfo(t *testing.T) {
+	a := New()
+	info := a.Info()
+
+	if info.Name != AgentName {
+		t.Errorf("Name = %q, want %q", info.Name, AgentName)
+	}
+	if info.Type != AgentType {
+		t.Errorf("Type = %q, want %q", info.Type, AgentType)
+	}
+	if !info.Capabilities.Hooks {
+		t.Error("Hooks capability should be true")
+	}
+	if !info.Capabilities.TranscriptAnalyzer {
+		t.Error("TranscriptAnalyzer capability should be true")
+	}
+	if !info.Capabilities.CompactTranscript {
+		t.Error("CompactTranscript capability should be true")
+	}
+	if len(info.HookNames) != 8 {
+		t.Errorf("HookNames count = %d, want 8", len(info.HookNames))
+	}
+}
+
+func TestDetect(t *testing.T) {
+	a := New()
+	a.LookPath = func(name string) (string, error) {
+		if name == geminiBinary {
+			return "/usr/bin/gemini", nil
+		}
+		return "", os.ErrNotExist
+	}
+	if !a.Detect().Present {
+		t.Error("Detect should return true when gemini is on PATH")
+	}
+
+	a.LookPath = func(name string) (string, error) {
+		return "", os.ErrNotExist
+	}
+	if a.Detect().Present {
+		t.Error("Detect should return false when gemini is not on PATH")
+	}
+}
+
+func TestGetSessionIDFromInput(t *testing.T) {
+	a := New()
+	input := &protocol.HookInputJSON{SessionID: "abc-123"}
+	sid := a.GetSessionID(input)
+	if sid != "abc-123" {
+		t.Errorf("GetSessionID = %q, want abc-123", sid)
+	}
+}
+
+func TestGetSessionIDFromEnv(t *testing.T) {
+	a := New()
+	t.Setenv("GEMINI_SESSION_ID", "env-session-456")
+
+	sid := a.GetSessionID(nil)
+	if sid != "env-session-456" {
+		t.Errorf("GetSessionID(nil) = %q, want env-session-456", sid)
+	}
+}
+
+func TestGetSessionIDFallback(t *testing.T) {
+	a := New()
+	t.Setenv("GEMINI_SESSION_ID", "")
+
+	sid := a.GetSessionID(nil)
+	if sid != stubSessionID {
+		t.Errorf("GetSessionID(nil) = %q, want %q", sid, stubSessionID)
+	}
+}
+
+func TestGetSessionDir(t *testing.T) {
+	a := New()
+	dir, err := a.GetSessionDir("/home/user/myproject")
+	if err != nil {
+		t.Fatalf("GetSessionDir error: %v", err)
+	}
+	if dir == "" {
+		t.Error("GetSessionDir returned empty string")
+	}
+	if !filepath.IsAbs(dir) {
+		t.Errorf("GetSessionDir should return absolute path, got %q", dir)
+	}
+}
+
+func TestResolveSessionFile(t *testing.T) {
+	a := New()
+	path := a.ResolveSessionFile("/tmp/entire-gemini/abc123", "my-session-001")
+	expected := filepath.Join("/tmp/entire-gemini/abc123", "my-session-001.jsonl")
+	if path != expected {
+		t.Errorf("ResolveSessionFile = %q, want %q", path, expected)
+	}
+}
+
+func TestFormatResumeCommand(t *testing.T) {
+	a := New()
+	cmd := a.FormatResumeCommand("sess-123")
+	if cmd != "gemini --resume sess-123" {
+		t.Errorf("FormatResumeCommand = %q, want %q", cmd, "gemini --resume sess-123")
+	}
+
+	cmd = a.FormatResumeCommand("")
+	if cmd != "gemini --continue" {
+		t.Errorf("FormatResumeCommand(\"\") = %q, want %q", cmd, "gemini --continue")
+	}
+}
+
+func TestSafeFilename(t *testing.T) {
+	tests := []struct {
+		input  string
+		expect string
+	}{
+		{"abc-123", "abc-123"},
+		{"a b c", "a_b_c"},
+		{"hello.txt", "hello.txt"},
+		{"path/with/slashes", "path_with_slashes"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		got := safeFilename(tc.input)
+		if got != tc.expect {
+			t.Errorf("safeFilename(%q) = %q, want %q", tc.input, got, tc.expect)
+		}
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	got := shellQuote("abc-123")
+	if got != "abc-123" {
+		t.Errorf("shellQuote(abc-123) = %q, want abc-123", got)
+	}
+
+	got = shellQuote("hello world")
+	want := "'hello world'"
+	if got != want {
+		t.Errorf("shellQuote(hello world) = %q, want %q", got, want)
+	}
+
+	got = shellQuote("")
+	if got != "''" {
+		t.Errorf("shellQuote() = %q, want ''", got)
+	}
+}

--- a/agents/entire-agent-gemini/internal/gemini/compact.go
+++ b/agents/entire-agent-gemini/internal/gemini/compact.go
@@ -1,0 +1,72 @@
+package gemini
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/entireio/external-agents/agents/entire-agent-gemini/internal/protocol"
+)
+
+func (a *Agent) CompactTranscript(sessionRef string) (protocol.CompactTranscriptResponse, error) {
+	data, err := os.ReadFile(sessionRef)
+	if err != nil {
+		return protocol.CompactTranscriptResponse{}, fmt.Errorf("read transcript: %w", err)
+	}
+
+	// Parse sidecar JSONL and build compact representation
+	type compactEntry struct {
+		Event      string `json:"event"`
+		Prompt     string `json:"prompt,omitempty"`
+		Model      string `json:"model,omitempty"`
+		ToolName   string `json:"tool_name,omitempty"`
+		Response   string `json:"last_assistant_message,omitempty"`
+		Summary    string `json:"compact_summary,omitempty"`
+		TS         string `json:"ts,omitempty"`
+	}
+
+	lines := splitLines(data)
+	var entries []compactEntry
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		var rec sidecarRecord
+		if err := json.Unmarshal(line, &rec); err != nil {
+			continue
+		}
+		entries = append(entries, compactEntry{
+			Event:    rec.Event,
+			Prompt:   rec.Prompt,
+			Model:    rec.Model,
+			ToolName: rec.ToolName,
+			Response: rec.LastAssistantMessage,
+			Summary:  rec.CompactSummary,
+			TS:       rec.TS,
+		})
+	}
+
+	compact, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return protocol.CompactTranscriptResponse{}, err
+	}
+
+	return protocol.CompactTranscriptResponse{
+		Transcript: string(compact),
+	}, nil
+}
+
+func splitLines(data []byte) [][]byte {
+	var lines [][]byte
+	start := 0
+	for i, b := range data {
+		if b == '\n' {
+			lines = append(lines, data[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(data) {
+		lines = append(lines, data[start:])
+	}
+	return lines
+}

--- a/agents/entire-agent-gemini/internal/gemini/hooks.go
+++ b/agents/entire-agent-gemini/internal/gemini/hooks.go
@@ -1,0 +1,431 @@
+package gemini
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/entireio/external-agents/agents/entire-agent-gemini/internal/protocol"
+)
+
+func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, error) {
+	raw, err := parseHookInput(input)
+	if err != nil {
+		return nil, err
+	}
+	raw.HookEventName = geminiEventName(hookName, raw.HookEventName)
+	normalizeRawHook(&raw)
+
+	if err := a.appendSidecar(raw); err != nil {
+		return nil, err
+	}
+
+	sessionRef := a.sidecarPath(raw.SessionID)
+	metadata := hookMetadata(raw)
+
+	switch hookName {
+	case HookNameSessionStart:
+		return &protocol.EventJSON{
+			Type:       1,
+			SessionID:  raw.SessionID,
+			SessionRef: sessionRef,
+			Model:      raw.Model,
+			Timestamp:  raw.Timestamp,
+			Metadata:   metadata,
+		}, nil
+	case HookNameBeforeAgent:
+		if strings.TrimSpace(raw.Prompt) == "" && strings.TrimSpace(raw.UserPrompt) == "" {
+			return nil, nil
+		}
+		prompt := raw.Prompt
+		if prompt == "" {
+			prompt = raw.UserPrompt
+		}
+		return &protocol.EventJSON{
+			Type:       2,
+			SessionID:  raw.SessionID,
+			SessionRef: sessionRef,
+			Prompt:     prompt,
+			Model:      raw.Model,
+			Timestamp:  raw.Timestamp,
+			Metadata:   metadata,
+		}, nil
+	case HookNameAfterAgent:
+		return &protocol.EventJSON{
+			Type:            3,
+			SessionID:       raw.SessionID,
+			SessionRef:      sessionRef,
+			Model:           raw.Model,
+			Timestamp:       raw.Timestamp,
+			ResponseMessage: raw.LastAssistantMessage,
+			Metadata:        metadata,
+		}, nil
+	case HookNameSessionEnd:
+		return &protocol.EventJSON{
+			Type:       5,
+			SessionID:  raw.SessionID,
+			SessionRef: sessionRef,
+			Timestamp:  raw.Timestamp,
+			Metadata:   metadata,
+		}, nil
+	case HookNamePreCompress:
+		return &protocol.EventJSON{
+			Type:       4,
+			SessionID:  raw.SessionID,
+			SessionRef: sessionRef,
+			Timestamp:  raw.Timestamp,
+			Metadata:   metadata,
+		}, nil
+	default:
+		return nil, nil
+	}
+}
+
+func (a *Agent) InstallHooks(_ bool, _ bool) (int, error) {
+	repoRoot := protocol.RepoRoot()
+	settingsDir := filepath.Join(repoRoot, ".gemini")
+	settingsPath := filepath.Join(settingsDir, settingsFileName)
+
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		return 0, fmt.Errorf("create .gemini dir: %w", err)
+	}
+
+	existing := map[string]json.RawMessage{}
+	if data, err := os.ReadFile(settingsPath); err == nil {
+		_ = json.Unmarshal(data, &existing)
+	} else if !os.IsNotExist(err) {
+		return 0, fmt.Errorf("read settings: %w", err)
+	}
+
+	hooksRaw, hasHooks := existing["hooks"]
+	hooksMap := map[string]json.RawMessage{}
+	if hasHooks {
+		_ = json.Unmarshal(hooksRaw, &hooksMap)
+	}
+
+	count := 0
+	for _, spec := range hookSpecs {
+		matchers := parseMatchers(hooksMap[spec.GeminiEvent])
+		if hookExists(matchers, spec.Matcher, spec.EntryName) {
+			continue
+		}
+		entry := geminiHookEntry{
+			Type:    "command",
+			Command: hookCommand(spec.HookName),
+			Name:    spec.EntryName,
+			Timeout: 10000,
+		}
+		matchers = upsertMatcher(matchers, spec.Matcher, entry)
+		mb, _ := json.Marshal(matchers)
+		hooksMap[spec.GeminiEvent] = mb
+		count++
+	}
+
+	hooksBytes, _ := json.Marshal(hooksMap)
+	existing["hooks"] = hooksBytes
+
+	out, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		return 0, fmt.Errorf("marshal settings: %w", err)
+	}
+	out = append(out, '\n')
+	if err := os.WriteFile(settingsPath, out, 0o644); err != nil {
+		return 0, fmt.Errorf("write settings: %w", err)
+	}
+	return count, nil
+}
+
+func (a *Agent) UninstallHooks() error {
+	repoRoot := protocol.RepoRoot()
+	settingsPath := filepath.Join(repoRoot, ".gemini", settingsFileName)
+
+	data, err := os.ReadFile(settingsPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	existing := map[string]json.RawMessage{}
+	if err := json.Unmarshal(data, &existing); err != nil {
+		return err
+	}
+
+	hooksRaw, hasHooks := existing["hooks"]
+	if !hasHooks {
+		return nil
+	}
+
+	hooksMap := map[string]json.RawMessage{}
+	if err := json.Unmarshal(hooksRaw, &hooksMap); err != nil {
+		return err
+	}
+
+	for _, spec := range hookSpecs {
+		matchers := parseMatchers(hooksMap[spec.GeminiEvent])
+		filtered := make([]geminiHookMatcher, 0, len(matchers))
+		for _, m := range matchers {
+			fh := make([]geminiHookEntry, 0, len(m.Hooks))
+			for _, h := range m.Hooks {
+				if !isEntireHook(h) {
+					fh = append(fh, h)
+				}
+			}
+			if len(fh) > 0 {
+				m.Hooks = fh
+				filtered = append(filtered, m)
+			}
+		}
+		if len(filtered) == 0 {
+			delete(hooksMap, spec.GeminiEvent)
+		} else {
+			fb, _ := json.Marshal(filtered)
+			hooksMap[spec.GeminiEvent] = fb
+		}
+	}
+
+	if len(hooksMap) == 0 {
+		delete(existing, "hooks")
+	} else {
+		hb, _ := json.Marshal(hooksMap)
+		existing["hooks"] = hb
+	}
+
+	out, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		return err
+	}
+	out = append(out, '\n')
+	return os.WriteFile(settingsPath, out, 0o644)
+}
+
+func (a *Agent) AreHooksInstalled() bool {
+	repoRoot := protocol.RepoRoot()
+	settingsPath := filepath.Join(repoRoot, ".gemini", settingsFileName)
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		return false
+	}
+
+	existing := map[string]json.RawMessage{}
+	if err := json.Unmarshal(data, &existing); err != nil {
+		return false
+	}
+
+	hooksRaw, hasHooks := existing["hooks"]
+	if !hasHooks {
+		return false
+	}
+
+	hooksMap := map[string]json.RawMessage{}
+	if err := json.Unmarshal(hooksRaw, &hooksMap); err != nil {
+		return false
+	}
+
+	for _, spec := range hookSpecs {
+		matchers := parseMatchers(hooksMap[spec.GeminiEvent])
+		if !hookExists(matchers, spec.Matcher, spec.EntryName) {
+			return false
+		}
+	}
+	return true
+}
+
+// hookCommand builds the shell command that Gemini CLI will execute for each hook event.
+// The command calls `entire hooks gemini <hookName>` which the Entire CLI routes to
+// `entire-agent-gemini parse-hook --hook <hookName>`.
+func hookCommand(hookName string) string {
+	entire := "entire"
+	if path, err := exec.LookPath("entire"); err == nil && strings.TrimSpace(path) != "" {
+		entire = path
+	}
+	return fmt.Sprintf("sh -c 'if command -v %s >/dev/null 2>&1; then %s hooks gemini %s >/dev/null 2>&1 || true; fi'",
+		shellQuote(entire), shellQuote(entire), hookName)
+}
+
+func parseMatchers(raw json.RawMessage) []geminiHookMatcher {
+	if len(raw) == 0 {
+		return nil
+	}
+	var matchers []geminiHookMatcher
+	if err := json.Unmarshal(raw, &matchers); err != nil {
+		var single geminiHookMatcher
+		if err := json.Unmarshal(raw, &single); err == nil {
+			return []geminiHookMatcher{single}
+		}
+		return nil
+	}
+	return matchers
+}
+
+func hookExists(matchers []geminiHookMatcher, matcher string, entryName string) bool {
+	for _, m := range matchers {
+		if m.Matcher != matcher && matcher != "" {
+			continue
+		}
+		for _, h := range m.Hooks {
+			if h.Type == "command" && h.Name == entryName && isEntireHook(h) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func upsertMatcher(matchers []geminiHookMatcher, matcher string, entry geminiHookEntry) []geminiHookMatcher {
+	for i := range matchers {
+		if matchers[i].Matcher == matcher {
+			for j := range matchers[i].Hooks {
+				if isEntireHook(matchers[i].Hooks[j]) && matchers[i].Hooks[j].Name == entry.Name {
+					matchers[i].Hooks[j] = entry
+					return matchers
+				}
+			}
+			matchers[i].Hooks = append(matchers[i].Hooks, entry)
+			return matchers
+		}
+	}
+	return append(matchers, geminiHookMatcher{
+		Matcher: matcher,
+		Hooks:   []geminiHookEntry{entry},
+	})
+}
+
+func isEntireHook(hook geminiHookEntry) bool {
+	if strings.HasPrefix(hook.Name, "entire-") {
+		return true
+	}
+	return strings.Contains(hook.Command, "entire hooks gemini")
+}
+
+func parseHookInput(input []byte) (geminiHookInputRaw, error) {
+	var raw geminiHookInputRaw
+	if len(input) == 0 {
+		raw.SessionID = os.Getenv("GEMINI_SESSION_ID")
+		raw.CWD = os.Getenv("GEMINI_CWD")
+		return raw, nil
+	}
+	if err := json.Unmarshal(input, &raw); err != nil {
+		return raw, fmt.Errorf("parse hook input: %w", err)
+	}
+	if raw.SessionID == "" {
+		raw.SessionID = os.Getenv("GEMINI_SESSION_ID")
+	}
+	if raw.CWD == "" {
+		raw.CWD = os.Getenv("GEMINI_CWD")
+	}
+	return raw, nil
+}
+
+func geminiEventName(hookName string, existing string) string {
+	if strings.TrimSpace(existing) != "" {
+		return existing
+	}
+	for _, spec := range hookSpecs {
+		if spec.HookName == hookName {
+			return spec.GeminiEvent
+		}
+	}
+	return hookName
+}
+
+func normalizeRawHook(raw *geminiHookInputRaw) {
+	if strings.TrimSpace(raw.SessionID) == "" {
+		raw.SessionID = stubSessionID
+	}
+	if strings.TrimSpace(raw.Timestamp) == "" {
+		raw.Timestamp = time.Now().UTC().Format(time.RFC3339)
+	}
+	if strings.TrimSpace(raw.Prompt) == "" {
+		raw.Prompt = raw.UserPrompt
+	}
+}
+
+func hookMetadata(raw geminiHookInputRaw) map[string]string {
+	m := map[string]string{
+		"agent":           AgentName,
+		"hook_event_name": raw.HookEventName,
+	}
+	if raw.TranscriptPath != "" {
+		m["native_transcript_path"] = raw.TranscriptPath
+	}
+	if raw.CWD != "" {
+		m["cwd"] = raw.CWD
+	}
+	if raw.Reason != "" {
+		m["reason"] = raw.Reason
+	}
+	if raw.Source != "" {
+		m["source"] = raw.Source
+	}
+	if raw.NotificationType != "" {
+		m["notification_type"] = raw.NotificationType
+	}
+	if raw.Message != "" {
+		m["message"] = raw.Message
+	}
+	if raw.Error != "" {
+		m["error"] = raw.Error
+	}
+	if raw.ToolName != "" {
+		m["tool_name"] = raw.ToolName
+	}
+	return m
+}
+
+func (a *Agent) sidecarPath(sessionID string) string {
+	sessionDir, _ := a.GetSessionDir(protocol.RepoRoot())
+	return a.ResolveSessionFile(sessionDir, sessionID)
+}
+
+func (a *Agent) appendSidecar(raw geminiHookInputRaw) error {
+	sessionDir, _ := a.GetSessionDir(protocol.RepoRoot())
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		return err
+	}
+	path := a.ResolveSessionFile(sessionDir, raw.SessionID)
+
+	record := sidecarRecord{
+		V:                    1,
+		Agent:                AgentName,
+		Event:                raw.HookEventName,
+		SessionID:            raw.SessionID,
+		TS:                   raw.Timestamp,
+		CWD:                  raw.CWD,
+		NativeTranscriptPath: raw.TranscriptPath,
+		Prompt:               raw.Prompt,
+		Model:                raw.Model,
+		Reason:               raw.Reason,
+		Source:               raw.Source,
+		ToolName:             raw.ToolName,
+		ToolUseID:            raw.ToolUseID,
+		ToolInput:            raw.ToolInput,
+		ToolResponse:         raw.ToolResponse,
+		Error:                raw.Error,
+		ErrorDetails:         raw.ErrorDetails,
+		LastAssistantMessage: raw.LastAssistantMessage,
+		CompactSummary:       raw.CompactSummary,
+		NotificationType:     raw.NotificationType,
+		Message:              raw.Message,
+	}
+
+	data, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.Write(data)
+	return err
+}

--- a/agents/entire-agent-gemini/internal/gemini/hooks_test.go
+++ b/agents/entire-agent-gemini/internal/gemini/hooks_test.go
@@ -1,0 +1,418 @@
+package gemini
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseHookSessionStart(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	input := `{"session_id":"test-sess-001","hook_event_name":"SessionStart","timestamp":"2026-08-01T12:00:00Z","model":"gemini-2.5-pro"}`
+	event, err := a.ParseHook(HookNameSessionStart, []byte(input))
+	if err != nil {
+		t.Fatalf("ParseHook error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("event should not be nil for session-start")
+	}
+	if event.Type != 1 {
+		t.Errorf("Type = %d, want 1", event.Type)
+	}
+	if event.SessionID != "test-sess-001" {
+		t.Errorf("SessionID = %q, want test-sess-001", event.SessionID)
+	}
+	if event.Model != "gemini-2.5-pro" {
+		t.Errorf("Model = %q, want gemini-2.5-pro", event.Model)
+	}
+}
+
+func TestParseHookBeforeAgent(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	input := `{"session_id":"test-sess-001","hook_event_name":"BeforeAgent","timestamp":"2026-08-01T12:01:00Z","prompt":"Create hello.txt","model":"gemini-2.5-pro"}`
+	event, err := a.ParseHook(HookNameBeforeAgent, []byte(input))
+	if err != nil {
+		t.Fatalf("ParseHook error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("event should not be nil for before-agent with prompt")
+	}
+	if event.Type != 2 {
+		t.Errorf("Type = %d, want 2", event.Type)
+	}
+	if event.Prompt != "Create hello.txt" {
+		t.Errorf("Prompt = %q, want Create hello.txt", event.Prompt)
+	}
+}
+
+func TestParseHookBeforeAgentNoPrompt(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	input := `{"session_id":"test-sess-001","timestamp":"2026-08-01T12:01:00Z"}`
+	event, err := a.ParseHook(HookNameBeforeAgent, []byte(input))
+	if err != nil {
+		t.Fatalf("ParseHook error: %v", err)
+	}
+	if event != nil {
+		t.Error("event should be nil when no prompt")
+	}
+}
+
+func TestParseHookAfterAgent(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	input := `{"session_id":"test-sess-001","hook_event_name":"AfterAgent","timestamp":"2026-08-01T12:02:00Z","last_assistant_message":"Done!","model":"gemini-2.5-pro"}`
+	event, err := a.ParseHook(HookNameAfterAgent, []byte(input))
+	if err != nil {
+		t.Fatalf("ParseHook error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("event should not be nil for after-agent")
+	}
+	if event.Type != 3 {
+		t.Errorf("Type = %d, want 3", event.Type)
+	}
+	if event.ResponseMessage != "Done!" {
+		t.Errorf("ResponseMessage = %q, want Done!", event.ResponseMessage)
+	}
+}
+
+func TestParseHookSessionEnd(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	input := `{"session_id":"test-sess-001","hook_event_name":"SessionEnd","timestamp":"2026-08-01T12:03:00Z"}`
+	event, err := a.ParseHook(HookNameSessionEnd, []byte(input))
+	if err != nil {
+		t.Fatalf("ParseHook error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("event should not be nil for session-end")
+	}
+	if event.Type != 5 {
+		t.Errorf("Type = %d, want 5", event.Type)
+	}
+}
+
+func TestParseHookPreCompress(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	input := `{"session_id":"test-sess-001","hook_event_name":"PreCompress","timestamp":"2026-08-01T12:04:00Z"}`
+	event, err := a.ParseHook(HookNamePreCompress, []byte(input))
+	if err != nil {
+		t.Fatalf("ParseHook error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("event should not be nil for pre-compress")
+	}
+	if event.Type != 4 {
+		t.Errorf("Type = %d, want 4", event.Type)
+	}
+}
+
+func TestParseHookBeforeToolReturnsNil(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	input := `{"session_id":"test-sess-001","hook_event_name":"BeforeTool","timestamp":"2026-08-01T12:01:30Z","tool_name":"write_file"}`
+	event, err := a.ParseHook(HookNameBeforeTool, []byte(input))
+	if err != nil {
+		t.Fatalf("ParseHook error: %v", err)
+	}
+	if event != nil {
+		t.Error("BeforeTool should return nil event (recorded in sidecar only)")
+	}
+}
+
+func TestParseHookAfterToolReturnsNil(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	input := `{"session_id":"test-sess-001","hook_event_name":"AfterTool","timestamp":"2026-08-01T12:01:35Z","tool_name":"write_file"}`
+	event, err := a.ParseHook(HookNameAfterTool, []byte(input))
+	if err != nil {
+		t.Fatalf("ParseHook error: %v", err)
+	}
+	if event != nil {
+		t.Error("AfterTool should return nil event (recorded in sidecar only)")
+	}
+}
+
+func TestParseHookEmptyInput(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+	t.Setenv("GEMINI_SESSION_ID", "env-session-999")
+
+	event, err := a.ParseHook(HookNameSessionStart, nil)
+	if err != nil {
+		t.Fatalf("ParseHook error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("event should not be nil for session-start with empty input")
+	}
+	if event.SessionID != "env-session-999" {
+		t.Errorf("SessionID = %q, want env-session-999", event.SessionID)
+	}
+}
+
+func TestSidecarWritten(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	input := `{"session_id":"sidecar-test-001","hook_event_name":"SessionStart","timestamp":"2026-08-01T12:00:00Z","model":"gemini-2.5-pro"}`
+	_, err := a.ParseHook(HookNameSessionStart, []byte(input))
+	if err != nil {
+		t.Fatalf("ParseHook error: %v", err)
+	}
+
+	// Check sidecar file exists
+	dir, _ := a.GetSessionDir(tmp)
+	sidecarPath := a.ResolveSessionFile(dir, "sidecar-test-001")
+	data, err := os.ReadFile(sidecarPath)
+	if err != nil {
+		t.Fatalf("sidecar file not written: %v", err)
+	}
+
+	var rec sidecarRecord
+	if err := json.Unmarshal(data[:len(data)-1], &rec); err != nil {
+		t.Fatalf("invalid sidecar JSON: %v", err)
+	}
+	if rec.Agent != AgentName {
+		t.Errorf("sidecar agent = %q, want %q", rec.Agent, AgentName)
+	}
+	if rec.Event != "SessionStart" {
+		t.Errorf("sidecar event = %q, want SessionStart", rec.Event)
+	}
+}
+
+func TestInstallAndUninstallHooks(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	// Install
+	count, err := a.InstallHooks(false, false)
+	if err != nil {
+		t.Fatalf("InstallHooks error: %v", err)
+	}
+	if count != 8 {
+		t.Errorf("InstallHooks count = %d, want 8", count)
+	}
+
+	// Verify installed
+	if !a.AreHooksInstalled() {
+		t.Error("AreHooksInstalled should return true after install")
+	}
+
+	// Read settings.json and verify
+	settingsPath := filepath.Join(tmp, ".gemini", settingsFileName)
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+
+	var settings map[string]json.RawMessage
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("parse settings.json: %v", err)
+	}
+
+	hooksRaw, ok := settings["hooks"]
+	if !ok {
+		t.Fatal("no hooks key in settings.json")
+	}
+
+	hooksMap := map[string]json.RawMessage{}
+	if err := json.Unmarshal(hooksRaw, &hooksMap); err != nil {
+		t.Fatalf("parse hooks: %v", err)
+	}
+
+	for _, spec := range hookSpecs {
+		if _, ok := hooksMap[spec.GeminiEvent]; !ok {
+			t.Errorf("hook event %q missing from settings.json", spec.GeminiEvent)
+		}
+	}
+
+	// Uninstall
+	if err := a.UninstallHooks(); err != nil {
+		t.Fatalf("UninstallHooks error: %v", err)
+	}
+
+	// Verify uninstalled
+	if a.AreHooksInstalled() {
+		t.Error("AreHooksInstalled should return false after uninstall")
+	}
+}
+
+func TestInstallHooksIdempotent(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	// First install
+	count1, _ := a.InstallHooks(false, false)
+	if count1 != 8 {
+		t.Fatalf("first install count = %d, want 8", count1)
+	}
+
+	// Second install should not add duplicates
+	count2, _ := a.InstallHooks(false, false)
+	if count2 != 0 {
+		t.Errorf("second install count = %d, want 0 (already installed)", count2)
+	}
+}
+
+func TestInstallHooksPreservesExisting(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	// Write existing user hook
+	settingsDir := filepath.Join(tmp, ".gemini")
+	os.MkdirAll(settingsDir, 0o755)
+	existingSettings := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"SessionStart": []map[string]interface{}{
+				{
+					"hooks": []map[string]interface{}{
+						{
+							"type":    "command",
+							"command": "echo user-hook",
+							"name":    "user-hook",
+						},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(existingSettings, "", "  ")
+	os.WriteFile(filepath.Join(settingsDir, settingsFileName), data, 0o644)
+
+	// Install Entire hooks
+	count, err := a.InstallHooks(false, false)
+	if err != nil {
+		t.Fatalf("InstallHooks error: %v", err)
+	}
+	if count == 0 {
+		t.Error("InstallHooks should add hooks even with existing user hooks")
+	}
+
+	// Read back and verify user hook is preserved
+	settingsData, _ := os.ReadFile(filepath.Join(settingsDir, settingsFileName))
+	var settings map[string]json.RawMessage
+	json.Unmarshal(settingsData, &settings)
+
+	hooksMap := map[string][]geminiHookMatcher{}
+	hooksBytes, _ := json.Marshal(settings["hooks"])
+	json.Unmarshal(hooksBytes, &hooksMap)
+
+	sessionStartHooks := hooksMap["SessionStart"]
+	foundUser := false
+	foundEntire := false
+	for _, m := range sessionStartHooks {
+		for _, h := range m.Hooks {
+			if h.Name == "user-hook" {
+				foundUser = true
+			}
+			if h.Name == "entire-session-start" {
+				foundEntire = true
+			}
+		}
+	}
+	if !foundUser {
+		t.Error("user hook should be preserved after Entire install")
+	}
+	if !foundEntire {
+		t.Error("entire hook should be added after install")
+	}
+}
+
+func TestHookCommand(t *testing.T) {
+	cmd := hookCommand("session-start")
+	if cmd == "" {
+		t.Error("hookCommand returned empty string")
+	}
+	// Should contain "entire hooks gemini session-start"
+	if !contains(cmd, "entire hooks gemini session-start") {
+		t.Errorf("hookCommand = %q, should contain 'entire hooks gemini session-start'", cmd)
+	}
+	// Should have sh -c wrapper
+	if !contains(cmd, "sh -c") {
+		t.Errorf("hookCommand = %q, should contain 'sh -c'", cmd)
+	}
+}
+
+func TestIsEntireHook(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want bool
+	}{
+		{"entire-session-start", "sh -c 'entire hooks gemini session-start'", true},
+		{"user-hook", "echo hello", false},
+		{"entire-custom", "entire hooks gemini custom-event", true},
+		{"my-hook", "my-script.sh", false},
+	}
+	for _, tc := range tests {
+		hook := geminiHookEntry{Name: tc.name, Command: tc.cmd}
+		got := isEntireHook(hook)
+		if got != tc.want {
+			t.Errorf("isEntireHook(name=%q, cmd=%q) = %v, want %v", tc.name, tc.cmd, got, tc.want)
+		}
+	}
+}
+
+func TestGeminiEventName(t *testing.T) {
+	// Should return existing event name if present
+	got := geminiEventName("session-start", "ExistingEvent")
+	if got != "ExistingEvent" {
+		t.Errorf("geminiEventName with existing = %q, want ExistingEvent", got)
+	}
+
+	// Should map hook name to Gemini event
+	got = geminiEventName(HookNameSessionStart, "")
+	if got != "SessionStart" {
+		t.Errorf("geminiEventName(session-start) = %q, want SessionStart", got)
+	}
+
+	got = geminiEventName(HookNameBeforeAgent, "")
+	if got != "BeforeAgent" {
+		t.Errorf("geminiEventName(before-agent) = %q, want BeforeAgent", got)
+	}
+
+	// Unknown hook name should return the hook name itself
+	got = geminiEventName("unknown-hook", "")
+	if got != "unknown-hook" {
+		t.Errorf("geminiEventName(unknown-hook) = %q, want unknown-hook", got)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && findSubstring(s, substr))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/agents/entire-agent-gemini/internal/gemini/transcript.go
+++ b/agents/entire-agent-gemini/internal/gemini/transcript.go
@@ -1,0 +1,259 @@
+package gemini
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/entireio/external-agents/agents/entire-agent-gemini/internal/protocol"
+)
+
+var fileModificationTools = map[string]struct{}{
+	"write_file":         {},
+	"edit":               {},
+	"edit_file":          {},
+	"replace":            {},
+	"save_file":          {},
+	"writeFile":          {},
+	"WriteFile":          {},
+	"Write":              {},
+	"Edit":               {},
+	"MultiEdit":          {},
+	"str_replace_editor": {},
+	"Shell":              {},
+	"Bash":               {},
+	"run_shell_command":  {},
+	"shell":              {},
+}
+
+var commonPathKeys = []string{
+	"file_path",
+	"filePath",
+	"filepath",
+	"path",
+	"file",
+	"notebook_path",
+	"absolute_path",
+	"relative_path",
+	"target_file",
+	"filename",
+}
+
+func (a *Agent) ReadSession(input *protocol.HookInputJSON) (protocol.AgentSessionJSON, error) {
+	sessionID, sessionRef := a.sessionIDAndRef(input)
+	data, err := os.ReadFile(sessionRef)
+	if errors.Is(err, os.ErrNotExist) {
+		data = nil
+	} else if err != nil {
+		return protocol.AgentSessionJSON{}, err
+	}
+	modifiedFiles, _, err := a.ExtractModifiedFiles(sessionRef, 0)
+	if errors.Is(err, os.ErrNotExist) {
+		modifiedFiles = nil
+	} else if err != nil {
+		return protocol.AgentSessionJSON{}, err
+	}
+	return protocol.AgentSessionJSON{
+		SessionID:     sessionID,
+		AgentName:     AgentName,
+		RepoPath:      protocol.RepoRoot(),
+		SessionRef:    sessionRef,
+		StartTime:     time.Now().UTC().Format(time.RFC3339),
+		NativeData:    data,
+		ModifiedFiles: modifiedFiles,
+		NewFiles:      []string{},
+		DeletedFiles:  []string{},
+	}, nil
+}
+
+func (a *Agent) WriteSession(session protocol.AgentSessionJSON) error {
+	sessionDir, err := a.GetSessionDir(session.RepoPath)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		return err
+	}
+	path := a.ResolveSessionFile(sessionDir, session.SessionID)
+	return os.WriteFile(path, session.NativeData, 0o644)
+}
+
+func (a *Agent) ReadTranscript(sessionRef string) ([]byte, error) {
+	if strings.TrimSpace(sessionRef) == "" {
+		return nil, errMissingSessionRef
+	}
+	data, err := os.ReadFile(sessionRef)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (a *Agent) ChunkTranscript(content []byte, maxSize int) ([][]byte, error) {
+	if maxSize <= 0 {
+		return [][]byte{content}, nil
+	}
+	var chunks [][]byte
+	for len(content) > maxSize {
+		split := bytes.LastIndexByte(content[:maxSize], '\n')
+		if split < 0 {
+			split = maxSize
+		}
+		chunks = append(chunks, content[:split])
+		content = content[split:]
+		if len(content) > 0 && content[0] == '\n' {
+			content = content[1:]
+		}
+	}
+	if len(content) > 0 {
+		chunks = append(chunks, content)
+	}
+	return chunks, nil
+}
+
+func (a *Agent) ReassembleTranscript(chunks [][]byte) ([]byte, error) {
+	return bytes.Join(chunks, []byte("\n")), nil
+}
+
+func (a *Agent) GetTranscriptPosition(path string) (int, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	return int(info.Size()), nil
+}
+
+func (a *Agent) ExtractModifiedFiles(path string, offset int) ([]string, int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	currentPosition := len(data)
+	if offset >= currentPosition {
+		return nil, currentPosition, nil
+	}
+
+	lines := bytes.Split(data[offset:], []byte("\n"))
+	seen := map[string]struct{}{}
+	var files []string
+
+	for _, line := range lines {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var rec sidecarRecord
+		if err := json.Unmarshal(line, &rec); err != nil {
+			continue
+		}
+		if _, isMod := fileModificationTools[rec.ToolName]; !isMod {
+			continue
+		}
+		filePath := extractFilePathFromInput(rec.ToolInput)
+		if filePath != "" {
+			if _, ok := seen[filePath]; !ok {
+				seen[filePath] = struct{}{}
+				files = append(files, filePath)
+			}
+		}
+	}
+	return files, currentPosition, nil
+}
+
+func (a *Agent) ExtractPrompts(sessionRef string, offset int) ([]string, error) {
+	data, err := os.ReadFile(sessionRef)
+	if err != nil {
+		return nil, err
+	}
+	lines := bytes.Split(data, []byte("\n"))
+	var prompts []string
+	for _, line := range lines {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var rec sidecarRecord
+		if err := json.Unmarshal(line, &rec); err != nil {
+			continue
+		}
+		if rec.Event == "BeforeAgent" && rec.Prompt != "" {
+			prompts = append(prompts, rec.Prompt)
+		}
+	}
+	return prompts, nil
+}
+
+func (a *Agent) ExtractSummary(sessionRef string) (string, bool, error) {
+	data, err := os.ReadFile(sessionRef)
+	if err != nil {
+		return "", false, err
+	}
+	lines := bytes.Split(data, []byte("\n"))
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := lines[i]
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var rec sidecarRecord
+		if err := json.Unmarshal(line, &rec); err != nil {
+			continue
+		}
+		if rec.Event == "PreCompress" && rec.CompactSummary != "" {
+			return rec.CompactSummary, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func (a *Agent) sessionIDAndRef(input *protocol.HookInputJSON) (string, string) {
+	sessionID := a.GetSessionID(input)
+	sessionRef := a.sidecarPath(sessionID)
+	return sessionID, sessionRef
+}
+
+func extractFilePathFromInput(toolInput json.RawMessage) string {
+	if len(toolInput) == 0 {
+		return ""
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(toolInput, &m); err != nil {
+		return ""
+	}
+	for _, key := range commonPathKeys {
+		if v, ok := m[key]; ok {
+			if s, ok := v.(string); ok && s != "" {
+				return filepath.Clean(s)
+			}
+		}
+	}
+	// Search nested
+	for _, v := range m {
+		if s, ok := v.(string); ok {
+			if looksLikeFilePath(s) {
+				return filepath.Clean(s)
+			}
+		}
+	}
+	return ""
+}
+
+var pathLikeRe = regexp.MustCompile(`[/\\]\w+|^\w+\.\w+`)
+
+func looksLikeFilePath(s string) bool {
+	if len(s) == 0 || len(s) > 4096 {
+		return false
+	}
+	if !unicode.IsLetter(rune(s[0])) && s[0] != '/' && s[0] != '.' && s[0] != '~' {
+		return false
+	}
+	return pathLikeRe.MatchString(s)
+}
+
+// Suppress unused import warning
+var _ = fmt.Sprintf
+var _ = errors.New

--- a/agents/entire-agent-gemini/internal/gemini/transcript_test.go
+++ b/agents/entire-agent-gemini/internal/gemini/transcript_test.go
@@ -1,0 +1,309 @@
+package gemini
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTestSidecar(t *testing.T, a *Agent, tmpDir, sessionID string, records []sidecarRecord) string {
+	t.Helper()
+	dir, _ := a.GetSessionDir(tmpDir)
+	os.MkdirAll(dir, 0o755)
+	path := a.ResolveSessionFile(dir, sessionID)
+	for _, rec := range records {
+		data, _ := json.Marshal(rec)
+		data = append(data, '\n')
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			t.Fatalf("write sidecar: %v", err)
+		}
+		f.Write(data)
+		f.Close()
+	}
+	return path
+}
+
+func TestReadTranscript(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	records := []sidecarRecord{
+		{V: 1, Agent: AgentName, Event: "SessionStart", SessionID: "t-001", TS: "2026-08-01T12:00:00Z"},
+		{V: 1, Agent: AgentName, Event: "BeforeAgent", SessionID: "t-001", TS: "2026-08-01T12:01:00Z", Prompt: "hello"},
+		{V: 1, Agent: AgentName, Event: "AfterAgent", SessionID: "t-001", TS: "2026-08-01T12:02:00Z", LastAssistantMessage: "hi there"},
+	}
+	path := writeTestSidecar(t, a, tmp, "t-001", records)
+
+	data, err := a.ReadTranscript(path)
+	if err != nil {
+		t.Fatalf("ReadTranscript error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("ReadTranscript returned empty data")
+	}
+
+	// Verify we can parse the JSONL
+	lines := splitLines(data)
+	if len(lines) != 3 {
+		t.Errorf("expected 3 lines, got %d", len(lines))
+	}
+}
+
+func TestReadTranscriptEmptyRef(t *testing.T) {
+	a := New()
+	_, err := a.ReadTranscript("")
+	if err == nil {
+		t.Error("ReadTranscript(\"\") should return error")
+	}
+}
+
+func TestChunkTranscript(t *testing.T) {
+	a := New()
+	data := []byte("line1\nline2\nline3\nline4\nline5")
+
+	chunks, err := a.ChunkTranscript(data, 12)
+	if err != nil {
+		t.Fatalf("ChunkTranscript error: %v", err)
+	}
+	if len(chunks) < 2 {
+		t.Errorf("expected at least 2 chunks, got %d", len(chunks))
+	}
+}
+
+func TestChunkTranscriptNoSplit(t *testing.T) {
+	a := New()
+	data := []byte("small line")
+
+	chunks, err := a.ChunkTranscript(data, 1000)
+	if err != nil {
+		t.Fatalf("ChunkTranscript error: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Errorf("expected 1 chunk, got %d", len(chunks))
+	}
+	if string(chunks[0]) != "small line" {
+		t.Errorf("chunk content = %q, want 'small line'", string(chunks[0]))
+	}
+}
+
+func TestReassembleTranscript(t *testing.T) {
+	a := New()
+	chunks := [][]byte{[]byte("a"), []byte("b"), []byte("c")}
+	result, err := a.ReassembleTranscript(chunks)
+	if err != nil {
+		t.Fatalf("ReassembleTranscript error: %v", err)
+	}
+	if string(result) != "a\nb\nc" {
+		t.Errorf("ReassembleTranscript = %q, want 'a\\nb\\nc'", string(result))
+	}
+}
+
+func TestExtractPrompts(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	records := []sidecarRecord{
+		{V: 1, Agent: AgentName, Event: "SessionStart", SessionID: "p-001", TS: "2026-08-01T12:00:00Z"},
+		{V: 1, Agent: AgentName, Event: "BeforeAgent", SessionID: "p-001", TS: "2026-08-01T12:01:00Z", Prompt: "first prompt"},
+		{V: 1, Agent: AgentName, Event: "AfterAgent", SessionID: "p-001", TS: "2026-08-01T12:02:00Z"},
+		{V: 1, Agent: AgentName, Event: "BeforeAgent", SessionID: "p-001", TS: "2026-08-01T12:03:00Z", Prompt: "second prompt"},
+	}
+	path := writeTestSidecar(t, a, tmp, "p-001", records)
+
+	prompts, err := a.ExtractPrompts(path, 0)
+	if err != nil {
+		t.Fatalf("ExtractPrompts error: %v", err)
+	}
+	if len(prompts) != 2 {
+		t.Fatalf("expected 2 prompts, got %d", len(prompts))
+	}
+	if prompts[0] != "first prompt" {
+		t.Errorf("prompts[0] = %q, want 'first prompt'", prompts[0])
+	}
+	if prompts[1] != "second prompt" {
+		t.Errorf("prompts[1] = %q, want 'second prompt'", prompts[1])
+	}
+}
+
+func TestExtractSummary(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	records := []sidecarRecord{
+		{V: 1, Agent: AgentName, Event: "SessionStart", SessionID: "s-001", TS: "2026-08-01T12:00:00Z"},
+		{V: 1, Agent: AgentName, Event: "BeforeAgent", SessionID: "s-001", TS: "2026-08-01T12:01:00Z", Prompt: "do something"},
+		{V: 1, Agent: AgentName, Event: "PreCompress", SessionID: "s-001", TS: "2026-08-01T12:02:00Z", CompactSummary: "Summary of conversation"},
+	}
+	path := writeTestSidecar(t, a, tmp, "s-001", records)
+
+	summary, found, err := a.ExtractSummary(path)
+	if err != nil {
+		t.Fatalf("ExtractSummary error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected summary to be found")
+	}
+	if summary != "Summary of conversation" {
+		t.Errorf("summary = %q, want 'Summary of conversation'", summary)
+	}
+}
+
+func TestExtractSummaryNotFound(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	records := []sidecarRecord{
+		{V: 1, Agent: AgentName, Event: "SessionStart", SessionID: "s-002", TS: "2026-08-01T12:00:00Z"},
+	}
+	path := writeTestSidecar(t, a, tmp, "s-002", records)
+
+	summary, found, err := a.ExtractSummary(path)
+	if err != nil {
+		t.Fatalf("ExtractSummary error: %v", err)
+	}
+	if found {
+		t.Error("should not find summary when none exists")
+	}
+	if summary != "" {
+		t.Errorf("summary = %q, want empty", summary)
+	}
+}
+
+func TestExtractModifiedFiles(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	toolInput, _ := json.Marshal(map[string]string{"file_path": "/src/main.go"})
+	records := []sidecarRecord{
+		{V: 1, Agent: AgentName, Event: "BeforeTool", SessionID: "m-001", TS: "2026-08-01T12:01:00Z", ToolName: "write_file", ToolInput: toolInput},
+		{V: 1, Agent: AgentName, Event: "AfterTool", SessionID: "m-001", TS: "2026-08-01T12:01:05Z", ToolName: "write_file", ToolInput: toolInput},
+		{V: 1, Agent: AgentName, Event: "BeforeTool", SessionID: "m-001", TS: "2026-08-01T12:02:00Z", ToolName: "read_file", ToolInput: toolInput},
+	}
+	path := writeTestSidecar(t, a, tmp, "m-001", records)
+
+	files, _, err := a.ExtractModifiedFiles(path, 0)
+	if err != nil {
+		t.Fatalf("ExtractModifiedFiles error: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 modified file, got %d", len(files))
+	}
+	if files[0] != "/src/main.go" {
+		t.Errorf("files[0] = %q, want /src/main.go", files[0])
+	}
+}
+
+func TestCompactTranscript(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	records := []sidecarRecord{
+		{V: 1, Agent: AgentName, Event: "SessionStart", SessionID: "c-001", TS: "2026-08-01T12:00:00Z", Model: "gemini-2.5-pro"},
+		{V: 1, Agent: AgentName, Event: "BeforeAgent", SessionID: "c-001", TS: "2026-08-01T12:01:00Z", Prompt: "test prompt"},
+		{V: 1, Agent: AgentName, Event: "AfterAgent", SessionID: "c-001", TS: "2026-08-01T12:02:00Z", LastAssistantMessage: "response"},
+	}
+	path := writeTestSidecar(t, a, tmp, "c-001", records)
+
+	result, err := a.CompactTranscript(path)
+	if err != nil {
+		t.Fatalf("CompactTranscript error: %v", err)
+	}
+	if result.Transcript == "" {
+		t.Fatal("CompactTranscript returned empty transcript")
+	}
+
+	// Verify it's valid JSON
+	var entries []map[string]interface{}
+	if err := json.Unmarshal([]byte(result.Transcript), &entries); err != nil {
+		t.Fatalf("compact transcript is not valid JSON: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Errorf("expected 3 entries, got %d", len(entries))
+	}
+}
+
+func TestGetTranscriptPosition(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	records := []sidecarRecord{
+		{V: 1, Agent: AgentName, Event: "SessionStart", SessionID: "pos-001", TS: "2026-08-01T12:00:00Z"},
+	}
+	path := writeTestSidecar(t, a, tmp, "pos-001", records)
+
+	pos, err := a.GetTranscriptPosition(path)
+	if err != nil {
+		t.Fatalf("GetTranscriptPosition error: %v", err)
+	}
+	if pos <= 0 {
+		t.Errorf("position = %d, should be > 0", pos)
+	}
+}
+
+func TestExtractFilePathFromInput(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want string
+	}{
+		{"file_path", `{"file_path":"/src/main.go"}`, "/src/main.go"},
+		{"filePath", `{"filePath":"/src/utils.ts"}`, "/src/utils.ts"},
+		{"path", `{"path":"README.md"}`, "README.md"},
+		{"empty", `{}`, ""},
+		{"invalid_json", `not json`, ""},
+	}
+	for _, tc := range tests {
+		got := extractFilePathFromInput(json.RawMessage(tc.json))
+		if got != tc.want {
+			t.Errorf("extractFilePathFromInput(%s) = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestLooksLikeFilePath(t *testing.T) {
+	if !looksLikeFilePath("/src/main.go") {
+		t.Error("/src/main.go should look like a file path")
+	}
+	if !looksLikeFilePath("main.go") {
+		t.Error("main.go should look like a file path")
+	}
+	if looksLikeFilePath("") {
+		t.Error("empty string should not look like a file path")
+	}
+	if looksLikeFilePath("just text without path") {
+		t.Error("plain text should not look like a file path")
+	}
+}
+
+func TestWriteAndReadSession(t *testing.T) {
+	a := New()
+	tmp := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", tmp)
+
+	// Write sidecar first
+	records := []sidecarRecord{
+		{V: 1, Agent: AgentName, Event: "SessionStart", SessionID: "wr-001", TS: "2026-08-01T12:00:00Z"},
+	}
+	sidecarPath := writeTestSidecar(t, a, tmp, "wr-001", records)
+
+	// Read it back
+	data, err := a.ReadTranscript(sidecarPath)
+	if err != nil {
+		t.Fatalf("ReadTranscript: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("no data read")
+	}
+
+	// Clean up
+	_ = filepath.Clean(sidecarPath)
+}

--- a/agents/entire-agent-gemini/internal/gemini/types.go
+++ b/agents/entire-agent-gemini/internal/gemini/types.go
@@ -1,0 +1,104 @@
+package gemini
+
+import "encoding/json"
+
+const (
+	AgentName        = "gemini"
+	AgentType        = "Gemini CLI"
+	geminiBinary     = "gemini"
+	stubSessionID    = "gemini-session-000"
+	settingsFileName = "settings.json"
+)
+
+const (
+	HookNameSessionStart       = "session-start"
+	HookNameBeforeAgent        = "before-agent"
+	HookNameAfterAgent         = "after-agent"
+	HookNameBeforeTool         = "before-tool"
+	HookNameAfterTool          = "after-tool"
+	HookNamePreCompress        = "pre-compress"
+	HookNameNotification       = "notification"
+	HookNameSessionEnd         = "session-end"
+)
+
+var hookSpecs = []hookSpec{
+	{GeminiEvent: "SessionStart", HookName: HookNameSessionStart, EntryName: "entire-session-start"},
+	{GeminiEvent: "BeforeAgent", HookName: HookNameBeforeAgent, EntryName: "entire-before-agent"},
+	{GeminiEvent: "AfterAgent", HookName: HookNameAfterAgent, EntryName: "entire-after-agent"},
+	{GeminiEvent: "BeforeTool", HookName: HookNameBeforeTool, EntryName: "entire-before-tool", Matcher: "*"},
+	{GeminiEvent: "AfterTool", HookName: HookNameAfterTool, EntryName: "entire-after-tool", Matcher: "*"},
+	{GeminiEvent: "PreCompress", HookName: HookNamePreCompress, EntryName: "entire-pre-compress"},
+	{GeminiEvent: "Notification", HookName: HookNameNotification, EntryName: "entire-notification", Matcher: "*"},
+	{GeminiEvent: "SessionEnd", HookName: HookNameSessionEnd, EntryName: "entire-session-end"},
+}
+
+type hookSpec struct {
+	GeminiEvent string
+	HookName    string
+	EntryName   string
+	Matcher     string
+}
+
+// Gemini hook config structure (matches .gemini/settings.json hooks schema)
+type geminiHookMatcher struct {
+	Matcher    string                     `json:"matcher,omitempty"`
+	Hooks      []geminiHookEntry           `json:"hooks"`
+	Extra      map[string]json.RawMessage  `json:"-"`
+}
+
+type geminiHookEntry struct {
+	Type        string                     `json:"type"`
+	Command     string                     `json:"command,omitempty"`
+	Name        string                     `json:"name,omitempty"`
+	Description string                     `json:"description,omitempty"`
+	Timeout     int                        `json:"timeout,omitempty"`
+	Extra       map[string]json.RawMessage `json:"-"`
+}
+
+// Gemini CLI hook input payload (from stdin)
+type geminiHookInputRaw struct {
+	SessionID            string          `json:"session_id"`
+	TranscriptPath       string          `json:"transcript_path"`
+	CWD                  string          `json:"cwd"`
+	HookEventName        string          `json:"hook_event_name"`
+	Timestamp            string          `json:"timestamp"`
+	Prompt               string          `json:"prompt,omitempty"`
+	UserPrompt           string          `json:"user_prompt,omitempty"`
+	Model                string          `json:"model,omitempty"`
+	LastAssistantMessage string          `json:"last_assistant_message,omitempty"`
+	ToolName             string          `json:"tool_name,omitempty"`
+	ToolUseID            string          `json:"tool_use_id,omitempty"`
+	ToolInput            json.RawMessage `json:"tool_input,omitempty"`
+	ToolResponse         json.RawMessage `json:"tool_response,omitempty"`
+	Error                string          `json:"error,omitempty"`
+	ErrorDetails         string          `json:"error_details,omitempty"`
+	CompactSummary       string          `json:"compact_summary,omitempty"`
+	NotificationType     string          `json:"notification_type,omitempty"`
+	Message              string          `json:"message,omitempty"`
+	Reason               string          `json:"reason,omitempty"`
+	Source               string          `json:"source,omitempty"`
+}
+
+type sidecarRecord struct {
+	V                    int             `json:"v"`
+	Agent                string          `json:"agent"`
+	Event                string          `json:"event"`
+	SessionID            string          `json:"session_id"`
+	TS                   string          `json:"ts"`
+	CWD                  string          `json:"cwd,omitempty"`
+	NativeTranscriptPath string          `json:"native_transcript_path,omitempty"`
+	Prompt               string          `json:"prompt,omitempty"`
+	Model                string          `json:"model,omitempty"`
+	Reason               string          `json:"reason,omitempty"`
+	Source               string          `json:"source,omitempty"`
+	ToolName             string          `json:"tool_name,omitempty"`
+	ToolUseID            string          `json:"tool_use_id,omitempty"`
+	ToolInput            json.RawMessage `json:"tool_input,omitempty"`
+	ToolResponse         json.RawMessage `json:"tool_response,omitempty"`
+	Error                string          `json:"error,omitempty"`
+	ErrorDetails         string          `json:"error_details,omitempty"`
+	LastAssistantMessage string          `json:"last_assistant_message,omitempty"`
+	CompactSummary       string          `json:"compact_summary,omitempty"`
+	NotificationType     string          `json:"notification_type,omitempty"`
+	Message              string          `json:"message,omitempty"`
+}

--- a/agents/entire-agent-gemini/internal/protocol/protocol.go
+++ b/agents/entire-agent-gemini/internal/protocol/protocol.go
@@ -1,0 +1,330 @@
+package protocol
+
+import (
+	"encoding/json"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type sessionDirResolver interface {
+	GetSessionDir(repoPath string) (string, error)
+}
+
+type sessionFileResolver interface {
+	ResolveSessionFile(sessionDir, sessionID string) string
+}
+
+type sessionIDProvider interface {
+	GetSessionID(*HookInputJSON) string
+}
+
+type sessionReader interface {
+	ReadSession(*HookInputJSON) (AgentSessionJSON, error)
+}
+
+type sessionWriter interface {
+	WriteSession(AgentSessionJSON) error
+}
+
+type transcriptReader interface {
+	ReadTranscript(sessionRef string) ([]byte, error)
+}
+
+type transcriptChunker interface {
+	ChunkTranscript(content []byte, maxSize int) ([][]byte, error)
+	ReassembleTranscript(chunks [][]byte) ([]byte, error)
+}
+
+type transcriptCompactor interface {
+	CompactTranscript(sessionRef string) (CompactTranscriptResponse, error)
+}
+
+type resumeFormatter interface {
+	FormatResumeCommand(sessionID string) string
+}
+
+type hookParser interface {
+	ParseHook(hookName string, input []byte) (*EventJSON, error)
+	InstallHooks(localDev bool, force bool) (int, error)
+	UninstallHooks() error
+	AreHooksInstalled() bool
+}
+
+type transcriptAnalyzer interface {
+	GetTranscriptPosition(path string) (int, error)
+	ExtractModifiedFiles(path string, offset int) ([]string, int, error)
+	ExtractPrompts(sessionRef string, offset int) ([]string, error)
+	ExtractSummary(sessionRef string) (string, bool, error)
+}
+
+func WriteJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(v)
+}
+
+func ReadJSON[T any](r io.Reader) (*T, error) {
+	var value T
+	if err := json.NewDecoder(r).Decode(&value); err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
+func RepoRoot() string {
+	if root := os.Getenv("ENTIRE_REPO_ROOT"); root != "" {
+		return root
+	}
+	root, _ := os.Getwd()
+	return root
+}
+
+func HandleGetSessionID(stdin io.Reader, stdout io.Writer, provider sessionIDProvider) error {
+	input, err := ReadJSON[HookInputJSON](stdin)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionIDResponse{SessionID: provider.GetSessionID(input)})
+}
+
+func HandleGetSessionDir(args []string, stdout io.Writer, resolver sessionDirResolver) error {
+	fs := flag.NewFlagSet("get-session-dir", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	repoPath := fs.String("repo-path", "", "repo path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	sessionDir, err := resolver.GetSessionDir(*repoPath)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionDirResponse{SessionDir: sessionDir})
+}
+
+func HandleResolveSessionFile(args []string, stdout io.Writer, resolver sessionFileResolver) error {
+	fs := flag.NewFlagSet("resolve-session-file", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionDir := fs.String("session-dir", "", "session dir")
+	sessionID := fs.String("session-id", "", "session id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionFileResponse{SessionFile: resolver.ResolveSessionFile(*sessionDir, *sessionID)})
+}
+
+func HandleReadSession(stdin io.Reader, stdout io.Writer, reader sessionReader) error {
+	input, err := ReadJSON[HookInputJSON](stdin)
+	if err != nil {
+		return err
+	}
+	session, err := reader.ReadSession(input)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, session)
+}
+
+func HandleWriteSession(stdin io.Reader, writer sessionWriter) error {
+	session, err := ReadJSON[AgentSessionJSON](stdin)
+	if err != nil {
+		return err
+	}
+	return writer.WriteSession(*session)
+}
+
+func HandleReadTranscript(args []string, stdout io.Writer, reader transcriptReader) error {
+	fs := flag.NewFlagSet("read-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	data, err := reader.ReadTranscript(*sessionRef)
+	if err != nil {
+		return err
+	}
+	_, err = stdout.Write(data)
+	return err
+}
+
+func HandleChunkTranscript(args []string, stdin io.Reader, stdout io.Writer, chunker transcriptChunker) error {
+	fs := flag.NewFlagSet("chunk-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	maxSize := fs.Int("max-size", 0, "max size")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	content, err := io.ReadAll(stdin)
+	if err != nil {
+		return err
+	}
+	chunks, err := chunker.ChunkTranscript(content, *maxSize)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ChunkResponse{Chunks: chunks})
+}
+
+func HandleReassembleTranscript(stdin io.Reader, stdout io.Writer, chunker transcriptChunker) error {
+	input, err := ReadJSON[ChunkResponse](stdin)
+	if err != nil {
+		return err
+	}
+	data, err := chunker.ReassembleTranscript(input.Chunks)
+	if err != nil {
+		return err
+	}
+	_, err = stdout.Write(data)
+	return err
+}
+
+func HandleCompactTranscript(args []string, stdout io.Writer, compactor transcriptCompactor) error {
+	fs := flag.NewFlagSet("compact-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	compacted, err := compactor.CompactTranscript(*sessionRef)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, compacted)
+}
+
+func HandleFormatResumeCommand(args []string, stdout io.Writer, formatter resumeFormatter) error {
+	fs := flag.NewFlagSet("format-resume-command", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionID := fs.String("session-id", "", "session id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ResumeCommandResponse{Command: formatter.FormatResumeCommand(*sessionID)})
+}
+
+// readStdinWithTimeout reads from r but returns empty data if nothing arrives
+// within the timeout. This prevents blocking when an IDE keeps stdin open
+// without sending data (e.g., for hooks that have no payload).
+func readStdinWithTimeout(r io.Reader, timeout time.Duration) ([]byte, error) {
+	type result struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		data, err := io.ReadAll(r)
+		ch <- result{data, err}
+	}()
+	select {
+	case res := <-ch:
+		return res.data, res.err
+	case <-time.After(timeout):
+		return nil, nil
+	}
+}
+
+func HandleParseHook(args []string, stdin io.Reader, stdout io.Writer, parser hookParser) error {
+	fs := flag.NewFlagSet("parse-hook", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	hook := fs.String("hook", "", "hook name")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	input, err := readStdinWithTimeout(stdin, 100*time.Millisecond)
+	if err != nil {
+		return err
+	}
+	event, err := parser.ParseHook(*hook, input)
+	if err != nil {
+		return err
+	}
+	if event == nil {
+		_, err = io.WriteString(stdout, "null\n")
+		return err
+	}
+	return WriteJSON(stdout, event)
+}
+
+func HandleInstallHooks(args []string, stdout io.Writer, parser hookParser) error {
+	fs := flag.NewFlagSet("install-hooks", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	localDev := fs.Bool("local-dev", false, "local dev")
+	force := fs.Bool("force", false, "force")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	count, err := parser.InstallHooks(*localDev, *force)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, HooksInstalledCountResponse{HooksInstalled: count})
+}
+
+func HandleGetTranscriptPosition(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("get-transcript-position", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	path := fs.String("path", "", "path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	position, err := analyzer.GetTranscriptPosition(*path)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, TranscriptPositionResponse{Position: position})
+}
+
+func HandleExtractModifiedFiles(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-modified-files", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	path := fs.String("path", "", "path")
+	offset := fs.Int("offset", 0, "offset")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	files, currentPosition, err := analyzer.ExtractModifiedFiles(*path, *offset)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractFilesResponse{Files: files, CurrentPosition: currentPosition})
+}
+
+func HandleExtractPrompts(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-prompts", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	offset := fs.Int("offset", 0, "offset")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	prompts, err := analyzer.ExtractPrompts(*sessionRef, *offset)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractPromptsResponse{Prompts: prompts})
+}
+
+func HandleExtractSummary(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-summary", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	summary, hasSummary, err := analyzer.ExtractSummary(*sessionRef)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractSummaryResponse{Summary: summary, HasSummary: hasSummary})
+}
+
+func DefaultSessionDir(repoPath string) string {
+	return filepath.Join(repoPath, ".entire", "tmp")
+}
+
+func ResolveSessionFile(sessionDir, sessionID string) string {
+	return filepath.Join(sessionDir, sessionID+".json")
+}

--- a/agents/entire-agent-gemini/internal/protocol/types.go
+++ b/agents/entire-agent-gemini/internal/protocol/types.go
@@ -1,0 +1,130 @@
+package protocol
+
+import "encoding/json"
+
+const ProtocolVersion = 1
+
+type DeclaredCapabilities struct {
+	Hooks                  bool `json:"hooks"`
+	TranscriptAnalyzer     bool `json:"transcript_analyzer"`
+	TranscriptPreparer     bool `json:"transcript_preparer"`
+	TokenCalculator        bool `json:"token_calculator"`
+	CompactTranscript      bool `json:"compact_transcript"`
+	TextGenerator          bool `json:"text_generator"`
+	HookResponseWriter     bool `json:"hook_response_writer"`
+	SubagentAwareExtractor bool `json:"subagent_aware_extractor"`
+	UsesTerminal           bool `json:"uses_terminal"`
+}
+
+type InfoResponse struct {
+	ProtocolVersion int                  `json:"protocol_version"`
+	Name            string               `json:"name"`
+	Type            string               `json:"type"`
+	Description     string               `json:"description"`
+	IsPreview       bool                 `json:"is_preview"`
+	ProtectedDirs   []string             `json:"protected_dirs"`
+	HookNames       []string             `json:"hook_names"`
+	Capabilities    DeclaredCapabilities `json:"capabilities"`
+}
+
+type DetectResponse struct {
+	Present bool `json:"present"`
+}
+
+type SessionIDResponse struct {
+	SessionID string `json:"session_id"`
+}
+
+type SessionDirResponse struct {
+	SessionDir string `json:"session_dir"`
+}
+
+type SessionFileResponse struct {
+	SessionFile string `json:"session_file"`
+}
+
+type ChunkResponse struct {
+	Chunks [][]byte `json:"chunks"`
+}
+
+type ResumeCommandResponse struct {
+	Command string `json:"command"`
+}
+
+type HooksInstalledCountResponse struct {
+	HooksInstalled int `json:"hooks_installed"`
+}
+
+type AreHooksInstalledResponse struct {
+	Installed bool `json:"installed"`
+}
+
+type TranscriptPositionResponse struct {
+	Position int `json:"position"`
+}
+
+type ExtractFilesResponse struct {
+	Files           []string `json:"files"`
+	CurrentPosition int      `json:"current_position"`
+}
+
+type ExtractPromptsResponse struct {
+	Prompts []string `json:"prompts"`
+}
+
+type ExtractSummaryResponse struct {
+	Summary    string `json:"summary"`
+	HasSummary bool   `json:"has_summary"`
+}
+
+type CompactTranscriptResponse struct {
+	Transcript string                       `json:"transcript"`
+	Assets     []CompactTranscriptAssetJSON `json:"assets,omitempty"`
+}
+
+type CompactTranscriptAssetJSON struct {
+	Name      string `json:"name"`
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
+}
+
+type AgentSessionJSON struct {
+	SessionID     string   `json:"session_id"`
+	AgentName     string   `json:"agent_name"`
+	RepoPath      string   `json:"repo_path"`
+	SessionRef    string   `json:"session_ref"`
+	StartTime     string   `json:"start_time"`
+	NativeData    []byte   `json:"native_data"`
+	ModifiedFiles []string `json:"modified_files"`
+	NewFiles      []string `json:"new_files"`
+	DeletedFiles  []string `json:"deleted_files"`
+}
+
+type HookInputJSON struct {
+	HookType   string                 `json:"hook_type"`
+	SessionID  string                 `json:"session_id"`
+	SessionRef string                 `json:"session_ref"`
+	Timestamp  string                 `json:"timestamp"`
+	UserPrompt string                 `json:"user_prompt,omitempty"`
+	ToolName   string                 `json:"tool_name,omitempty"`
+	ToolUseID  string                 `json:"tool_use_id,omitempty"`
+	ToolInput  json.RawMessage        `json:"tool_input,omitempty"`
+	RawData    map[string]interface{} `json:"raw_data,omitempty"`
+}
+
+type EventJSON struct {
+	Type              int               `json:"type"`
+	SessionID         string            `json:"session_id"`
+	PreviousSessionID string            `json:"previous_session_id,omitempty"`
+	SessionRef        string            `json:"session_ref,omitempty"`
+	Prompt            string            `json:"prompt,omitempty"`
+	Model             string            `json:"model,omitempty"`
+	Timestamp         string            `json:"timestamp,omitempty"`
+	ToolUseID         string            `json:"tool_use_id,omitempty"`
+	SubagentID        string            `json:"subagent_id,omitempty"`
+	ToolInput         json.RawMessage   `json:"tool_input,omitempty"`
+	SubagentType      string            `json:"subagent_type,omitempty"`
+	TaskDescription   string            `json:"task_description,omitempty"`
+	ResponseMessage   string            `json:"response_message,omitempty"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+}

--- a/agents/entire-agent-gemini/mise.toml
+++ b/agents/entire-agent-gemini/mise.toml
@@ -1,0 +1,10 @@
+[tools]
+go = "1.26.0"
+
+[tasks.build]
+description = "Build the entire-agent-gemini binary"
+run = "go build -o entire-agent-gemini ./cmd/entire-agent-gemini"
+
+[tasks.test]
+description = "Run unit tests"
+run = "go test ./..."


### PR DESCRIPTION
## Summary

Adds a new external agent binary (`entire-agent-gemini`) that integrates Google's [Gemini CLI](https://github.com/google-gemini/gemini-cli) with the Entire CLI.

## Implementation

- **12 files**, ~1,600 lines of Go + 882 lines of tests
- Follows the existing agent architecture (mirrors `entire-agent-qwen` and `entire-agent-claude` patterns)

### Capabilities

| Capability | Status |
|---|---|
| hooks | Yes — 8 events in `.gemini/settings.json` |
| transcript_analyzer | Yes — Sidecar JSONL |
| compact_transcript | Yes — JSONL compact format |
| transcript_preparer | No |
| token_calculator | No |

### Hook Events

| Gemini CLI Event | Protocol Type | Description |
|---|---|---|
| SessionStart | 1 | Session begins |
| BeforeAgent | 2 | User submits prompt |
| AfterAgent | 3 | Agent loop ends |
| BeforeTool | — | Recorded in sidecar |
| AfterTool | — | Recorded in sidecar |
| PreCompress | 4 | Before context compression |
| Notification | — | Recorded in sidecar |
| SessionEnd | 5 | Session ends |

Hooks route through `entire hooks gemini <event>` -> `entire-agent-gemini parse-hook`, wrapped in `sh -c` so a missing `entire` binary never breaks a Gemini session.

### Tests

40 unit tests covering:
- Info, Detect, session ID resolution (input/env/fallback)
- ParseHook for all 8 events
- Sidecar JSONL writing and reading
- Install/Uninstall/AreHooksInstalled lifecycle
- Hook idempotency and preservation of existing user hooks
- Transcript operations: read, chunk, reassemble, extract prompts/summary/modified files, compact

All 40 tests pass.

## Usage

```bash
cd /path/to/repo
entire enable --agent gemini
gemini "Create hello.txt with hello world"
git add . && git commit -m "checkpoint"
entire checkpoint list
```