### PR TITLE
docs: list Goose in the Available Agents table

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ External agents communicate with Entire CLI via subcommands that accept and retu
 | [Qwen Code](agents/entire-agent-qwen/) | `agents/entire-agent-qwen/` | Implemented — hooks + transcript analysis + compact transcripts |
 | [Oh My Pi](agents/entire-agent-omp/) | `agents/entire-agent-omp/` | Implemented — hooks + transcript analysis + compact transcripts |
 | [Kilo](agents/entire-agent-kilo/) | `agents/entire-agent-kilo/` | Implemented (preview) — hooks + transcript analysis + token calculation + compact transcripts |
+| [Goose](agents/entire-agent-goose/) | `agents/entire-agent-goose/` | Implemented (preview) — hooks + transcript analysis + token calculation + compact transcripts |
 
 See each agent's own README for setup and usage instructions.
 


### PR DESCRIPTION
### What
Adds the **Goose** agent to the "Available Agents" table in the README.

### Why
`agents/entire-agent-goose/` is a fully wired external agent — it's registered in the e2e lifecycle harness (`e2e/agents/goose.go`) and ships unit tests — but it was missing from the README table, so users can't discover it.

Its `Info()` declares `IsPreview: true` and the full capability set (`Hooks`, `TranscriptAnalyzer`, `TranscriptPreparer`, `TokenCalculator`, `CompactTranscript`), so I listed it as **"Implemented (preview)"** to match the existing Kilo row.

### Testing
Docs-only change; no code affected.