### PR TITLE
fix(amp): store the transcript as JSONL so checkpoint scoping works

### DIFF
--- a/agents/entire-agent-amp/internal/amp/command_runner.go
+++ b/agents/entire-agent-amp/internal/amp/command_runner.go
@@ -6,28 +6,24 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 )
 
 // CommandRunner defines the interface for running `amp` commands, allowing for easier testing and abstraction.
 type CommandRunner interface {
-	// ExportThread runs the `amp threads export <threadID>` command for the given thread ID, stores the output at the specified outputPath and returns the path to the exported transcript file.
-	ExportThread(ctx context.Context, threadID string, outputPath string) (string, error)
+	// ExportThread runs `amp threads export <threadID>` and returns the raw
+	// export document. It deliberately does not write to disk: the native
+	// single-JSON export is an ingestion format only, converted to JSONL by
+	// Agent.exportThread before anything is stored (see session_jsonl.go).
+	ExportThread(ctx context.Context, threadID string) ([]byte, error)
 }
 
 // DefaultCommandRunner is the default implementation of CommandRunner that actually runs the `amp` commands.
 type DefaultCommandRunner struct{}
 
-func (r *DefaultCommandRunner) ExportThread(ctx context.Context, threadID string, outputPath string) (string, error) {
+func (r *DefaultCommandRunner) ExportThread(ctx context.Context, threadID string) ([]byte, error) {
 	if strings.TrimSpace(threadID) == "" {
-		return "", errors.New("thread ID is required")
-	}
-	if strings.TrimSpace(outputPath) == "" {
-		return "", errors.New("output path is required")
-	}
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0o750); err != nil {
-		return "", fmt.Errorf("create output dir: %w", err)
+		return nil, errors.New("thread ID is required")
 	}
 
 	cmd := exec.CommandContext(ctx, "amp", "threads", "export", threadID)
@@ -35,15 +31,11 @@ func (r *DefaultCommandRunner) ExportThread(ctx context.Context, threadID string
 	out, err := cmd.Output()
 	if err != nil {
 		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
-			return "", fmt.Errorf("amp threads export %s: %w: %s", threadID, err, strings.TrimSpace(string(exitErr.Stderr)))
+			return nil, fmt.Errorf("amp threads export %s: %w: %s", threadID, err, strings.TrimSpace(string(exitErr.Stderr)))
 		}
-		return "", fmt.Errorf("amp threads export %s: %w", threadID, err)
+		return nil, fmt.Errorf("amp threads export %s: %w", threadID, err)
 	}
-	if err := os.WriteFile(outputPath, out, 0o600); err != nil {
-		return "", fmt.Errorf("write exported transcript: %w", err)
-	}
-
-	return outputPath, nil
+	return out, nil
 }
 
 // ampEnv returns the parent environment with Bun-specific variables stripped.

--- a/agents/entire-agent-amp/internal/amp/compact.go
+++ b/agents/entire-agent-amp/internal/amp/compact.go
@@ -64,17 +64,17 @@ func (a *Agent) CompactTranscript(sessionRef string) (protocol.CompactTranscript
 }
 
 func compactTranscriptBytes(data []byte) ([]byte, error) {
-	thread, err := parseAmpThread(data)
+	messages, err := decodeTranscript(data)
 	if err != nil {
 		return nil, err
 	}
-	if len(thread.Messages) == 0 {
+	if len(messages) == 0 {
 		return nil, errors.New("compact transcript produced no output")
 	}
 
 	cliVersion := compactCLIVersion()
 	var buf bytes.Buffer
-	for _, msg := range thread.Messages {
+	for _, msg := range messages {
 		switch msg.Role {
 		case ThreadMessageRoleUser:
 			content := compactUserContent(msg.Content)
@@ -92,7 +92,7 @@ func compactTranscriptBytes(data []byte) ([]byte, error) {
 				return nil, err
 			}
 		case ThreadMessageRoleAssistant:
-			content := compactAssistantContent(msg.Content, thread.Messages)
+			content := compactAssistantContent(msg.Content, messages)
 			if len(content) == 0 {
 				continue
 			}

--- a/agents/entire-agent-amp/internal/amp/compact_test.go
+++ b/agents/entire-agent-amp/internal/amp/compact_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestCompactTranscriptBytes(t *testing.T) {
 	t.Setenv("ENTIRE_CLI_VERSION", "9.9.9")
-	data, err := compactTranscriptBytes([]byte(testPreparedTranscriptJSON))
+	data, err := compactTranscriptBytes([]byte(testPreparedTranscriptJSONL))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,8 @@ func TestCompactTranscriptBytes_UnpreparedJSONL(t *testing.T) {
 	}
 }
 
-func TestCompactTranscriptBytes_PreparedJSON(t *testing.T) {
+// Compaction of a pre-JSONL session file still works.
+func TestCompactTranscriptBytes_LegacyThreadExport(t *testing.T) {
 	t.Setenv("ENTIRE_CLI_VERSION", "9.9.9")
 	data, err := compactTranscriptBytes([]byte(testPreparedTranscriptJSON))
 	if err != nil {

--- a/agents/entire-agent-amp/internal/amp/empty_export_test.go
+++ b/agents/entire-agent-amp/internal/amp/empty_export_test.go
@@ -1,0 +1,38 @@
+package amp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEmptyExportCanBePreparedAgain(t *testing.T) {
+	runner := &emptyExportRunner{}
+	a := New()
+	a.CommandRunner = runner
+	path := filepath.Join(t.TempDir(), "T-empty.jsonl")
+	if err := a.exportThread("T-empty", path); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := threadIDFromTranscriptData(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "T-empty" {
+		t.Fatalf("thread ID = %q", id)
+	}
+	if err := a.PrepareTranscript(path); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type emptyExportRunner struct{}
+
+func (*emptyExportRunner) ExportThread(context.Context, string) ([]byte, error) {
+	return []byte(`{"id":"T-empty","messages":[]}`), nil
+}

--- a/agents/entire-agent-amp/internal/amp/hooks.go
+++ b/agents/entire-agent-amp/internal/amp/hooks.go
@@ -95,10 +95,12 @@ func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, e
 	}
 }
 
-// exportThread runs `amp threads export` for the given thread and writes the
-// result to sessionRef. The parent directory is created if needed. Callers
-// generally ignore the returned error and fall back to reporting an empty
-// model so events are still emitted.
+// exportThread runs `amp threads export` for the given thread and stores the
+// result at sessionRef as one-message-per-line JSONL, so Entire's line-based
+// transcript scoping lands on message boundaries (see session_jsonl.go). The
+// native single-JSON export never reaches disk. The parent directory is created
+// if needed. Callers generally ignore the returned error and fall back to
+// reporting an empty model so events are still emitted.
 func (a *Agent) exportThread(threadID, sessionRef string) error {
 	if strings.TrimSpace(threadID) == "" || strings.TrimSpace(sessionRef) == "" {
 		return errors.New("thread id and session ref are required")
@@ -112,8 +114,23 @@ func (a *Agent) exportThread(threadID, sessionRef string) error {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), prepareTranscriptTimeout)
 	defer cancel()
-	_, err := runner.ExportThread(ctx, threadID, sessionRef)
-	return err
+
+	raw, err := runner.ExportThread(ctx, threadID)
+	if err != nil {
+		return err
+	}
+	thread, err := parseAmpExport(raw)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(thread.ID) == "" {
+		thread.ID = strings.TrimSpace(threadID)
+	}
+	encoded, err := materializeThread(thread)
+	if err != nil {
+		return err
+	}
+	return atomicWriteFile(sessionRef, encoded, 0o600)
 }
 
 // latestModelFromSessionRef returns the most recent model string recorded in
@@ -127,11 +144,11 @@ func latestModelFromSessionRef(sessionRef string) string {
 	if err != nil || len(bytes.TrimSpace(data)) == 0 {
 		return ""
 	}
-	thread, err := parseAmpThread(data)
+	messages, err := decodeTranscript(data)
 	if err != nil {
 		return ""
 	}
-	return latestThreadModel(thread)
+	return latestThreadModel(messages)
 }
 
 func (a *Agent) InstallHooks(_ bool, force bool) (int, error) {

--- a/agents/entire-agent-amp/internal/amp/hooks_test.go
+++ b/agents/entire-agent-amp/internal/amp/hooks_test.go
@@ -72,7 +72,7 @@ func TestParseHookAgentStartSkipsExportWhenPrepared(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path, []byte(testPreparedTranscriptJSON), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(testPreparedTranscriptJSONL), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	runner := &fakeCommandRunner{}
@@ -115,7 +115,7 @@ func TestParseHookUsesSessionRefExportedThreadModel(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path, []byte(testPreparedTranscriptJSON), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(testPreparedTranscriptJSONL), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	runner := &fakeCommandRunner{}
@@ -138,14 +138,13 @@ func assertExportedThread(t *testing.T, runner *fakeCommandRunner, root string) 
 		t.Fatalf("threadID = %q, want T-123", runner.threadID)
 	}
 	wantPath := filepath.Join(root, ".entire", "tmp", "amp", "T-123.jsonl")
-	if runner.outputPath != wantPath {
-		t.Fatalf("outputPath = %q, want %q", runner.outputPath, wantPath)
-	}
 	data, err := os.ReadFile(wantPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(data) != testPreparedTranscriptJSON {
+	// The native single-JSON export must never reach disk: Entire scopes this
+	// file by line offset, so it is stored as one message per line.
+	if string(data) != testPreparedTranscriptJSONL {
 		t.Fatalf("exported data = %s", data)
 	}
 }

--- a/agents/entire-agent-amp/internal/amp/jsonl_test.go
+++ b/agents/entire-agent-amp/internal/amp/jsonl_test.go
@@ -1,0 +1,243 @@
+package amp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/external-agents/agents/entire-agent-amp/internal/protocol"
+)
+
+// sliceFromLine mirrors Entire's transcript.SliceFromLine
+// (cmd/entire/cli/transcript/parse.go:114): return the bytes starting after the
+// Nth newline, or nil when there aren't that many lines. This is what
+// cmd/entire/cli/explain.go:1883 (scopeTranscriptForCheckpoint) and
+// cmd/entire/cli/strategy/manual_commit_condensation.go:1006 apply to every
+// agent type that is not one of Entire's built-ins — amp included.
+func sliceFromLine(content []byte, startLine int) []byte {
+	if len(content) == 0 || startLine <= 0 {
+		return content
+	}
+	count, offset := 0, 0
+	for i, b := range content {
+		if b == '\n' {
+			count++
+			if count == startLine {
+				offset = i + 1
+				break
+			}
+		}
+	}
+	if count < startLine || offset >= len(content) {
+		return nil
+	}
+	return content[offset:]
+}
+
+func fourMessageTranscript(t *testing.T) []byte {
+	t.Helper()
+	data, err := materializeThread(&Thread{
+		ID: "T-4",
+		Messages: []ThreadMessage{
+			makeTextMessage("1", ThreadMessageRoleUser, "first prompt"),
+			makeTextMessage("a1", ThreadMessageRoleAssistant, "first answer"),
+			makeTextMessage("2", ThreadMessageRoleUser, "second prompt"),
+			makeTextMessage("a2", ThreadMessageRoleAssistant, "second answer"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	return data
+}
+
+func makeTextMessage(id ThreadMessageID, role ThreadMessageRole, text string) ThreadMessage {
+	return ThreadMessage{
+		MessageID: id,
+		Role:      role,
+		Meta:      &ThreadMessageMeta{SentAt: 1778155200000},
+		Content:   []ThreadContentBlock{{Type: ThreadContentText, Text: text}},
+	}
+}
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	data := fourMessageTranscript(t)
+	if lines := bytes.Count(data, []byte{'\n'}); lines != 4 {
+		t.Fatalf("expected 4 newline-terminated lines, got %d", lines)
+	}
+	msgs, err := decodeTranscript(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(msgs) != 4 || msgs[0].MessageID != "1" || msgs[3].MessageID != "a2" {
+		t.Fatalf("round-trip messages = %+v", msgs)
+	}
+	for _, msg := range msgs {
+		if msg.ThreadID != "T-4" {
+			t.Fatalf("thread id not stamped on message %q", msg.MessageID)
+		}
+	}
+}
+
+// The regression this whole change exists for: Entire scopes checkpoint
+// transcripts by line offset before calling compact-transcript. With
+// one-message-per-line JSONL a mid-session slice is still valid and compacts;
+// the old single-blob layout produced empty/invalid bytes and summaries failed.
+func TestCompactToleratesLineScopedSlice(t *testing.T) {
+	full := fourMessageTranscript(t)
+
+	// Offset 2 == start of the second turn (messages 2, a2).
+	scoped := sliceFromLine(full, 2)
+	if len(scoped) == 0 {
+		t.Fatal("scoped slice unexpectedly empty")
+	}
+	compacted, err := compactTranscriptBytes(scoped)
+	if err != nil {
+		t.Fatalf("compact scoped slice: %v", err)
+	}
+	if got := bytes.Count(compacted, []byte{'\n'}); got != 2 {
+		t.Fatalf("compact scoped slice produced %d lines, want 2", got)
+	}
+	if !bytes.Contains(compacted, []byte("second prompt")) {
+		t.Fatalf("scoped compact missing expected content: %s", compacted)
+	}
+	if bytes.Contains(compacted, []byte("first prompt")) {
+		t.Fatalf("scoped compact leaked pre-offset content: %s", compacted)
+	}
+}
+
+// A scoped slice has no thread header, so every analyzer must still work on it
+// and the thread id must still be recoverable.
+func TestScopedSliceRemainsAnalyzable(t *testing.T) {
+	t.Setenv("ENTIRE_REPO_ROOT", t.TempDir())
+	full := fourMessageTranscript(t)
+	path := filepath.Join(t.TempDir(), "amp.jsonl")
+	if err := os.WriteFile(path, sliceFromLine(full, 2), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	agent := New()
+	pos, err := agent.GetTranscriptPosition(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pos != 2 {
+		t.Fatalf("scoped position = %d, want 2", pos)
+	}
+	prompts, err := agent.ExtractPrompts(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prompts) != 1 || prompts[0] != "second prompt" {
+		t.Fatalf("scoped prompts = %v", prompts)
+	}
+	session, err := agent.ReadSession(&protocol.HookInputJSON{SessionRef: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.SessionID != "T-4" {
+		t.Fatalf("scoped session id = %q, want T-4 (recovered from a message)", session.SessionID)
+	}
+}
+
+func TestGetTranscriptPositionMatchesLineCount(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "amp.jsonl")
+	data := fourMessageTranscript(t)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pos, err := New().GetTranscriptPosition(path)
+	if err != nil {
+		t.Fatalf("GetTranscriptPosition: %v", err)
+	}
+	if lines := bytes.Count(data, []byte{'\n'}); pos != lines {
+		t.Fatalf("position %d != newline count %d (Entire slices by line)", pos, lines)
+	}
+}
+
+// The native export is an ingestion format: it must be converted before it is
+// stored, never written to session_ref as-is.
+func TestExportThreadStoresJSONL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "amp.jsonl")
+	runner := &fakeCommandRunner{}
+	if err := (&Agent{CommandRunner: runner}).exportThread("T-123", path); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.HasPrefix(bytes.TrimSpace(data), []byte(`{"v":`)) {
+		t.Fatalf("native single-document export was stored verbatim: %s", data)
+	}
+	if lines := bytes.Count(data, []byte{'\n'}); lines != 3 {
+		t.Fatalf("expected 3 JSONL lines, got %d: %s", lines, data)
+	}
+	for line := range bytes.SplitSeq(bytes.TrimRight(data, "\n"), []byte{'\n'}) {
+		var msg ThreadMessage
+		if err := json.Unmarshal(line, &msg); err != nil {
+			t.Fatalf("line not valid message JSON: %v (%s)", err, line)
+		}
+		if msg.ThreadID != "T-123" {
+			t.Fatalf("line missing thread id: %s", line)
+		}
+	}
+}
+
+// An export whose document omits the id still gets the requested thread id, so
+// scoped slices stay identifiable.
+func TestExportThreadStampsRequestedThreadID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "amp.jsonl")
+	runner := &stubExportRunner{out: []byte(`{"messages":[{"role":"user","messageId":1,"content":[{"type":"text","text":"hi"}]}]}`)}
+	if err := (&Agent{CommandRunner: runner}).exportThread("T-fallback", path); err != nil {
+		t.Fatal(err)
+	}
+	messages, err := decodeTranscript(readFileT(t, path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 || messages[0].ThreadID != "T-fallback" {
+		t.Fatalf("messages = %+v", messages)
+	}
+}
+
+// Session files written before amp materialized JSONL must keep reading; the
+// next export rewrites them.
+func TestDecodeTranscriptAcceptsLegacyThreadExport(t *testing.T) {
+	messages, err := decodeTranscript([]byte(testPreparedTranscriptJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 3 {
+		t.Fatalf("legacy messages = %d, want 3", len(messages))
+	}
+	if messages[0].ThreadID != "T-123" {
+		t.Fatalf("legacy thread id = %q, want T-123", messages[0].ThreadID)
+	}
+}
+
+func TestDecodeTranscriptReportsUnpreparedHookPayloads(t *testing.T) {
+	if _, err := decodeTranscript([]byte(testTranscriptJSONL)); err == nil {
+		t.Fatal("expected unprepared transcript error")
+	}
+}
+
+type stubExportRunner struct {
+	out []byte
+}
+
+func (r *stubExportRunner) ExportThread(_ context.Context, _ string) ([]byte, error) {
+	return r.out, nil
+}
+
+func readFileT(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}

--- a/agents/entire-agent-amp/internal/amp/jsonl_test.go
+++ b/agents/entire-agent-amp/internal/amp/jsonl_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/entireio/external-agents/agents/entire-agent-amp/internal/protocol"
@@ -240,4 +241,222 @@ func readFileT(t *testing.T, path string) []byte {
 		t.Fatal(err)
 	}
 	return data
+}
+
+// compactKind mirrors normalizeKind in Entire's
+// cmd/entire/cli/transcript/compact/compact.go:197: the entry kind comes from
+// the TOP-LEVEL "type", falling back to "role". Amp's message already carries
+// "role", so this half held once the transcript became JSONL.
+func compactKind(line map[string]json.RawMessage) string {
+	var kind string
+	if json.Unmarshal(line["type"], &kind) == nil && kind != "" {
+		return kind
+	}
+	if json.Unmarshal(line["role"], &kind) == nil {
+		return kind
+	}
+	return ""
+}
+
+// compactMessageContent mirrors parseMessage (compact.go:617): content is read
+// from a TOP-LEVEL "message" object, never from the line's own "content" array.
+// This is the half amp was missing — lines were kept, and every one of them
+// compacted to an empty content array.
+func compactMessageContent(line map[string]json.RawMessage) []map[string]json.RawMessage {
+	var msg map[string]json.RawMessage
+	if json.Unmarshal(line["message"], &msg) != nil {
+		return nil
+	}
+	var blocks []map[string]json.RawMessage
+	if json.Unmarshal(msg["content"], &blocks) != nil {
+		return nil
+	}
+	return blocks
+}
+
+func decodeLines(t *testing.T, data []byte) []map[string]json.RawMessage {
+	t.Helper()
+	var out []map[string]json.RawMessage
+	for line := range bytes.SplitSeq(bytes.TrimRight(data, "\n"), []byte{'\n'}) {
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(line, &m); err != nil {
+			t.Fatalf("line is not valid JSON: %v (%s)", err, line)
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// preparedLines materializes the native export through the real write path
+// (materializeThread -> encodeMessagesJSONL) and returns the stored lines, so
+// these assertions exercise the encoder rather than a checked-in constant.
+func preparedLines(t *testing.T) []map[string]json.RawMessage {
+	t.Helper()
+	export, ok := legacyThreadExport([]byte(testPreparedTranscriptJSON))
+	if !ok {
+		t.Fatal("testPreparedTranscriptJSON is not a thread export")
+	}
+	data, err := materializeThread(export)
+	if err != nil {
+		t.Fatalf("materializeThread: %v", err)
+	}
+	return decodeLines(t, data)
+}
+
+func blockString(t *testing.T, block map[string]json.RawMessage, key string) string {
+	t.Helper()
+	var s string
+	if err := json.Unmarshal(block[key], &s); err != nil {
+		t.Fatalf("block[%q] = %s: %v", key, block[key], err)
+	}
+	return s
+}
+
+// Storing JSONL made Entire keep the lines; it did not make them carry
+// anything. Both halves of the contract are asserted because satisfying only
+// the first yields a correctly-sized transcript.jsonl full of empty content.
+func TestStoredLinesSatisfyEntireCompactContract(t *testing.T) {
+	lines := decodeLines(t, fourMessageTranscript(t))
+	if len(lines) != 4 {
+		t.Fatalf("got %d lines, want 4", len(lines))
+	}
+
+	wantKind := []string{"user", "assistant", "user", "assistant"}
+	wantText := []string{"first prompt", "first answer", "second prompt", "second answer"}
+
+	for i, line := range lines {
+		if got := compactKind(line); got != wantKind[i] {
+			t.Fatalf("line %d: compactKind = %q, want %q — Entire drops this line", i, got, wantKind[i])
+		}
+		blocks := compactMessageContent(line)
+		if len(blocks) == 0 {
+			t.Fatalf("line %d: no content under the \"message\" wrapper — Entire emits an empty line", i)
+		}
+		if got := blockString(t, blocks[0], "text"); got != wantText[i] {
+			t.Fatalf("line %d: message content text = %q, want %q", i, got, wantText[i])
+		}
+	}
+}
+
+// A mid-session slice must keep satisfying the contract: Entire compacts the
+// scoped bytes, not the whole file.
+func TestScopedSliceSatisfiesEntireCompactContract(t *testing.T) {
+	lines := decodeLines(t, sliceFromLine(fourMessageTranscript(t), 2))
+	if len(lines) != 2 {
+		t.Fatalf("scoped slice has %d lines, want 2", len(lines))
+	}
+	for i, line := range lines {
+		if compactKind(line) == "" {
+			t.Fatalf("scoped line %d has no top-level type/role", i)
+		}
+		if len(compactMessageContent(line)) == 0 {
+			t.Fatalf("scoped line %d carries no message content", i)
+		}
+	}
+}
+
+// Tool calls and their results must land in the shapes Entire matches on:
+// tool_use keeps type/id/name/input (compact.go:704), and a user tool_result
+// uses snake_case tool_use_id with a string "content" (compact.go:665) so
+// Entire can inline the output into the preceding assistant's tool_use.
+func TestToolBlocksProjectToEntireShapes(t *testing.T) {
+	lines := preparedLines(t)
+	if len(lines) != 3 {
+		t.Fatalf("got %d lines, want 3", len(lines))
+	}
+
+	toolUse := compactMessageContent(lines[1])[0]
+	for key, want := range map[string]string{"type": "tool_use", "id": "tool1", "name": "edit_file"} {
+		if got := blockString(t, toolUse, key); got != want {
+			t.Fatalf("tool_use %q = %q, want %q", key, got, want)
+		}
+	}
+	if got := string(toolUse["input"]); got != `{"path":"hello.txt"}` {
+		t.Fatalf("tool_use input = %s", got)
+	}
+
+	toolResult := compactMessageContent(lines[2])[0]
+	for key, want := range map[string]string{"type": "tool_result", "tool_use_id": "tool1", "content": "ok"} {
+		if got := blockString(t, toolResult, key); got != want {
+			t.Fatalf("tool_result %q = %q, want %q", key, got, want)
+		}
+	}
+}
+
+// Usage must use Entire's snake_case names (compact.go:517). Amp's native
+// camelCase inputTokens/outputTokens read as zero there.
+func TestUsageProjectsToSnakeCaseTokens(t *testing.T) {
+	lines := preparedLines(t)
+	var msg struct {
+		Usage struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(lines[1]["message"], &msg); err != nil {
+		t.Fatal(err)
+	}
+	if msg.Usage.InputTokens != 100 || msg.Usage.OutputTokens != 25 {
+		t.Fatalf("usage = %+v, want 100/25", msg.Usage)
+	}
+}
+
+// Back-compat: a JSONL transcript written before the projection existed carries
+// only the native fields. It must still decode, and re-encoding self-heals it.
+func TestLegacyJSONLWithoutProjectionStillDecodes(t *testing.T) {
+	legacy := []byte(`{"threadID":"T-9","role":"user","content":[{"type":"text","text":"old line"}],"messageId":1}` + "\n")
+	msgs, err := decodeTranscript(legacy)
+	if err != nil {
+		t.Fatalf("decodeTranscript: %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].ThreadID != "T-9" || msgs[0].Content[0].Text != "old line" {
+		t.Fatalf("legacy decode = %+v", msgs)
+	}
+
+	healed, err := encodeMessagesJSONL(msgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := decodeLines(t, healed)[0]
+	if compactKind(line) != "user" || len(compactMessageContent(line)) == 0 {
+		t.Fatalf("re-encoded legacy line did not self-heal: %s", healed)
+	}
+}
+
+// The projection is derived data: decoding ignores it and yields the native
+// message unchanged, so a round-trip through the stored layout is lossless.
+func TestProjectionIsIgnoredOnDecode(t *testing.T) {
+	in := stampThreadID([]ThreadMessage{
+		makeTextMessage("1", ThreadMessageRoleUser, "first prompt"),
+		makeTextMessage("2", ThreadMessageRoleAssistant, "first answer"),
+	}, "T-4")
+	data, err := encodeMessagesJSONL(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := decodeTranscript(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("round-trip lost data:\n in = %+v\nout = %+v", in, out)
+	}
+}
+
+// An info message has no compact representation, so it stays unprojected and
+// Entire drops it — same as compactTranscriptBytes does.
+func TestInfoMessagesAreNotProjected(t *testing.T) {
+	data, err := encodeMessagesJSONL([]ThreadMessage{
+		makeTextMessage("1", ThreadMessageRoleInfo, "connected"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := decodeLines(t, data)[0]
+	if _, ok := line["message"]; ok {
+		t.Fatalf("info message was projected: %s", data)
+	}
+	if kind := compactKind(line); kind != "info" {
+		t.Fatalf("compactKind = %q, want info (which Entire drops)", kind)
+	}
 }

--- a/agents/entire-agent-amp/internal/amp/large_record_test.go
+++ b/agents/entire-agent-amp/internal/amp/large_record_test.go
@@ -1,0 +1,22 @@
+package amp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProjectedLargeMessageRoundTrip(t *testing.T) {
+	large := strings.Repeat("x", 6*1024*1024)
+	messages := []ThreadMessage{{Role: ThreadMessageRoleUser, Content: []ThreadContentBlock{{Type: ThreadContentText, Text: large}}}}
+	data, err := encodeMessagesJSONL(messages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := decodeTranscript(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded) != 1 || decoded[0].Content[0].Text != large {
+		t.Fatal("large message lost")
+	}
+}

--- a/agents/entire-agent-amp/internal/amp/session_jsonl.go
+++ b/agents/entire-agent-amp/internal/amp/session_jsonl.go
@@ -1,0 +1,177 @@
+package amp
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const maxTranscriptLine = 10 * 1024 * 1024
+
+// The on-disk transcript is stored as JSONL: exactly one ThreadMessage per
+// line, in order, with no thread header line. Entire scopes external-agent
+// transcripts by LINE offset (transcript.SliceFromLine) before handing them to
+// compact-transcript, so a single-JSON-blob layout would be destroyed by that
+// slicing. One-message-per-line keeps line index == message index, which is
+// also the unit Entire records via get-transcript-position, so scoping lands on
+// message boundaries and header-less slices remain valid JSONL.
+//
+// The thread id lives on each message (ThreadMessage.ThreadID) rather than in a
+// header, so it survives in a scoped slice that starts past line 0.
+
+// errTranscriptNotPrepared reports a session file that still holds raw hook
+// payloads: `amp threads export` has not run for it yet.
+var errTranscriptNotPrepared = errors.New("amp transcript is not prepared: run prepare-transcript first")
+
+// encodeMessagesJSONL serializes messages as one JSON object per line.
+func encodeMessagesJSONL(messages []ThreadMessage) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf) // Encode writes directly into buf and appends '\n'.
+	for i := range messages {
+		if err := enc.Encode(&messages[i]); err != nil {
+			return nil, fmt.Errorf("encode message: %w", err)
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// materializeThread converts a native `amp threads export` document into the
+// stored JSONL layout, stamping the thread id onto every message so a scoped
+// slice still identifies its thread.
+func materializeThread(thread *Thread) ([]byte, error) {
+	if thread == nil {
+		return nil, nil
+	}
+	return encodeMessagesJSONL(stampThreadID(thread.Messages, thread.ID))
+}
+
+// stampThreadID returns a copy of messages with threadID recorded on each.
+func stampThreadID(messages []ThreadMessage, threadID string) []ThreadMessage {
+	out := make([]ThreadMessage, len(messages))
+	copy(out, messages)
+	if id := strings.TrimSpace(threadID); id != "" {
+		for i := range out {
+			out[i].ThreadID = id
+		}
+	}
+	return out
+}
+
+// decodeTranscript reads a stored transcript, which is one JSON message per
+// line (see encodeMessagesJSONL). Blank and non-message lines are skipped, so
+// header-less scoped slices decode cleanly.
+//
+// A whole-document `amp threads export` blob is still accepted so session files
+// written before amp materialized JSONL keep reading; the next export rewrites
+// them as JSONL. A file that holds only unprepared hook payloads reports
+// errTranscriptNotPrepared, as the single-document parser used to.
+func decodeTranscript(data []byte) ([]ThreadMessage, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return []ThreadMessage{}, nil
+	}
+	if export, ok := legacyThreadExport(trimmed); ok {
+		// Stamp the id the same way materializeThread does, so a legacy file
+		// and its materialized replacement read identically.
+		return stampThreadID(export.Messages, export.ID), nil
+	}
+
+	messages := make([]ThreadMessage, 0)
+	unprepared := false
+	scanner := bufio.NewScanner(bytes.NewReader(trimmed))
+	scanner.Buffer(make([]byte, 64*1024), maxTranscriptLine)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var msg ThreadMessage
+		if json.Unmarshal(line, &msg) == nil && !isEmptyThreadMessage(msg) {
+			messages = append(messages, msg)
+			continue
+		}
+		if isHookPayloadLine(line) {
+			unprepared = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan amp transcript: %w", err)
+	}
+	if len(messages) == 0 && unprepared {
+		return nil, errTranscriptNotPrepared
+	}
+	return messages, nil
+}
+
+// parseAmpExport reads Amp's native thread export (a single JSON document with
+// a "messages" array). Used only when ingesting a fresh export from
+// `amp threads export`; the result is stored as JSONL via materializeThread.
+func parseAmpExport(raw []byte) (*Thread, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return &Thread{}, nil
+	}
+	var thread Thread
+	if err := json.Unmarshal(trimmed, &thread); err != nil {
+		return nil, fmt.Errorf("parse amp thread export: %w", err)
+	}
+	return &thread, nil
+}
+
+// legacyThreadExport reports whether data is a whole-document thread export
+// rather than JSONL. A JSONL payload of two or more lines fails to unmarshal as
+// one object, and a single JSONL message line carries neither "id" nor
+// "messages", so it is not mistaken for an export.
+func legacyThreadExport(data []byte) (*Thread, bool) {
+	var thread Thread
+	if json.Unmarshal(data, &thread) != nil {
+		return nil, false
+	}
+	if strings.TrimSpace(thread.ID) == "" && thread.Messages == nil {
+		return nil, false
+	}
+	return &thread, true
+}
+
+// isEmptyThreadMessage reports a line that carries no message content at all,
+// such as a thread header or an unrelated JSON object.
+func isEmptyThreadMessage(msg ThreadMessage) bool {
+	return msg.Role == "" && msg.MessageID == "" && len(msg.Content) == 0
+}
+
+// isHookPayloadLine reports a raw Amp hook payload — what the plugin writes
+// before `amp threads export` has materialized the thread.
+func isHookPayloadLine(line []byte) bool {
+	var payload ampHookPayload
+	if json.Unmarshal(line, &payload) != nil {
+		return false
+	}
+	return strings.TrimSpace(payload.ThreadID) != "" || strings.TrimSpace(payload.Type) != ""
+}
+
+// atomicWriteFile writes data to path via a temp file + rename so a crash
+// mid-write cannot leave a partially-written transcript behind.
+func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".amp-write-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if err := tmp.Chmod(mode); err != nil {
+		return errors.Join(err, tmp.Close())
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return errors.Join(err, tmp.Close())
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/agents/entire-agent-amp/internal/amp/session_jsonl.go
+++ b/agents/entire-agent-amp/internal/amp/session_jsonl.go
@@ -23,17 +23,155 @@ const maxTranscriptLine = 10 * 1024 * 1024
 //
 // The thread id lives on each message (ThreadMessage.ThreadID) rather than in a
 // header, so it survives in a scoped slice that starts past line 0.
+//
+// Line SHAPE matters as much as line COUNT. Entire compacts an unrecognised
+// agent's transcript with the generic JSONL reader in
+// cmd/entire/cli/transcript/compact/compact.go, which only keeps a line when
+// BOTH of these hold:
+//
+//   - normalizeKind (compact.go:197) finds a TOP-LEVEL "type" or "role" of
+//     "user" or "assistant". Amp's message already carries "role", so this
+//     half was satisfied by the JSONL layout alone.
+//   - parseMessage (compact.go:617) finds the content under a TOP-LEVEL
+//     "message" object: "All JSONL agents nest content inside a 'message'
+//     object." Amp keeps content in a top-level "content" array, so every
+//     compacted line came out with an empty content array — the right number
+//     of lines, carrying nothing.
+//
+// Each record therefore carries the native ThreadMessage fields, authoritative
+// for Amp's own decoding, plus an Entire-facing projection (type, timestamp,
+// message) built from them. The projection is derived data: decodeTranscript
+// ignores it, so a transcript written by an older build still reads, and the
+// next export rewrites it with the projection attached.
 
 // errTranscriptNotPrepared reports a session file that still holds raw hook
 // payloads: `amp threads export` has not run for it yet.
 var errTranscriptNotPrepared = errors.New("amp transcript is not prepared: run prepare-transcript first")
+
+// transcriptRecord is one on-disk JSONL line: Amp's native message with the
+// Entire-facing projection alongside it. ThreadMessage is embedded, so its
+// keys stay at the top level exactly as before.
+type transcriptRecord struct {
+	ThreadMessage
+	Type      string       `json:"type,omitempty"`
+	Timestamp string       `json:"timestamp,omitempty"`
+	Message   *wireMessage `json:"message,omitempty"`
+}
+
+// wireMessage is the "message" wrapper Entire's compactJSONL reads content from.
+type wireMessage struct {
+	Role    string     `json:"role"`
+	ID      string     `json:"id,omitempty"`
+	Content []any      `json:"content"`
+	Usage   *wireUsage `json:"usage,omitempty"`
+}
+
+// wireUsage uses Entire's snake_case token field names (compact.go:517); Amp's
+// native camelCase inputTokens/outputTokens read as zero there.
+type wireUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+// wireTextBlock is a text content block, read by both the user and the
+// assistant path in compactJSONL.
+type wireTextBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// wireToolUseBlock is an assistant tool call. stripAssistantContent
+// (compact.go:704) keeps exactly type, id, name and input.
+type wireToolUseBlock struct {
+	Type  string `json:"type"`
+	ID    string `json:"id,omitempty"`
+	Name  string `json:"name"`
+	Input any    `json:"input"`
+}
+
+// wireToolResultBlock is a user tool result. extractUserContent (compact.go:665)
+// reads snake_case tool_use_id, a string "content", and is_error; Entire then
+// inlines it into the preceding assistant's matching tool_use block.
+type wireToolResultBlock struct {
+	Type      string `json:"type"`
+	ToolUseID string `json:"tool_use_id,omitempty"`
+	Content   string `json:"content"`
+	IsError   bool   `json:"is_error,omitempty"`
+}
+
+// newTranscriptRecord projects an Amp message into the on-disk record.
+func newTranscriptRecord(msg ThreadMessage) transcriptRecord {
+	record := transcriptRecord{
+		ThreadMessage: msg,
+		Type:          string(msg.Role),
+		Timestamp:     threadMessageTimestamp(msg),
+	}
+	// Only "user" and "assistant" mean anything to normalizeKind. Info
+	// messages stay unprojected, matching compactTranscriptBytes, which gives
+	// them no compact representation either.
+	if msg.Role != ThreadMessageRoleUser && msg.Role != ThreadMessageRoleAssistant {
+		return record
+	}
+	record.Message = &wireMessage{
+		Role:    string(msg.Role),
+		ID:      threadMessageIDString(msg.MessageID),
+		Content: wireContent(msg.Content),
+	}
+	if msg.Usage != nil {
+		record.Message.Usage = &wireUsage{
+			InputTokens:  msg.Usage.InputTokens,
+			OutputTokens: msg.Usage.OutputTokens,
+		}
+	}
+	return record
+}
+
+// wireContent converts Amp content blocks into the blocks Entire's compactJSONL
+// understands. Thinking blocks are dropped (compact.go:700 strips them anyway).
+func wireContent(blocks []ThreadContentBlock) []any {
+	out := make([]any, 0, len(blocks))
+	for _, block := range blocks {
+		switch block.Type {
+		case ThreadContentText:
+			if block.Text != "" {
+				out = append(out, wireTextBlock{Type: "text", Text: block.Text})
+			}
+		case ThreadContentToolUse, ThreadContentServerToolUse:
+			out = append(out, wireToolUseBlock{
+				Type:  "tool_use",
+				ID:    block.ID,
+				Name:  block.Name,
+				Input: decodeToolInput(block.Input),
+			})
+		case ThreadContentToolResult:
+			if block.Run == nil {
+				continue
+			}
+			out = append(out, wireToolResultBlock{
+				Type:      "tool_result",
+				ToolUseID: block.ToolUseID,
+				Content:   toolRunOutput(block.Run),
+				IsError:   block.Run.Status == "error" || block.Run.Status == "cancelled" || block.Run.Error != nil,
+			})
+		case ThreadContentImage:
+			// Image blocks pass through verbatim: extractUserContent
+			// (compact.go:673) keeps them as-is.
+			if raw, err := json.Marshal(block); err == nil {
+				out = append(out, json.RawMessage(raw))
+			}
+		case ThreadContentThinking, ThreadContentToolSearchResult:
+		}
+	}
+	return out
+}
 
 // encodeMessagesJSONL serializes messages as one JSON object per line.
 func encodeMessagesJSONL(messages []ThreadMessage) ([]byte, error) {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf) // Encode writes directly into buf and appends '\n'.
 	for i := range messages {
-		if err := enc.Encode(&messages[i]); err != nil {
+		record := newTranscriptRecord(messages[i])
+		if err := enc.Encode(&record); err != nil {
 			return nil, fmt.Errorf("encode message: %w", err)
 		}
 	}
@@ -64,7 +202,9 @@ func stampThreadID(messages []ThreadMessage, threadID string) []ThreadMessage {
 
 // decodeTranscript reads a stored transcript, which is one JSON message per
 // line (see encodeMessagesJSONL). Blank and non-message lines are skipped, so
-// header-less scoped slices decode cleanly.
+// header-less scoped slices decode cleanly. Only the native ThreadMessage
+// fields are read: the Entire-facing projection is derived data and is ignored
+// here, so a transcript written before the projection existed still decodes.
 //
 // A whole-document `amp threads export` blob is still accepted so session files
 // written before amp materialized JSONL keep reading; the next export rewrites

--- a/agents/entire-agent-amp/internal/amp/session_jsonl.go
+++ b/agents/entire-agent-amp/internal/amp/session_jsonl.go
@@ -1,7 +1,6 @@
 package amp
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -10,8 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 )
-
-const maxTranscriptLine = 10 * 1024 * 1024
 
 // The on-disk transcript is stored as JSONL: exactly one ThreadMessage per
 // line, in order, with no thread header line. Entire scopes external-agent
@@ -185,6 +182,11 @@ func materializeThread(thread *Thread) ([]byte, error) {
 	if thread == nil {
 		return nil, nil
 	}
+	if len(thread.Messages) == 0 {
+		// Keep the native header until a message can carry the thread ID.
+		// Otherwise the next prepare cannot identify this empty session.
+		return json.Marshal(thread)
+	}
 	return encodeMessagesJSONL(stampThreadID(thread.Messages, thread.ID))
 }
 
@@ -210,6 +212,8 @@ func stampThreadID(messages []ThreadMessage, threadID string) []ThreadMessage {
 // written before amp materialized JSONL keep reading; the next export rewrites
 // them as JSONL. A file that holds only unprepared hook payloads reports
 // errTranscriptNotPrepared, as the single-document parser used to.
+// Iterate the bytes already in memory: the native payload plus its projection
+// can exceed Scanner's line limit even when the source message fits it.
 func decodeTranscript(data []byte) ([]ThreadMessage, error) {
 	trimmed := bytes.TrimSpace(data)
 	if len(trimmed) == 0 {
@@ -223,10 +227,8 @@ func decodeTranscript(data []byte) ([]ThreadMessage, error) {
 
 	messages := make([]ThreadMessage, 0)
 	unprepared := false
-	scanner := bufio.NewScanner(bytes.NewReader(trimmed))
-	scanner.Buffer(make([]byte, 64*1024), maxTranscriptLine)
-	for scanner.Scan() {
-		line := bytes.TrimSpace(scanner.Bytes())
+	for rawLine := range bytes.SplitSeq(trimmed, []byte{'\n'}) {
+		line := bytes.TrimSpace(rawLine)
 		if len(line) == 0 {
 			continue
 		}
@@ -238,9 +240,6 @@ func decodeTranscript(data []byte) ([]ThreadMessage, error) {
 		if isHookPayloadLine(line) {
 			unprepared = true
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan amp transcript: %w", err)
 	}
 	if len(messages) == 0 && unprepared {
 		return nil, errTranscriptNotPrepared

--- a/agents/entire-agent-amp/internal/amp/transcript.go
+++ b/agents/entire-agent-amp/internal/amp/transcript.go
@@ -2,7 +2,6 @@ package amp
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,29 +17,22 @@ import (
 
 const prepareTranscriptTimeout = 30 * time.Second
 
-func parseAmpThread(data []byte) (*Thread, error) {
-	trimmed := bytes.TrimSpace(data)
-	if len(trimmed) == 0 {
-		return &Thread{}, nil
-	}
-	if trimmed[0] != '{' {
-		return nil, errors.New("amp transcript is not prepared: run prepare-transcript first")
-	}
-	var thread Thread
-	if err := json.Unmarshal(trimmed, &thread); err != nil {
-		return nil, fmt.Errorf("parse amp thread transcript: %w", err)
-	}
-	return &thread, nil
-}
-
+// threadIDFromTranscriptData recovers the Amp thread id from a stored
+// transcript. The JSONL layout has no thread header, so the id comes from the
+// messages first (see ThreadMessage.ThreadID), then from any unprepared hook
+// payload lines the plugin wrote before the first export.
 func threadIDFromTranscriptData(data []byte) (string, error) {
 	trimmed := bytes.TrimSpace(data)
 	if len(trimmed) == 0 {
 		return "", errors.New("empty amp transcript")
 	}
 
-	if thread, err := parseAmpThread(trimmed); err == nil && thread.ID != "" {
-		return thread.ID, nil
+	// An unprepared transcript is not an error here: the hook payloads it
+	// holds are exactly what carries the thread id we need to export with.
+	if messages, err := decodeTranscript(trimmed); err == nil {
+		if id := threadIDFromMessages(messages); id != "" {
+			return id, nil
+		}
 	}
 
 	for line := range bytes.SplitSeq(trimmed, []byte("\n")) {
@@ -67,6 +59,29 @@ func threadIDFromTranscriptData(data []byte) (string, error) {
 	return "", errors.New("cannot prepare transcript: missing amp thread_id")
 }
 
+// threadIDFromMessages returns the first thread id stamped on a message.
+func threadIDFromMessages(messages []ThreadMessage) string {
+	for _, msg := range messages {
+		if id := strings.TrimSpace(msg.ThreadID); id != "" {
+			return id
+		}
+	}
+	return ""
+}
+
+// startTimeFromMessages returns the first message send time, or now.
+func startTimeFromMessages(messages []ThreadMessage) time.Time {
+	for _, msg := range messages {
+		if msg.Meta == nil {
+			continue
+		}
+		if ts := msg.Meta.SentAt.Time(); !ts.IsZero() {
+			return ts
+		}
+	}
+	return time.Now().UTC()
+}
+
 func (a *Agent) ReadSession(input *protocol.HookInputJSON) (protocol.AgentSessionJSON, error) {
 	var sessionID string
 	var sessionRef string
@@ -85,11 +100,11 @@ func (a *Agent) ReadSession(input *protocol.HookInputJSON) (protocol.AgentSessio
 	if err != nil {
 		return protocol.AgentSessionJSON{}, err
 	}
-	thread, err := parseAmpThread(data)
+	messages, err := decodeTranscript(data)
 	if err != nil {
 		return protocol.AgentSessionJSON{}, err
 	}
-	if thread.ID == "" {
+	if len(messages) == 0 {
 		if sessionID == "" {
 			sessionID = strings.TrimSuffix(filepath.Base(sessionRef), filepath.Ext(sessionRef))
 		}
@@ -106,22 +121,23 @@ func (a *Agent) ReadSession(input *protocol.HookInputJSON) (protocol.AgentSessio
 		}, nil
 	}
 
-	startTime := thread.Created.Time()
-	if startTime.IsZero() && !thread.UpdatedAt.IsZero() {
-		startTime = thread.UpdatedAt.UTC()
+	// The JSONL layout carries no thread header, so recover the id from the
+	// hook input, the messages, or the file name (in that order).
+	if sessionID == "" {
+		sessionID = threadIDFromMessages(messages)
 	}
-	if startTime.IsZero() {
-		startTime = time.Now().UTC()
+	if sessionID == "" {
+		sessionID = strings.TrimSuffix(filepath.Base(sessionRef), filepath.Ext(sessionRef))
 	}
 
 	return protocol.AgentSessionJSON{
-		SessionID:     thread.ID,
+		SessionID:     sessionID,
 		AgentName:     "amp",
 		RepoPath:      protocol.RepoRoot(),
 		SessionRef:    sessionRef,
-		StartTime:     startTime.Format(time.RFC3339),
+		StartTime:     startTimeFromMessages(messages).Format(time.RFC3339),
 		NativeData:    data,
-		ModifiedFiles: modifiedFilesFromThread(thread),
+		ModifiedFiles: modifiedFilesFromMessages(messages),
 		NewFiles:      []string{},
 		DeletedFiles:  []string{},
 	}, nil
@@ -142,14 +158,7 @@ func (a *Agent) PrepareTranscript(sessionRef string) error {
 	if threadID == "" {
 		return nil
 	}
-	runner := a.CommandRunner
-	if runner == nil {
-		runner = &DefaultCommandRunner{}
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), prepareTranscriptTimeout)
-	defer cancel()
-	_, err = runner.ExportThread(ctx, threadID, sessionRef)
-	return err
+	return a.exportThread(threadID, sessionRef)
 }
 
 func (a *Agent) WriteSession(session protocol.AgentSessionJSON) error {
@@ -159,7 +168,7 @@ func (a *Agent) WriteSession(session protocol.AgentSessionJSON) error {
 	if err := os.MkdirAll(filepath.Dir(session.SessionRef), 0o700); err != nil {
 		return err
 	}
-	return os.WriteFile(session.SessionRef, session.NativeData, 0o600)
+	return atomicWriteFile(session.SessionRef, session.NativeData, 0o600)
 }
 
 func (a *Agent) ReadTranscript(sessionRef string) ([]byte, error) {
@@ -167,7 +176,7 @@ func (a *Agent) ReadTranscript(sessionRef string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, err := parseAmpThread(data); err != nil {
+	if _, err := decodeTranscript(data); err != nil {
 		return nil, err
 	}
 	return data, nil
@@ -202,11 +211,11 @@ func (a *Agent) GetTranscriptPosition(path string) (int, error) {
 		}
 		return 0, err
 	}
-	thread, err := parseAmpThread(data)
+	messages, err := decodeTranscript(data)
 	if err != nil {
 		return 0, err
 	}
-	return len(thread.Messages), nil
+	return len(messages), nil
 }
 
 func (a *Agent) ExtractModifiedFiles(path string, offset int) ([]string, int, error) {
@@ -214,11 +223,11 @@ func (a *Agent) ExtractModifiedFiles(path string, offset int) ([]string, int, er
 	if err != nil {
 		return nil, 0, err
 	}
-	thread, err := parseAmpThread(data)
+	messages, err := decodeTranscript(data)
 	if err != nil {
 		return nil, 0, err
 	}
-	return modifiedFilesFromThreadFromOffset(thread, offset), len(thread.Messages), nil
+	return modifiedFilesFromMessagesFromOffset(messages, offset), len(messages), nil
 }
 
 func (a *Agent) ExtractPrompts(sessionRef string, offset int) ([]string, error) {
@@ -226,12 +235,12 @@ func (a *Agent) ExtractPrompts(sessionRef string, offset int) ([]string, error) 
 	if err != nil {
 		return nil, err
 	}
-	thread, err := parseAmpThread(data)
+	messages, err := decodeTranscript(data)
 	if err != nil {
 		return nil, err
 	}
 	var prompts []string
-	for _, msg := range threadMessagesFromOffset(thread, offset) {
+	for _, msg := range messagesFromOffset(messages, offset) {
 		if msg.Role != ThreadMessageRoleUser {
 			continue
 		}
@@ -247,12 +256,12 @@ func (a *Agent) ExtractSummary(sessionRef string) (string, bool, error) {
 	if err != nil {
 		return "", false, err
 	}
-	thread, err := parseAmpThread(data)
+	messages, err := decodeTranscript(data)
 	if err != nil {
 		return "", false, err
 	}
-	for i := len(thread.Messages) - 1; i >= 0; i-- {
-		msg := thread.Messages[i]
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
 		if msg.Role != ThreadMessageRoleAssistant {
 			continue
 		}
@@ -264,12 +273,12 @@ func (a *Agent) ExtractSummary(sessionRef string) (string, bool, error) {
 }
 
 func (a *Agent) CalculateTokens(data []byte, offset int) (protocol.TokenUsageResponse, error) {
-	thread, err := parseAmpThread(data)
+	messages, err := decodeTranscript(data)
 	if err != nil {
 		return protocol.TokenUsageResponse{}, err
 	}
 	var usage protocol.TokenUsageResponse
-	for _, msg := range threadMessagesFromOffset(thread, offset) {
+	for _, msg := range messagesFromOffset(messages, offset) {
 		if msg.Usage == nil {
 			continue
 		}
@@ -282,25 +291,25 @@ func (a *Agent) CalculateTokens(data []byte, offset int) (protocol.TokenUsageRes
 	return usage, nil
 }
 
-func threadMessagesFromOffset(thread *Thread, offset int) []ThreadMessage {
-	if thread == nil || len(thread.Messages) == 0 {
+// messagesFromOffset returns the messages at index >= offset. Because the
+// on-disk transcript is one message per line, the offset Entire records via
+// get-transcript-position (a line index) is also a message index.
+func messagesFromOffset(messages []ThreadMessage, offset int) []ThreadMessage {
+	if len(messages) == 0 {
 		return nil
 	}
 	if offset < 0 {
 		offset = 0
 	}
-	if offset >= len(thread.Messages) {
+	if offset >= len(messages) {
 		return nil
 	}
-	return thread.Messages[offset:]
+	return messages[offset:]
 }
 
-func latestThreadModel(thread *Thread) string {
-	if thread == nil {
-		return ""
-	}
-	for i := len(thread.Messages) - 1; i >= 0; i-- {
-		usage := thread.Messages[i].Usage
+func latestThreadModel(messages []ThreadMessage) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		usage := messages[i].Usage
 		if usage != nil && strings.TrimSpace(usage.Model) != "" {
 			return strings.TrimSpace(usage.Model)
 		}
@@ -308,18 +317,12 @@ func latestThreadModel(thread *Thread) string {
 	return ""
 }
 
-func modifiedFilesFromThread(thread *Thread) []string {
-	if thread == nil {
-		return nil
-	}
-	return modifiedFilesFromMessagesWithContext(thread.Messages, thread.Messages)
+func modifiedFilesFromMessages(messages []ThreadMessage) []string {
+	return modifiedFilesFromMessagesWithContext(messages, messages)
 }
 
-func modifiedFilesFromThreadFromOffset(thread *Thread, offset int) []string {
-	if thread == nil {
-		return nil
-	}
-	return modifiedFilesFromMessagesWithContext(threadMessagesFromOffset(thread, offset), thread.Messages)
+func modifiedFilesFromMessagesFromOffset(messages []ThreadMessage, offset int) []string {
+	return modifiedFilesFromMessagesWithContext(messagesFromOffset(messages, offset), messages)
 }
 
 func modifiedFilesFromMessagesWithContext(messages []ThreadMessage, contextMessages []ThreadMessage) []string {

--- a/agents/entire-agent-amp/internal/amp/transcript.go
+++ b/agents/entire-agent-amp/internal/amp/transcript.go
@@ -27,6 +27,10 @@ func threadIDFromTranscriptData(data []byte) (string, error) {
 		return "", errors.New("empty amp transcript")
 	}
 
+	if thread, ok := legacyThreadExport(trimmed); ok && strings.TrimSpace(thread.ID) != "" {
+		return strings.TrimSpace(thread.ID), nil
+	}
+
 	// An unprepared transcript is not an error here: the hook payloads it
 	// holds are exactly what carries the thread id we need to export with.
 	if messages, err := decodeTranscript(trimmed); err == nil {

--- a/agents/entire-agent-amp/internal/amp/transcript_test.go
+++ b/agents/entire-agent-amp/internal/amp/transcript_test.go
@@ -14,24 +14,31 @@ const testTranscriptJSONL = `{"type":"agent.start","thread_id":"T-123","message"
 {"type":"agent.end","thread_id":"T-123","status":"done","modified_files":["hello.txt"],"timestamp":"2026-05-07T12:00:03Z","messages":[{"role":"user","id":1,"content":[{"type":"text","text":"Create hello.txt"}]},{"role":"assistant","id":"a1","content":[{"type":"tool_use","id":"tool1","name":"edit_file","input":{"path":"hello.txt"}},{"type":"text","text":"Created hello.txt"}]},{"role":"user","id":2,"content":[{"type":"tool_result","toolUseID":"tool1","status":"done","output":"ok"}]}]}
 `
 
+// testPreparedTranscriptJSON is Amp's native `amp threads export` output: one
+// JSON document. It is an ingestion format only — never what Entire stores.
 const testPreparedTranscriptJSON = `{"v":1,"id":"T-123","created":1778155200000,"updatedAt":"2026-05-07T12:00:05Z","messages":[{"role":"user","messageId":1,"meta":{"sentAt":1778155200000},"content":[{"type":"text","text":"Create hello.txt"}]},{"role":"assistant","messageId":"a1","meta":{"sentAt":1778155201000},"usage":{"model":"claude","timestamp":"2026-05-07T12:00:01Z","inputTokens":100,"outputTokens":25,"cacheReadInputTokens":7,"cacheCreationInputTokens":3},"content":[{"type":"tool_use","id":"tool1","name":"edit_file","input":{"path":"hello.txt"}},{"type":"text","text":"Created hello.txt"}]},{"role":"user","messageId":2,"meta":{"sentAt":1778155202000},"content":[{"type":"tool_result","toolUseID":"tool1","run":{"status":"done","trackFiles":["hello.txt"],"result":{"output":"ok"}}}]}]}`
 
+// testPreparedTranscriptJSONL is what the agent stores at session_ref after
+// materializing the export above: one message per line, thread id stamped on
+// each, so Entire's line-based scoping lands on message boundaries.
+const testPreparedTranscriptJSONL = `{"threadID":"T-123","meta":{"sentAt":1778155200000},"role":"user","content":[{"type":"text","text":"Create hello.txt"}],"messageId":1}
+{"threadID":"T-123","meta":{"sentAt":1778155201000},"role":"assistant","content":[{"type":"tool_use","id":"tool1","name":"edit_file","input":{"path":"hello.txt"}},{"type":"text","text":"Created hello.txt"}],"messageId":"a1","usage":{"model":"claude","timestamp":"2026-05-07T12:00:01Z","inputTokens":100,"outputTokens":25,"maxInputTokens":0,"totalInputTokens":0,"cacheReadInputTokens":7,"cacheCreationInputTokens":3}}
+{"threadID":"T-123","meta":{"sentAt":1778155202000},"role":"user","content":[{"type":"tool_result","toolUseID":"tool1","run":{"status":"done","result":{"output":"ok"},"trackFiles":["hello.txt"]}}],"messageId":2}
+`
+
 type fakeCommandRunner struct {
-	threadID   string
-	outputPath string
-	err        error
+	threadID string
+	err      error
 }
 
-func (r *fakeCommandRunner) ExportThread(_ context.Context, threadID string, outputPath string) (string, error) {
+// ExportThread returns Amp's native single-document export, exactly as the real
+// `amp threads export` does. Storing it as JSONL is the agent's job.
+func (r *fakeCommandRunner) ExportThread(_ context.Context, threadID string) ([]byte, error) {
 	r.threadID = threadID
-	r.outputPath = outputPath
 	if r.err != nil {
-		return "", r.err
+		return nil, r.err
 	}
-	if err := os.WriteFile(outputPath, []byte(testPreparedTranscriptJSON), 0o600); err != nil {
-		return "", err
-	}
-	return outputPath, nil
+	return []byte(testPreparedTranscriptJSON), nil
 }
 
 func writeTestTranscript(t *testing.T) string {
@@ -43,7 +50,20 @@ func writeTestTranscript(t *testing.T) string {
 	return path
 }
 
+// writePreparedTranscript writes the stored JSONL layout — what a session_ref
+// actually holds once prepare-transcript has run.
 func writePreparedTranscript(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "amp.jsonl")
+	if err := os.WriteFile(path, []byte(testPreparedTranscriptJSONL), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// writeLegacyThreadExport writes a session file in the pre-JSONL single
+// document layout, to keep the back-compat read path covered.
+func writeLegacyThreadExport(t *testing.T) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "amp.json")
 	if err := os.WriteFile(path, []byte(testPreparedTranscriptJSON), 0o600); err != nil {
@@ -60,12 +80,9 @@ func TestExtractModifiedFiles(t *testing.T) {
 	}
 }
 
-func TestExtractModifiedFiles_PreparedJSON(t *testing.T) {
+func TestExtractModifiedFiles_PreparedJSONL(t *testing.T) {
 	agent := New()
-	path := filepath.Join(t.TempDir(), "amp.json")
-	if err := os.WriteFile(path, []byte(testPreparedTranscriptJSON), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	path := writePreparedTranscript(t)
 	files, pos, err := agent.ExtractModifiedFiles(path, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -229,12 +246,9 @@ func TestExtractPrompts(t *testing.T) {
 	}
 }
 
-func TestExtractPrompts_PreparedJSON(t *testing.T) {
+func TestExtractPrompts_PreparedJSONL(t *testing.T) {
 	agent := New()
-	path := filepath.Join(t.TempDir(), "amp.json")
-	if err := os.WriteFile(path, []byte(testPreparedTranscriptJSON), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	path := writePreparedTranscript(t)
 	prompts, err := agent.ExtractPrompts(path, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -258,12 +272,9 @@ func TestExtractSummary(t *testing.T) {
 	}
 }
 
-func TestExtractSummary_PreparedJSON(t *testing.T) {
+func TestExtractSummary_PreparedJSONL(t *testing.T) {
 	agent := New()
-	path := filepath.Join(t.TempDir(), "amp.json")
-	if err := os.WriteFile(path, []byte(testPreparedTranscriptJSON), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	path := writePreparedTranscript(t)
 	summary, has, err := agent.ExtractSummary(path)
 	if err != nil {
 		t.Fatal(err)
@@ -282,12 +293,9 @@ func TestReadSession(t *testing.T) {
 	}
 }
 
-func TestReadSession_PreparedJSON(t *testing.T) {
+func TestReadSession_PreparedJSONL(t *testing.T) {
 	t.Setenv("ENTIRE_REPO_ROOT", t.TempDir())
-	path := filepath.Join(t.TempDir(), "amp.json")
-	if err := os.WriteFile(path, []byte(testPreparedTranscriptJSON), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	path := writePreparedTranscript(t)
 	agent := New()
 	session, err := agent.ReadSession(&protocol.HookInputJSON{SessionRef: path})
 	if err != nil {
@@ -322,16 +330,16 @@ func TestReadSession_PlaceholderTranscript(t *testing.T) {
 	}
 }
 
-func TestCalculateTokens_PreparedJSON(t *testing.T) {
+func TestCalculateTokens_PreparedJSONL(t *testing.T) {
 	agent := New()
-	usage, err := agent.CalculateTokens([]byte(testPreparedTranscriptJSON), 0)
+	usage, err := agent.CalculateTokens([]byte(testPreparedTranscriptJSONL), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if usage.InputTokens != 100 || usage.OutputTokens != 25 || usage.CacheReadTokens != 7 || usage.CacheCreationTokens != 3 || usage.APICallCount != 1 {
 		t.Fatalf("usage = %+v", usage)
 	}
-	usage, err = agent.CalculateTokens([]byte(testPreparedTranscriptJSON), 2)
+	usage, err = agent.CalculateTokens([]byte(testPreparedTranscriptJSONL), 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -372,14 +380,11 @@ func TestPrepareTranscript(t *testing.T) {
 	if runner.threadID != "T-123" {
 		t.Fatalf("threadID = %q", runner.threadID)
 	}
-	if runner.outputPath != path {
-		t.Fatalf("outputPath = %q", runner.outputPath)
-	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(data) != testPreparedTranscriptJSON {
+	if string(data) != testPreparedTranscriptJSONL {
 		t.Fatalf("prepared data = %s", data)
 	}
 }
@@ -464,5 +469,21 @@ func TestWriteSession(t *testing.T) {
 	}
 	if string(data) != "x" {
 		t.Fatalf("data = %q", data)
+	}
+}
+
+// A session file still in the pre-JSONL single-document layout keeps reading,
+// with the same session id and modified files it had before.
+func TestReadSession_LegacyThreadExport(t *testing.T) {
+	t.Setenv("ENTIRE_REPO_ROOT", t.TempDir())
+	session, err := New().ReadSession(&protocol.HookInputJSON{SessionRef: writeLegacyThreadExport(t)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.SessionID != "T-123" || session.AgentName != "amp" {
+		t.Fatalf("session = %+v", session)
+	}
+	if len(session.ModifiedFiles) != 1 || session.ModifiedFiles[0] != "hello.txt" {
+		t.Fatalf("modified files = %v", session.ModifiedFiles)
 	}
 }

--- a/agents/entire-agent-amp/internal/amp/transcript_test.go
+++ b/agents/entire-agent-amp/internal/amp/transcript_test.go
@@ -21,9 +21,15 @@ const testPreparedTranscriptJSON = `{"v":1,"id":"T-123","created":1778155200000,
 // testPreparedTranscriptJSONL is what the agent stores at session_ref after
 // materializing the export above: one message per line, thread id stamped on
 // each, so Entire's line-based scoping lands on message boundaries.
-const testPreparedTranscriptJSONL = `{"threadID":"T-123","meta":{"sentAt":1778155200000},"role":"user","content":[{"type":"text","text":"Create hello.txt"}],"messageId":1}
-{"threadID":"T-123","meta":{"sentAt":1778155201000},"role":"assistant","content":[{"type":"tool_use","id":"tool1","name":"edit_file","input":{"path":"hello.txt"}},{"type":"text","text":"Created hello.txt"}],"messageId":"a1","usage":{"model":"claude","timestamp":"2026-05-07T12:00:01Z","inputTokens":100,"outputTokens":25,"maxInputTokens":0,"totalInputTokens":0,"cacheReadInputTokens":7,"cacheCreationInputTokens":3}}
-{"threadID":"T-123","meta":{"sentAt":1778155202000},"role":"user","content":[{"type":"tool_result","toolUseID":"tool1","run":{"status":"done","result":{"output":"ok"},"trackFiles":["hello.txt"]}}],"messageId":2}
+//
+// Each line also carries the Entire-facing projection ("type", "timestamp",
+// "message"). The native fields stay where Amp puts them; the projection is
+// what Entire's generic compactJSONL actually reads content from
+// (compact.go:617 parseMessage). Without it every compacted line came out with
+// an empty content array.
+const testPreparedTranscriptJSONL = `{"threadID":"T-123","meta":{"sentAt":1778155200000},"role":"user","content":[{"type":"text","text":"Create hello.txt"}],"messageId":1,"type":"user","timestamp":"2026-05-07T12:00:00Z","message":{"role":"user","id":"1","content":[{"type":"text","text":"Create hello.txt"}]}}
+{"threadID":"T-123","meta":{"sentAt":1778155201000},"role":"assistant","content":[{"type":"tool_use","id":"tool1","name":"edit_file","input":{"path":"hello.txt"}},{"type":"text","text":"Created hello.txt"}],"messageId":"a1","usage":{"model":"claude","timestamp":"2026-05-07T12:00:01Z","inputTokens":100,"outputTokens":25,"maxInputTokens":0,"totalInputTokens":0,"cacheReadInputTokens":7,"cacheCreationInputTokens":3},"type":"assistant","timestamp":"2026-05-07T12:00:01Z","message":{"role":"assistant","id":"a1","content":[{"type":"tool_use","id":"tool1","name":"edit_file","input":{"path":"hello.txt"}},{"type":"text","text":"Created hello.txt"}],"usage":{"input_tokens":100,"output_tokens":25}}}
+{"threadID":"T-123","meta":{"sentAt":1778155202000},"role":"user","content":[{"type":"tool_result","toolUseID":"tool1","run":{"status":"done","result":{"output":"ok"},"trackFiles":["hello.txt"]}}],"messageId":2,"type":"user","timestamp":"2026-05-07T12:00:02Z","message":{"role":"user","id":"2","content":[{"type":"tool_result","tool_use_id":"tool1","content":"ok"}]}}
 `
 
 type fakeCommandRunner struct {

--- a/agents/entire-agent-amp/internal/amp/types.go
+++ b/agents/entire-agent-amp/internal/amp/types.go
@@ -160,7 +160,12 @@ const (
 )
 
 // ThreadMessage is a user, assistant, or informational entry in the transcript.
+//
+// ThreadID is written by Entire, not by Amp: the stored transcript is JSONL
+// with no thread header (session_jsonl.go), so the thread id is stamped onto
+// every message to survive a scoped slice that starts past line 0.
 type ThreadMessage struct {
+	ThreadID             string                     `json:"threadID,omitempty"`
 	Meta                 *ThreadMessageMeta         `json:"meta,omitempty"`
 	Role                 ThreadMessageRole          `json:"role"`
 	Content              []ThreadContentBlock       `json:"content,omitempty"`

--- a/e2e/amp_protocol_test.go
+++ b/e2e/amp_protocol_test.go
@@ -40,10 +40,14 @@ func TestLifecycle_AmpPrepareTranscriptProtocol(t *testing.T) {
 
 	runAgent(t, binPath, env, nil, "prepare-transcript", "--session-ref", sessionRef)
 	prepared := readFile(t, sessionRef)
-	assert.JSONEq(t, ampE2EThreadJSON, string(prepared))
+
+	// Entire scopes an external agent's transcript by LINE offset before
+	// compacting it, so the stored transcript must be one message per line —
+	// not the single JSON document `amp threads export` emits.
+	assertJSONLTranscript(t, prepared, 3)
 
 	readTranscript := runAgent(t, binPath, env, nil, "read-transcript", "--session-ref", sessionRef)
-	assert.JSONEq(t, ampE2EThreadJSON, string(readTranscript))
+	assert.Equal(t, string(prepared), string(readTranscript))
 
 	readSession := runAgent(t, binPath, env, []byte(`{"hook_type":"stop","session_ref":"`+sessionRef+`"}`), "read-session")
 	var session struct {
@@ -74,17 +78,73 @@ func TestLifecycle_AmpPrepareTranscriptProtocol(t *testing.T) {
 	tokens := runAgent(t, binPath, env, prepared, "calculate-tokens", "--offset", "0")
 	assert.JSONEq(t, `{"input_tokens":100,"cache_creation_tokens":3,"cache_read_tokens":7,"output_tokens":25,"api_call_count":1}`, string(tokens))
 
+	// A mid-session checkpoint hands compact-transcript a line-scoped slice
+	// with no thread header. It must still be valid and still compact.
+	scopedRef := filepath.Join(repoRoot, ".entire", "tmp", "amp", "T-e2e-amp-scoped.json")
+	require.NoError(t, os.WriteFile(scopedRef, sliceFromLine(prepared, 1), 0o600))
+	assertJSONLTranscript(t, readFile(t, scopedRef), 2)
+	scopedCompact := runAgent(t, binPath, env, nil, "compact-transcript", "--session-ref", scopedRef)
+	var scopedResp struct {
+		Transcript string `json:"transcript"`
+	}
+	require.NoError(t, json.Unmarshal(scopedCompact, &scopedResp))
+	scopedDecoded, err := base64.StdEncoding.DecodeString(scopedResp.Transcript)
+	require.NoError(t, err)
+	assert.NotEmpty(t, scopedDecoded)
+	assert.Contains(t, string(scopedDecoded), `"input_tokens":100`)
+	assert.NotContains(t, string(scopedDecoded), "Create hello.txt")
+
 	compact := runAgent(t, binPath, env, nil, "compact-transcript", "--session-ref", sessionRef)
 	var compactResp struct {
 		Transcript string `json:"transcript"`
 	}
 	require.NoError(t, json.Unmarshal(compact, &compactResp))
-	decoded, err := base64.StdEncoding.DecodeString(compactResp.Transcript)
-	require.NoError(t, err)
+	decoded, decodeErr := base64.StdEncoding.DecodeString(compactResp.Transcript)
+	require.NoError(t, decodeErr)
 	assert.Contains(t, string(decoded), `"agent":"amp"`)
 	assert.Contains(t, string(decoded), `"type":"assistant"`)
 	assert.Contains(t, string(decoded), `"input_tokens":100`)
 	assert.Contains(t, string(decoded), `"result":{"output":"ok","status":"success"}`)
+}
+
+// assertJSONLTranscript asserts that data is exactly wantLines newline-
+// terminated lines, each an independently parseable Amp message.
+func assertJSONLTranscript(t *testing.T, data []byte, wantLines int) {
+	t.Helper()
+	require.Equal(t, wantLines, bytes.Count(data, []byte{'\n'}), "transcript is not one message per line: %s", data)
+	for _, line := range bytes.Split(bytes.TrimRight(data, "\n"), []byte{'\n'}) {
+		var msg struct {
+			ThreadID string            `json:"threadID"`
+			Role     string            `json:"role"`
+			Content  []json.RawMessage `json:"content"`
+		}
+		require.NoError(t, json.Unmarshal(line, &msg), "line is not valid JSON: %s", line)
+		require.Equal(t, "T-e2e-amp", msg.ThreadID, "line lost its thread id: %s", line)
+		require.NotEmpty(t, msg.Role, "line has no role: %s", line)
+	}
+}
+
+// sliceFromLine mirrors Entire's transcript.SliceFromLine
+// (cmd/entire/cli/transcript/parse.go:114), the scoping every non-built-in
+// agent transcript goes through.
+func sliceFromLine(content []byte, startLine int) []byte {
+	if len(content) == 0 || startLine <= 0 {
+		return content
+	}
+	count, offset := 0, 0
+	for i, b := range content {
+		if b == '\n' {
+			count++
+			if count == startLine {
+				offset = i + 1
+				break
+			}
+		}
+	}
+	if count < startLine || offset >= len(content) {
+		return nil
+	}
+	return content[offset:]
 }
 
 func writeFakeAmp(t *testing.T, dir string) {


### PR DESCRIPTION
Fixes the `amp` half of #67. `goose` and `kiro` have the same defect and are deliberately left alone — one focused PR per adapter, as the issue proposes.

## The defect

Entire scopes an external agent's transcript by **line** offset before handing it to `compact-transcript`:

| where | what it does |
|---|---|
| `cmd/entire/cli/explain.go:1883` | `scopeTranscriptForCheckpoint` falls through to `transcript.SliceFromLine` for every agent type that is not one of Entire's built-ins — amp included |
| `cmd/entire/cli/strategy/manual_commit_condensation.go:1006` | same slicing during condensation |
| `cmd/entire/cli/checkpoint/persistent.go:1136` | `writeCompactTranscript` passes `CheckpointTranscriptStart` to `transcript/compact.FullWithBoundary`, which line-slices and then parses each line as JSON |
| `cmd/entire/cli/transcript/parse.go:114` | `SliceFromLine` returns `nil` when the content has fewer newlines than the offset |

amp stored `amp threads export` output verbatim — one JSON document — while reporting `get-transcript-position` as `len(thread.Messages)`, a message index. Slicing a single-line document by line destroys it.

Measured by running this repository's own committed amp fixture (`ampE2EThreadJSON`, `e2e/amp_protocol_test.go:19`) through `entireio/cli@main`'s `transcript.SliceFromLine` + `compact.FullWithBoundary`:

```
before  pos=0  scoped=763B  transcript.jsonl=0B  boundary=0
before  pos=1  scoped=nil   transcript.jsonl=0B  boundary=0
before  pos=2  scoped=nil   transcript.jsonl=0B  boundary=0
```

`transcript.jsonl` was never written into **any** checkpoint — not just later ones, all of them, including the first — and from the second checkpoint on the scoped transcript was `nil`, so summaries had nothing to work with. `full.jsonl` is still written, so nothing was lost irrecoverably.

## The fix

Materialize the transcript as JSONL, one message per line, exactly as `entire-agent-kilo` (#47) and `entire-agent-omp` (#43) already do. Line index then equals message index — which is also the unit `get-transcript-position` reports — so scoping lands on message boundaries and header-less slices remain valid JSONL.

Same fixture, same cli, after this change (bytes produced by the built binary's own `prepare-transcript`, not a hand-written fixture):

```
after   pos=0  scoped=776B  transcript.jsonl=248B  boundary=0
after   pos=1  scoped=637B  transcript.jsonl=248B  boundary=1
after   pos=2  scoped=216B  transcript.jsonl=248B  boundary=2
```

Three things worth calling out:

- **The native export never reaches disk.** `CommandRunner.ExportThread` now returns the export bytes instead of writing them, and `Agent.exportThread` parses, converts, and atomically stores the result. That makes the invariant structural rather than best-effort, and matches kilo's `ExportSession` shape.
- **The thread id moves onto the messages.** The JSONL layout has no thread header, so `ThreadMessage.ThreadID` is stamped on every line — the analogue of kilo's `MessageInfo.SessionID`. A scoped slice starting past line 0 stays identifiable, which the single blob's top-level `"id"` could not manage.
- **Existing session files keep reading.** `decodeTranscript` still accepts a whole-document export and stamps its id the same way, so files written before this change are readable until the next export rewrites them as JSONL. A file holding only unprepared hook payloads still reports `transcript is not prepared`, exactly as the single-document parser did — the tests that guard that behaviour are unchanged.

## Verification

- `agents/entire-agent-amp`: `go build`, `go vet`, `go test ./...` — 50 tests green.
- `golangci-lint v2.11.3` (the pinned version) on `agents/entire-agent-amp` and `e2e`: 0 issues. `gofmt -l .` at the repo root: clean.
- `E2E_AGENT=amp go test -tags=e2e -run TestLifecycle_AmpPrepareTranscriptProtocol ./...` — green. The e2e test now asserts the stored file is one message per line with the thread id on each, and additionally line-slices it at offset 1 and runs `compact-transcript` over the slice, asserting the result is non-empty and excludes pre-offset content.
- New `internal/amp/jsonl_test.go` reproduces cli's `SliceFromLine` verbatim and asserts a mid-session slice still compacts, still analyses, and still yields the thread id.

Mutation-checked — each mutation compiles and is caught:

| mutation | tests failed |
|---|---|
| store the native export verbatim (the pre-fix behaviour) | 6 |
| stop stamping the thread id onto each line | 10 |
| encode all messages as one JSON array instead of one per line | 11 |

Restoring each mutation returns the suite to green.

## Scope

No overlap with #58 (session-id sanitisation), which touches `paths.go`/`paths_test.go` for amp, goose, and kiro. This PR touches none of those files, and no goose or kiro file at all.

Note for #67: `transcript.jsonl` is now non-empty with a correct boundary, but cli's generic `compactJSONL` reads `type`/`role` at the top level and message content under a `message` wrapper. amp's messages satisfy the first and not the second, so the emitted lines carry empty content — the same limitation kilo has today (measured: kilo's shape yields 0B, since its role is nested under `info`; omp's `type` + `message` wrapper yields full content). That is a separate question from this issue and not something this PR claims to fix.