### PR TITLE
fix(qwen): resolve entire through PATH in installed hook commands

### DIFF
--- a/agents/entire-agent-qwen/internal/qwen/hooks.go
+++ b/agents/entire-agent-qwen/internal/qwen/hooks.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -359,12 +358,15 @@ func marshalHookType(rawHooks map[string]json.RawMessage, event string, matchers
 	}
 }
 
+// hookCommand renders the command written into .qwen/settings.json. It names
+// the binary as plain `entire` so it is resolved through PATH when the hook
+// runs, matching every other Entire hook installer. Baking in the absolute
+// path `entire` happened to have at install time would put a machine-specific
+// path into a repo-local settings file that is routinely committed; on any
+// other machine that path does not exist, the `command -v` guard fails, and
+// every hook silently becomes a no-op.
 func hookCommand(hookName string) string {
-	entire := "entire"
-	if path, err := exec.LookPath("entire"); err == nil && strings.TrimSpace(path) != "" {
-		entire = path
-	}
-	return fmt.Sprintf("sh -c 'if command -v %s >/dev/null 2>&1; then %s hooks qwen %s >/dev/null 2>&1 || true; fi'", shellQuote(entire), shellQuote(entire), hookName)
+	return fmt.Sprintf("sh -c 'if command -v entire >/dev/null 2>&1; then entire hooks qwen %s >/dev/null 2>&1 || true; fi'", hookName)
 }
 
 func hookExists(matchers []qwenHookMatcher, matcher string, entryName string) bool {

--- a/agents/entire-agent-qwen/internal/qwen/hooks.go
+++ b/agents/entire-agent-qwen/internal/qwen/hooks.go
@@ -388,8 +388,9 @@ func upsertHook(matchers []qwenHookMatcher, matcher string, entryName string, co
 		if matchers[i].Matcher == matcher {
 			for j := range matchers[i].Hooks {
 				if isEntireHook(matchers[i].Hooks[j]) && matchers[i].Hooks[j].Name == entryName {
+					changed := matchers[i].Hooks[j].Command != command
 					matchers[i].Hooks[j] = entireHookEntry(entryName, command)
-					return matchers, false
+					return matchers, changed
 				}
 			}
 			matchers[i].Hooks = append(matchers[i].Hooks, entireHookEntry(entryName, command))

--- a/agents/entire-agent-qwen/internal/qwen/hooks_test.go
+++ b/agents/entire-agent-qwen/internal/qwen/hooks_test.go
@@ -1,0 +1,72 @@
+package qwen
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The installed hook command lands in .qwen/settings.json, a repo-local file
+// that is routinely committed and shared. It must resolve `entire` through
+// PATH when the hook runs, never bake in whatever absolute path `entire`
+// happened to have on the installing machine — that path does not exist on a
+// teammate's machine or in CI, where the `command -v` guard then makes every
+// hook a silent no-op and the session is never captured.
+func TestInstallHooksResolvesEntireThroughPATH(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repo)
+
+	// Put an `entire` executable on PATH at a path unique to this machine.
+	binDir := t.TempDir()
+	entirePath := filepath.Join(binDir, "entire")
+	if err := os.WriteFile(entirePath, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+
+	if _, err := New().InstallHooks(false, false); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(repo, ".qwen", "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), binDir) {
+		t.Fatalf("hook command baked in the install-time absolute path %q:\n%s", entirePath, data)
+	}
+
+	var settings struct {
+		Hooks map[string][]struct {
+			Hooks []struct {
+				Name    string `json:"name"`
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatal(err)
+	}
+	found := 0
+	for _, matchers := range settings.Hooks {
+		for _, matcher := range matchers {
+			for _, hook := range matcher.Hooks {
+				if !strings.HasPrefix(hook.Name, "entire-") {
+					continue
+				}
+				found++
+				if !strings.Contains(hook.Command, "command -v entire ") {
+					t.Fatalf("hook %s does not probe entire on PATH: %s", hook.Name, hook.Command)
+				}
+				if !strings.Contains(hook.Command, "entire hooks qwen ") {
+					t.Fatalf("hook %s does not invoke entire from PATH: %s", hook.Name, hook.Command)
+				}
+			}
+		}
+	}
+	if found != len(hookSpecs) {
+		t.Fatalf("expected %d entire hooks, found %d", len(hookSpecs), found)
+	}
+}

--- a/agents/entire-agent-qwen/internal/qwen/hooks_test.go
+++ b/agents/entire-agent-qwen/internal/qwen/hooks_test.go
@@ -70,3 +70,37 @@ func TestInstallHooksResolvesEntireThroughPATH(t *testing.T) {
 		t.Fatalf("expected %d entire hooks, found %d", len(hookSpecs), found)
 	}
 }
+
+func TestInstallHooksMigratesExistingAbsoluteCommands(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repo)
+	a := New()
+	if _, err := a.InstallHooks(false, false); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(repo, ".qwen", "settings.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Model a settings file written by the previous installer.
+	data = []byte(strings.ReplaceAll(string(data), "command -v entire ", "command -v /old/machine/entire "))
+	data = []byte(strings.ReplaceAll(string(data), "then entire hooks", "then /old/machine/entire hooks"))
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.InstallHooks(false, false); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(updated), "/old/machine/entire") {
+		t.Fatal("existing absolute commands were not migrated")
+	}
+	count, err := a.InstallHooks(false, false)
+	if err != nil || count != 0 {
+		t.Fatalf("reinstall count = %d, err = %v", count, err)
+	}
+}


### PR DESCRIPTION
## Problem

`hookCommand` resolved the CLI at install time and wrote the resulting absolute path
into the generated hook command:

```go
entire := "entire"
if path, err := exec.LookPath("entire"); err == nil && strings.TrimSpace(path) != "" {
    entire = path
}
return fmt.Sprintf("sh -c 'if command -v %s ...; then %s hooks qwen %s ...; fi'", ...)
```

`.qwen/settings.json` is a repo-local file that is routinely committed and shared, so the
hook command carried one machine's install prefix into the repository.

On any machine where that path does not exist — a teammate's checkout, a different install
method, a container, CI — the command's own `command -v` guard fails and **every qwen hook
becomes a silent no-op**. No session-start, no prompts, no stop; the session is never
captured and nothing reports an error, because the guard exists precisely to exit 0 when
the CLI is absent.

It also makes the generated command depend on where `entire` happened to be at install
time, so a reinstall that moves the binary rewrites every hook entry in the file.

## Fix

Name the binary as plain `entire` and let PATH resolve it when the hook runs.

That matches:

- the Entire CLI, which generates every hook command as `entire hooks <target> <verb>` —
  `cmd/entire/cli/agent/hook_command.go` documents this as "the entire binary resolved
  through PATH", and `WrapProductionSilentHookCommand` wraps it with the same
  `command -v entire` guard used here;
- the CLI's own Gemini CLI installer, which writes `entire hooks gemini <verb>` into the
  equivalent `.gemini/settings.json` (Qwen Code is a Gemini CLI fork and reads hooks the
  same way);
- the other five agents in this repo (`amp`, `goose`, `kilo`, `kiro`, `omp`), all of which
  emit a bare `entire`.

The `command -v` guard, the output redirection and the `|| true` are unchanged — this
commit only changes how the binary is named.

## Tests

`TestInstallHooksResolvesEntireThroughPATH` puts an `entire` executable in a temp dir,
points `PATH` at it, installs the hooks, and asserts the written settings contain no
absolute path and that every `entire-*` hook invokes `entire hooks qwen …` by name.

Mutation-verified: restoring the `exec.LookPath` lookup still compiles and the test fails
with `hook command baked in the install-time absolute path "/var/folders/…/entire"`.

## Verification

Gated locally (Actions may not have run):

```
go test ./...                 # agents/entire-agent-qwen — ok, 24 tests
golangci-lint run ./...       # 0 issues, repo .golangci.yaml
gofmt -l .                    # clean
```
