### PR TITLE
kilo: refuse to overwrite or remove user-owned plugins without an explicit force install

### DIFF
--- a/agents/entire-agent-kilo/internal/kilo/hooks.go
+++ b/agents/entire-agent-kilo/internal/kilo/hooks.go
@@ -231,10 +231,19 @@ func (a *Agent) InstallHooks(localDev bool, force bool) (int, error) {
 	content := strings.ReplaceAll(generatePlugin(), entireCmdPlaceholder, cmdPrefix)
 
 	path := filepath.Join(root, pluginFile)
-	if !force {
-		if existing, readErr := os.ReadFile(path); readErr == nil && string(existing) == content {
+	if existing, readErr := os.ReadFile(path); readErr == nil {
+		if string(existing) == content {
 			return 0, nil
 		}
+		// Protect user-owned or third-party Kilo plugins from being silently
+		// overwritten by the generated Entire plugin. Only an explicit force
+		// install may replace a foreign plugin file, matching the ownership
+		// contract used by the omp adapter.
+		if !isOwnedPlugin(existing) && !force {
+			return 0, fmt.Errorf("refusing to overwrite foreign kilo plugin %s; pass force to replace it", path)
+		}
+	} else if !os.IsNotExist(readErr) {
+		return 0, readErr
 	}
 
 	dir := filepath.Join(root, pluginDir)
@@ -251,6 +260,17 @@ func (a *Agent) InstallHooks(localDev bool, force bool) (int, error) {
 func (a *Agent) UninstallHooks() error {
 	root := protocol.RepoRoot()
 	path := filepath.Join(root, pluginFile)
+
+	// Leave user-owned or third-party Kilo plugins untouched; uninstall only
+	// removes the Entire-generated plugin identified by the ownership marker.
+	if existing, err := os.ReadFile(path); err == nil && !isOwnedPlugin(existing) {
+		return nil
+	} else if os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -265,10 +285,21 @@ func (a *Agent) UninstallHooks() error {
 	return nil
 }
 
+func isOwnedPlugin(data []byte) bool {
+	return strings.Contains(string(data), pluginMarker)
+}
+
 func (a *Agent) AreHooksInstalled() bool {
+	// Kilo skips loading external plugins in pure mode. A generated plugin file
+	// may still exist, but it is not active in that mode, so reporting hooks as
+	// installed would make Entire believe lifecycle events are being emitted.
+	if strings.TrimSpace(os.Getenv("KILO_PURE")) == "1" {
+		return false
+	}
+
 	root := protocol.RepoRoot()
 	data, err := os.ReadFile(filepath.Join(root, pluginFile))
-	return err == nil && strings.Contains(string(data), pluginMarker)
+	return err == nil && isOwnedPlugin(data)
 }
 
 // fetchSession is reserved for mid-turn refresh from the Kilo HTTP server.

--- a/agents/entire-agent-kilo/internal/kilo/hooks.go
+++ b/agents/entire-agent-kilo/internal/kilo/hooks.go
@@ -231,26 +231,39 @@ func (a *Agent) InstallHooks(localDev bool, force bool) (int, error) {
 	content := strings.ReplaceAll(generatePlugin(), entireCmdPlaceholder, cmdPrefix)
 
 	path := filepath.Join(root, pluginFile)
-	if existing, readErr := os.ReadFile(path); readErr == nil {
-		if string(existing) == content {
-			return 0, nil
+	if info, lstatErr := os.Lstat(path); lstatErr == nil {
+		// Never follow an existing symlink or overwrite a non-regular path. A
+		// forced install replaces the directory entry atomically rather than
+		// writing through it.
+		if !info.Mode().IsRegular() {
+			if !force {
+				return 0, fmt.Errorf("refusing to overwrite non-regular kilo plugin %s; pass force to replace it", path)
+			}
+		} else if existing, readErr := os.ReadFile(path); readErr == nil {
+			// Force is intentionally allowed to rewrite identical content so it
+			// can repair file metadata such as permissions.
+			if string(existing) == content && !force {
+				return 0, nil
+			}
+			// Protect user-owned or third-party Kilo plugins from being silently
+			// overwritten by the generated Entire plugin. Only an explicit force
+			// install may replace a foreign plugin file, matching the ownership
+			// contract used by the omp adapter.
+			if !isOwnedPlugin(existing) && !force {
+				return 0, fmt.Errorf("refusing to overwrite foreign kilo plugin %s; pass force to replace it", path)
+			}
+		} else if !force {
+			return 0, readErr
 		}
-		// Protect user-owned or third-party Kilo plugins from being silently
-		// overwritten by the generated Entire plugin. Only an explicit force
-		// install may replace a foreign plugin file, matching the ownership
-		// contract used by the omp adapter.
-		if !isOwnedPlugin(existing) && !force {
-			return 0, fmt.Errorf("refusing to overwrite foreign kilo plugin %s; pass force to replace it", path)
-		}
-	} else if !os.IsNotExist(readErr) {
-		return 0, readErr
+	} else if !os.IsNotExist(lstatErr) {
+		return 0, lstatErr
 	}
 
 	dir := filepath.Join(root, pluginDir)
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return 0, fmt.Errorf("create plugin dir: %w", err)
 	}
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+	if err := atomicWriteFile(path, []byte(content), 0o600); err != nil {
 		return 0, fmt.Errorf("write plugin: %w", err)
 	}
 
@@ -261,14 +274,24 @@ func (a *Agent) UninstallHooks() error {
 	root := protocol.RepoRoot()
 	path := filepath.Join(root, pluginFile)
 
-	// Leave user-owned or third-party Kilo plugins untouched; uninstall only
-	// removes the Entire-generated plugin identified by the ownership marker.
-	if existing, err := os.ReadFile(path); err == nil && !isOwnedPlugin(existing) {
+	// Leave user-owned, symlinked, or otherwise non-regular Kilo plugins
+	// untouched; uninstall only removes a regular Entire-generated plugin.
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
 		return nil
-	} else if os.IsNotExist(err) {
-		return nil
-	} else if err != nil {
+	}
+	if err != nil {
 		return err
+	}
+	if !info.Mode().IsRegular() {
+		return nil
+	}
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if !isOwnedPlugin(existing) {
+		return nil
 	}
 
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {

--- a/agents/entire-agent-kilo/internal/kilo/hooks.go
+++ b/agents/entire-agent-kilo/internal/kilo/hooks.go
@@ -232,9 +232,13 @@ func (a *Agent) InstallHooks(localDev bool, force bool) (int, error) {
 
 	path := filepath.Join(root, pluginFile)
 	if info, lstatErr := os.Lstat(path); lstatErr == nil {
-		// Never follow an existing symlink or overwrite a non-regular path. A
-		// forced install replaces the directory entry atomically rather than
-		// writing through it.
+		// Replacing a directory would require deleting potentially user-owned
+		// data. Force only permits replacing other directory entries.
+		if info.IsDir() {
+			return 0, fmt.Errorf("refusing to replace kilo plugin directory %s; move or remove the directory before installing", path)
+		}
+		// A forced install replaces symlinks and other non-regular entries
+		// atomically rather than writing through them.
 		if !info.Mode().IsRegular() {
 			if !force {
 				return 0, fmt.Errorf("refusing to overwrite non-regular kilo plugin %s; pass force to replace it", path)
@@ -313,13 +317,8 @@ func isOwnedPlugin(data []byte) bool {
 }
 
 func (a *Agent) AreHooksInstalled() bool {
-	// Kilo skips loading external plugins in pure mode. A generated plugin file
-	// may still exist, but it is not active in that mode, so reporting hooks as
-	// installed would make Entire believe lifecycle events are being emitted.
-	if strings.TrimSpace(os.Getenv("KILO_PURE")) == "1" {
-		return false
-	}
-
+	// Installation detection must include plugins disabled by KILO_PURE so
+	// Entire's uninstall sweep can still discover and remove them.
 	root := protocol.RepoRoot()
 	data, err := os.ReadFile(filepath.Join(root, pluginFile))
 	return err == nil && isOwnedPlugin(data)

--- a/agents/entire-agent-kilo/internal/kilo/hooks.go
+++ b/agents/entire-agent-kilo/internal/kilo/hooks.go
@@ -278,9 +278,9 @@ func (a *Agent) UninstallHooks() error {
 	root := protocol.RepoRoot()
 	path := filepath.Join(root, pluginFile)
 
-	// Leave user-owned, symlinked, or otherwise non-regular Kilo plugins
-	// untouched; uninstall only removes a regular Entire-generated plugin.
-	info, err := os.Lstat(path)
+	// Stat follows links only to inspect ownership of regular-file targets.
+	// Remove below unlinks path itself, preserving any symlink target.
+	info, err := os.Stat(path)
 	if os.IsNotExist(err) {
 		return nil
 	}
@@ -320,7 +320,12 @@ func (a *Agent) AreHooksInstalled() bool {
 	// Installation detection must include plugins disabled by KILO_PURE so
 	// Entire's uninstall sweep can still discover and remove them.
 	root := protocol.RepoRoot()
-	data, err := os.ReadFile(filepath.Join(root, pluginFile))
+	path := filepath.Join(root, pluginFile)
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	data, err := os.ReadFile(path)
 	return err == nil && isOwnedPlugin(data)
 }
 

--- a/agents/entire-agent-kilo/internal/kilo/hooks_test.go
+++ b/agents/entire-agent-kilo/internal/kilo/hooks_test.go
@@ -195,6 +195,87 @@ func TestParseHookMissingSessionID(t *testing.T) {
 	}
 }
 
+func TestInstallHooksRefusesForeignPluginWithoutForce(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repo)
+	a := New()
+
+	// Install the Entire-generated plugin once to establish ownership.
+	if _, err := a.InstallHooks(false, false); err != nil {
+		t.Fatalf("first install error: %v", err)
+	}
+
+	pluginPath := filepath.Join(repo, pluginFile)
+	if err := os.WriteFile(pluginPath, []byte("// user's custom kilo plugin\nexport default {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Default install must refuse to overwrite the foreign plugin.
+	count, err := a.InstallHooks(false, false)
+	if err == nil || count != 0 {
+		t.Fatalf("foreign install count=%d err=%v, want error", count, err)
+	}
+	foreign, readErr := os.ReadFile(pluginPath)
+	if readErr != nil || !strings.Contains(string(foreign), "user's custom kilo plugin") {
+		t.Fatalf("foreign plugin was changed: %q err=%v", foreign, readErr)
+	}
+
+	// Explicit force install may replace the foreign plugin.
+	count, err = a.InstallHooks(false, true)
+	if err != nil || count != 1 {
+		t.Fatalf("forced install count=%d err=%v, want success", count, err)
+	}
+	if !a.AreHooksInstalled() {
+		t.Fatal("generated plugin should be installed after forced replacement")
+	}
+}
+
+func TestUninstallHooksLeavesForeignPluginUntouched(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repo)
+	a := New()
+
+	pluginPath := filepath.Join(repo, pluginFile)
+	if err := os.MkdirAll(filepath.Dir(pluginPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pluginPath, []byte("// user's custom kilo plugin\nexport default {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := a.UninstallHooks(); err != nil {
+		t.Fatalf("uninstall error: %v", err)
+	}
+	data, readErr := os.ReadFile(pluginPath)
+	if readErr != nil || string(data) != "// user's custom kilo plugin\nexport default {}\n" {
+		t.Fatalf("uninstall changed foreign plugin: %q err=%v", data, readErr)
+	}
+}
+
+func TestAreHooksInstalledRequiresOwnershipMarker(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repo)
+	a := New()
+
+	pluginPath := filepath.Join(repo, pluginFile)
+	if err := os.MkdirAll(filepath.Dir(pluginPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pluginPath, []byte("// user's custom kilo plugin\nexport default {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if a.AreHooksInstalled() {
+		t.Fatal("foreign plugin reported as installed")
+	}
+	if err := a.UninstallHooks(); err != nil {
+		t.Fatal(err)
+	}
+	data, readErr := os.ReadFile(pluginPath)
+	if readErr != nil || !strings.Contains(string(data), "user's custom kilo plugin") {
+		t.Fatalf("uninstall changed foreign plugin: %q err=%v", data, readErr)
+	}
+}
+
 func TestInstallAndUninstallHooks(t *testing.T) {
 	repo := t.TempDir()
 	t.Setenv("ENTIRE_REPO_ROOT", repo)

--- a/agents/entire-agent-kilo/internal/kilo/hooks_test.go
+++ b/agents/entire-agent-kilo/internal/kilo/hooks_test.go
@@ -512,3 +512,55 @@ func TestInstallHooksRejectsDirectoryEvenWithForce(t *testing.T) {
 		})
 	}
 }
+
+func TestUninstallHooksHandlesPluginSymlinks(t *testing.T) {
+	for _, kind := range []string{"owned", "foreign", "dangling"} {
+		t.Run(kind, func(t *testing.T) {
+			repo := t.TempDir()
+			t.Setenv("ENTIRE_REPO_ROOT", repo)
+			a := New()
+			path := filepath.Join(repo, pluginFile)
+			if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+				t.Fatal(err)
+			}
+			target := filepath.Join(t.TempDir(), "plugin.ts")
+			content := "// user plugin"
+			if kind == "owned" {
+				content = generatePlugin()
+			}
+			if kind != "dangling" {
+				if err := os.WriteFile(target, []byte(content), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := os.Symlink(target, path); err != nil {
+				t.Fatal(err)
+			}
+			if got := a.AreHooksInstalled(); got != (kind == "owned") {
+				t.Fatalf("installed = %t for %s", got, kind)
+			}
+			if err := a.UninstallHooks(); err != nil {
+				t.Fatal(err)
+			}
+			_, err := os.Lstat(path)
+			if kind == "owned" {
+				if !os.IsNotExist(err) {
+					t.Fatalf("owned link remains: %v", err)
+				}
+				if a.AreHooksInstalled() {
+					t.Fatal("hooks still installed")
+				}
+			} else if err != nil {
+				t.Fatalf("foreign or dangling link removed: %v", err)
+			}
+			data, err := os.ReadFile(target)
+			if kind == "dangling" {
+				if !os.IsNotExist(err) {
+					t.Fatalf("dangling target changed: %v", err)
+				}
+			} else if err != nil || string(data) != content {
+				t.Fatalf("target modified: %v", err)
+			}
+		})
+	}
+}

--- a/agents/entire-agent-kilo/internal/kilo/hooks_test.go
+++ b/agents/entire-agent-kilo/internal/kilo/hooks_test.go
@@ -355,7 +355,7 @@ func TestUninstallHooksRemovesEmptyPluginDirectories(t *testing.T) {
 	}
 }
 
-func TestAreHooksInstalledHonorsKiloPure(t *testing.T) {
+func TestAreHooksInstalledAllowsUninstallInKiloPure(t *testing.T) {
 	repo := t.TempDir()
 	t.Setenv("ENTIRE_REPO_ROOT", repo)
 	a := New()
@@ -366,8 +366,14 @@ func TestAreHooksInstalledHonorsKiloPure(t *testing.T) {
 		t.Fatal("hooks should be installed outside pure mode")
 	}
 	t.Setenv("KILO_PURE", "1")
+	// Entire only uninstalls adapters that report installed hooks.
 	if a.AreHooksInstalled() {
-		t.Fatal("hooks should not be reported as installed in pure mode")
+		if err := a.UninstallHooks(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := os.Lstat(filepath.Join(repo, pluginFile)); !os.IsNotExist(err) {
+		t.Fatalf("owned plugin remains after uninstall in pure mode: %v", err)
 	}
 }
 
@@ -475,5 +481,34 @@ func TestSafeSessionID(t *testing.T) {
 		if got := safeSessionID(in); got != want {
 			t.Errorf("safeSessionID(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+func TestInstallHooksRejectsDirectoryEvenWithForce(t *testing.T) {
+	for _, force := range []bool{false, true} {
+		name := "without force"
+		if force {
+			name = "with force"
+		}
+		t.Run(name, func(t *testing.T) {
+			repo := t.TempDir()
+			t.Setenv("ENTIRE_REPO_ROOT", repo)
+			path := filepath.Join(repo, pluginFile)
+			if err := os.MkdirAll(path, 0o750); err != nil {
+				t.Fatal(err)
+			}
+			child := filepath.Join(path, "keep.txt")
+			if err := os.WriteFile(child, []byte("user data"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			count, err := New().InstallHooks(false, force)
+			if err == nil || count != 0 || !strings.Contains(err.Error(), "move or remove the directory") {
+				t.Fatalf("count=%d err=%v, want explicit directory guidance", count, err)
+			}
+			data, err := os.ReadFile(child)
+			if err != nil || string(data) != "user data" {
+				t.Fatalf("directory contents changed: %q, %v", data, err)
+			}
+		})
 	}
 }

--- a/agents/entire-agent-kilo/internal/kilo/hooks_test.go
+++ b/agents/entire-agent-kilo/internal/kilo/hooks_test.go
@@ -276,6 +276,101 @@ func TestAreHooksInstalledRequiresOwnershipMarker(t *testing.T) {
 	}
 }
 
+func TestInstallHooksRefusesSymlinkWithoutForce(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repo)
+	a := New()
+
+	pluginPath := filepath.Join(repo, pluginFile)
+	outside := filepath.Join(t.TempDir(), "outside.ts")
+	if err := os.MkdirAll(filepath.Dir(pluginPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, pluginPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := a.InstallHooks(false, false); err == nil {
+		t.Fatal("install should reject a plugin symlink without force")
+	}
+	if _, err := os.Lstat(pluginPath); err != nil {
+		t.Fatalf("plugin symlink was unexpectedly removed: %v", err)
+	}
+	if _, err := os.Stat(outside); !os.IsNotExist(err) {
+		t.Fatalf("install wrote through symlink to %s", outside)
+	}
+
+	count, err := a.InstallHooks(false, true)
+	if err != nil || count != 1 {
+		t.Fatalf("forced install count=%d err=%v, want 1 and success", count, err)
+	}
+	info, err := os.Lstat(pluginPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("forced install left the plugin as a symlink")
+	}
+}
+
+func TestInstallHooksForceRepairsPermissionsForIdenticalContent(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repo)
+	a := New()
+
+	if _, err := a.InstallHooks(false, false); err != nil {
+		t.Fatal(err)
+	}
+	pluginPath := filepath.Join(repo, pluginFile)
+	if err := os.Chmod(pluginPath, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	count, err := a.InstallHooks(false, true)
+	if err != nil || count != 1 {
+		t.Fatalf("forced identical install count=%d err=%v, want 1 and success", count, err)
+	}
+	info, err := os.Stat(pluginPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("forced install permissions = %o, want 600", got)
+	}
+}
+
+func TestUninstallHooksRemovesEmptyPluginDirectories(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repo)
+	a := New()
+	if _, err := a.InstallHooks(false, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.UninstallHooks(); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{filepath.Join(repo, pluginDir), filepath.Join(repo, ".kilo")} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("directory %s still exists, err=%v", path, err)
+		}
+	}
+}
+
+func TestAreHooksInstalledHonorsKiloPure(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repo)
+	a := New()
+	if _, err := a.InstallHooks(false, false); err != nil {
+		t.Fatal(err)
+	}
+	if !a.AreHooksInstalled() {
+		t.Fatal("hooks should be installed outside pure mode")
+	}
+	t.Setenv("KILO_PURE", "1")
+	if a.AreHooksInstalled() {
+		t.Fatal("hooks should not be reported as installed in pure mode")
+	}
+}
+
 func TestInstallAndUninstallHooks(t *testing.T) {
 	repo := t.TempDir()
 	t.Setenv("ENTIRE_REPO_ROOT", repo)
@@ -339,6 +434,11 @@ func TestInstallAndUninstallHooks(t *testing.T) {
 	}
 	if a.AreHooksInstalled() {
 		t.Fatal("hooks should not be installed after uninstall")
+	}
+	for _, path := range []string{filepath.Join(repo, pluginDir), filepath.Join(repo, ".kilo")} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("directory %s still exists after uninstall, err=%v", path, err)
+		}
 	}
 }
 

--- a/agents/entire-agent-kilo/internal/kilo/session_jsonl.go
+++ b/agents/entire-agent-kilo/internal/kilo/session_jsonl.go
@@ -81,7 +81,7 @@ func parseKiloExport(raw []byte) ([]SessionMessage, error) {
 
 // atomicWriteFile writes data to path via a temp file + rename so a crash
 // mid-write cannot leave a partially-written transcript behind.
-func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
+func atomicWriteFile(path string, data []byte, mode os.FileMode) error { //nolint:unparam // Keep permissions configurable for callers needing other file modes.
 	dir := filepath.Dir(path)
 	tmp, err := os.CreateTemp(dir, ".kilo-write-*")
 	if err != nil {


### PR DESCRIPTION
## Summary

The Kilo adapter's `InstallHooks` previously replaced `.kilo/plugins/entire.ts` whenever its content differed from the generated plugin, and `UninstallHooks` removed that file unconditionally. If a user or a third-party tool placed its own plugin at that path first, a default `entire enable --agent kilo` run would silently overwrite it, and a default `entire disable --agent kilo` run would delete it. This change aligns the Kilo adapter with the ownership contract already established by the `entire-agent-omp` adapter: lifecycle operations now recognize the `Auto-generated by \`entire enable --agent kilo\`` marker and only act on files Entire itself generated.

## Changes

`agents/entire-agent-kilo/internal/kilo/hooks.go`

- Added an `isOwnedPlugin` helper that recognizes the generated plugin by its ownership marker, mirroring `isOwnedExtension` in the omp adapter.
- `InstallHooks` now returns `0, nil` when the existing file already matches the generated content, and returns a descriptive error when the file exists but is not owned by Entire. An explicit `force` install may still replace a foreign plugin, making deliberate replacement an opt-in rather than a default.
- `UninstallHooks` now exits as a safe no-op when the plugin file is foreign, and leaves the file untouched in all other cases except removing an owned plugin.
- `AreHooksInstalled` now reports installed only when the file carries the ownership marker, so an unrelated file at the plugin path is never mistaken for an active Entire integration.

## Why this matters

A silently overwritten user plugin destroys developer configuration without any indication, and a removed third-party plugin breaks the agent the user relies on daily. Detecting and repairing the damage requires comparing against user-remembered content; preventing it is free. The fix keeps the integration's existing semantics for the vast majority of users, whose plugin file is Entire-generated, while making the failure mode explicit and recoverable for everyone else.

## Testing

Three new focused regression tests were added alongside the existing lifecycle suite:

| Test | Coverage |
|---|---|
| `TestInstallHooksRefusesForeignPluginWithoutForce` | default install refuses foreign plugin, file content preserved, forced install replaces it and installs cleanly |
| `TestUninstallHooksLeavesForeignPluginUntouched` | uninstall leaves a foreign plugin in place |
| `TestAreHooksInstalledRequiresOwnershipMarker` | a foreign plugin is never reported as installed, and uninstall still does not touch it |

The pre-existing `TestInstallAndUninstallHooks` suite continues to pass unchanged, since its install/uninstall cycle works with an Entire-generated (owned) plugin throughout.

## Compatibility

The change is behavior-preserving for every deployment where the plugin path is Entire-generated or absent, which is the overwhelmingly common case. Users who previously relied on `InstallHooks` overwriting a foreign plugin will now receive a clear error explaining that `force` is required. No protocol JSON surface, hook event format, or transcript format changes.

## Checklist

- Follows the existing adapter conventions (`pluginMarker`-based ownership)
- Adds deterministic unit tests (no Kilo binary or Entire CLI required)
- Preserves all existing lifecycle test behavior
- No changes to protocol handlers or the `entire-agent-tests` compliance suite required