### PR TITLE
fix(qwen): read sidecar records larger than 64 KB and skip torn lines

### DIFF
--- a/agents/entire-agent-qwen/internal/qwen/review_regression_test.go
+++ b/agents/entire-agent-qwen/internal/qwen/review_regression_test.go
@@ -1,0 +1,43 @@
+package qwen
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSidecarOffsetsIncludeMalformedAndBlankLines(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	data := `{"event":"UserPromptSubmit","prompt":"first"}` + "\n" +
+		`{"event":"UserPromptSubmit","prompt":"must not survive","v":"invalid"}` + "\n\n" +
+		`{"event":"UserPromptSubmit","prompt":"second"}` + "\n"
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	a := New()
+	pos, err := a.GetTranscriptPosition(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pos != 4 {
+		t.Errorf("position = %d, want physical line count 4", pos)
+	}
+	prompts, err := a.ExtractPrompts(path, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prompts) != 1 || prompts[0] != "second" {
+		t.Errorf("prompts after line 3 = %v, want second", prompts)
+	}
+	prompts, err = a.ExtractPrompts(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prompts) != 2 {
+		t.Errorf("malformed record leaked partial data: %v", prompts)
+	}
+	_, current, err := a.ExtractModifiedFiles(path, 3)
+	if err != nil || current != 4 {
+		t.Errorf("current = %d, err = %v, want 4", current, err)
+	}
+}

--- a/agents/entire-agent-qwen/internal/qwen/transcript.go
+++ b/agents/entire-agent-qwen/internal/qwen/transcript.go
@@ -316,6 +316,18 @@ func safeFilename(name string) string {
 	return out
 }
 
+// maxSidecarLine bounds a single sidecar record. One record embeds a whole
+// tool_input/tool_response, so 64 KB (bufio.Scanner's default) is far too
+// small: a single large file read or write would make every transcript
+// operation on that session fail with "token too long", permanently, because
+// the oversized record stays on disk. 10 MB matches the limit the other JSONL
+// transcript scanners use.
+const maxSidecarLine = 10 * 1024 * 1024
+
+// readSidecarRecords parses the append-only JSONL sidecar. Unparseable lines
+// are skipped rather than failing the whole read: the sidecar can be read
+// while Qwen is mid-turn, and a single torn or foreign line must not destroy
+// the rest of the session.
 func readSidecarRecords(path string) ([]sidecarRecord, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -325,14 +337,15 @@ func readSidecarRecords(path string) ([]sidecarRecord, error) {
 
 	var records []sidecarRecord
 	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), maxSidecarLine)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
 			continue
 		}
 		var record sidecarRecord
-		if err := json.Unmarshal([]byte(line), &record); err != nil {
-			return nil, err
+		if json.Unmarshal([]byte(line), &record) != nil {
+			continue
 		}
 		records = append(records, record)
 	}

--- a/agents/entire-agent-qwen/internal/qwen/transcript.go
+++ b/agents/entire-agent-qwen/internal/qwen/transcript.go
@@ -325,7 +325,7 @@ func safeFilename(name string) string {
 const maxSidecarLine = 10 * 1024 * 1024
 
 // readSidecarRecords parses the append-only JSONL sidecar. Unparseable lines
-// are skipped rather than failing the whole read: the sidecar can be read
+// retain empty placeholders rather than failing the whole read: the sidecar can be read
 // while Qwen is mid-turn, and a single torn or foreign line must not destroy
 // the rest of the session.
 func readSidecarRecords(path string) ([]sidecarRecord, error) {
@@ -340,12 +340,12 @@ func readSidecarRecords(path string) ([]sidecarRecord, error) {
 	scanner.Buffer(make([]byte, 64*1024), maxSidecarLine)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
-		}
 		var record sidecarRecord
 		if json.Unmarshal([]byte(line), &record) != nil {
-			continue
+			// Keep a placeholder for every physical line: Entire slices the
+			// original bytes by newline, including blank and malformed lines.
+			// Reset partial fields populated before a JSON type error, too.
+			record = sidecarRecord{}
 		}
 		records = append(records, record)
 	}

--- a/agents/entire-agent-qwen/internal/qwen/transcript_test.go
+++ b/agents/entire-agent-qwen/internal/qwen/transcript_test.go
@@ -1,0 +1,109 @@
+package qwen
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// A single Qwen hook record is not bounded by 64 KB: tool_response for a large
+// file read, or tool_input for a large write, routinely exceeds it. Every
+// transcript operation must still see the whole session.
+func TestSidecarRecordLargerThanScannerDefault(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repo)
+	agent := New()
+
+	big, err := json.Marshal(strings.Repeat("x", 128*1024))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inputs := []string{
+		`{"session_id":"big","timestamp":"2026-05-20T12:00:00Z","prompt":"Read the file"}`,
+		`{"session_id":"big","timestamp":"2026-05-20T12:00:01Z","tool_name":"write_file","tool_use_id":"tool-1","tool_input":{"file_path":"hello.txt"},"tool_response":` + string(big) + `}`,
+		`{"session_id":"big","timestamp":"2026-05-20T12:00:02Z","last_assistant_message":"done"}`,
+	}
+	hooks := []string{HookNameUserPromptSubmit, HookNamePostToolUse, HookNameStop}
+	for i, hook := range hooks {
+		if _, err := agent.ParseHook(hook, []byte(inputs[i])); err != nil {
+			t.Fatalf("ParseHook(%s): %v", hook, err)
+		}
+	}
+
+	sessionRef := agent.sidecarPath("big")
+
+	position, err := agent.GetTranscriptPosition(sessionRef)
+	if err != nil {
+		t.Fatalf("GetTranscriptPosition: %v", err)
+	}
+	if position != 3 {
+		t.Fatalf("expected 3 records, got %d", position)
+	}
+
+	files, current, err := agent.ExtractModifiedFiles(sessionRef, 0)
+	if err != nil {
+		t.Fatalf("ExtractModifiedFiles: %v", err)
+	}
+	if current != 3 {
+		t.Fatalf("expected current position 3, got %d", current)
+	}
+	if len(files) != 1 || files[0] != "hello.txt" {
+		t.Fatalf("unexpected modified files: %#v", files)
+	}
+
+	prompts, err := agent.ExtractPrompts(sessionRef, 0)
+	if err != nil {
+		t.Fatalf("ExtractPrompts: %v", err)
+	}
+	if len(prompts) != 1 || prompts[0] != "Read the file" {
+		t.Fatalf("unexpected prompts: %#v", prompts)
+	}
+
+	summary, ok, err := agent.ExtractSummary(sessionRef)
+	if err != nil {
+		t.Fatalf("ExtractSummary: %v", err)
+	}
+	if !ok || summary != "done" {
+		t.Fatalf("unexpected summary %q ok=%v", summary, ok)
+	}
+}
+
+// The sidecar is append-only and is read while Qwen is still running, so a
+// torn final line is normal. It must not destroy the records already written.
+func TestSidecarSkipsUnparseableLine(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repo)
+	agent := New()
+
+	if _, err := agent.ParseHook(HookNameUserPromptSubmit,
+		[]byte(`{"session_id":"torn","timestamp":"2026-05-20T12:00:00Z","prompt":"Create hello.txt"}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionRef := agent.sidecarPath("torn")
+	f, err := os.OpenFile(sessionRef, os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A record whose write was interrupted mid-line.
+	if _, err := f.WriteString(`{"v":1,"agent":"qwen","event":"PostToolUse","tool_inp` + "\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	prompts, err := agent.ExtractPrompts(sessionRef, 0)
+	if err != nil {
+		t.Fatalf("ExtractPrompts: %v", err)
+	}
+	if len(prompts) != 1 || prompts[0] != "Create hello.txt" {
+		t.Fatalf("unexpected prompts: %#v", prompts)
+	}
+
+	if _, err := agent.GetTranscriptPosition(sessionRef); err != nil {
+		t.Fatalf("GetTranscriptPosition: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

`readSidecarRecords` (`agents/entire-agent-qwen/internal/qwen/transcript.go`) built a
`bufio.Scanner` with no `Buffer()` call, so a single sidecar record was capped at
`bufio.MaxScanTokenSize` (64 KB).

A qwen sidecar record embeds the hook payload's whole `tool_input` and `tool_response`.
A `write_file` of a moderate source file, or a `read_file` of one, produces a record well
over 64 KB. When that happens the scanner stops with `bufio.Scanner: token too long` and
the function returns that error, so **every** transcript operation on the session fails:

- `get-transcript-position`
- `extract-modified-files`
- `extract-prompts`
- `extract-summary`

The sidecar is append-only, so the oversized record stays on disk and the failure is
permanent for the rest of that session — one large tool call ends capture for the session.

The same loop also returned `nil, err` for the entire file when any single line failed to
unmarshal. Entire reads the sidecar while qwen is still running, so a torn final line is a
normal transient state; it must not discard the records already written.

## Fix

- `scanner.Buffer(make([]byte, 64*1024), 10*1024*1024)`
- skip unparseable lines instead of failing the whole read

This is what the other JSONL transcript scanners in this repo already do:

- `agents/entire-agent-kilo/internal/kilo/session_jsonl.go` (10 MB limit, skips
  unparseable lines)
- `agents/entire-agent-omp/internal/omp/session.go` (10 MB limit, skips unparseable lines)

and what the Entire CLI does at every JSONL scan site, e.g.
`cmd/entire/cli/agent/copilotcli/transcript.go` ("10 MB max line", "skip malformed lines")
and `cmd/entire/cli/agent/pi/pijsonl/pijsonl.go` ("10 MB matches what other in-tree
transcript scanners use").

## Tests

`internal/qwen` had no transcript tests. Adds `transcript_test.go` with two regressions:

- `TestSidecarRecordLargerThanScannerDefault` — a 128 KB `tool_response`; all four
  transcript operations must still see the full session.
- `TestSidecarSkipsUnparseableLine` — a torn trailing record must not hide the completed
  ones.

Both were verified to fail against the old behaviour:

- dropping the `scanner.Buffer` call → `GetTranscriptPosition: bufio.Scanner: token too long`
- restoring `return nil, err` on unmarshal → `ExtractPrompts: unexpected end of JSON input`

## Verification

Gated locally (Actions may not have run):

```
go test ./...                 # agents/entire-agent-qwen — ok
golangci-lint run ./...       # 0 issues, repo .golangci.yaml
gofmt -l .                    # clean
```
