### PR TITLE
ci(lint): install Go via mise instead of setup-go "stable"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,9 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: "stable"
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
       - name: Check formatting
         run: |
@@ -65,9 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: "stable"
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
@@ -80,9 +76,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: "stable"
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
 
       - name: Run golangci-lint (e2e)
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0


### PR DESCRIPTION
Every `Lint` run in this repository has failed since 2026-08-29. The last green one was on 2026-08-28.

## Cause

`.github/workflows/lint.yml` pinned `go-version: "stable"` in all three jobs. Upstream `stable` rolled to **Go 1.27.0**, while `golangci-lint v2.11.3` (the version the workflow installs, and the version `mise.toml` pins) is built with Go 1.26 and cannot decode Go 1.27 export data.

From run [33254909126](https://github.com/entireio/external-agents/actions/runs/33254909126):

```
Setup go version spec stable
go version go1.27.0 linux/amd64
...
lint-agents: could not import encoding/json (.../go/1.27.0/x64/src/encoding/json/v2_decode.go:13:2:
  could not import cmp (-: could not load export data: internal error in importing "cmp"
  (cannot decode "cmp", export data version 4 is greater than maximum supported version 2)))
lint-e2e:    panic: file requires newer Go version go1.27 (application built with go1.26)
```

It fails identically for all six agent directories and for `e2e`, so it is not agent-specific — it blocks every open PR.

`mise.toml` pins `go = "1.26.0"`, which is why the same lint passes locally and fails only in CI.

## Fix

Use `jdx/mise-action` in `lint.yml`, exactly as `ci.yml` and `protocol-compliance.yml` already do. The Go toolchain then comes from `mise.toml`, so the Go version and the golangci-lint version have a single source of truth and cannot drift apart again. `ci.yml` stayed green throughout this outage for precisely that reason.

A future Go bump becomes one edit to `mise.toml`, made together with the matching golangci-lint bump.

## Verification

This is a CI-configuration change, so the proof is the `Lint` check on this PR going green. No unit test applies.