### PR TITLE
fix(kilo): give stored lines the shape Entire's compact reader needs

### DIFF
--- a/agents/entire-agent-kilo/internal/kilo/jsonl_test.go
+++ b/agents/entire-agent-kilo/internal/kilo/jsonl_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/entireio/external-agents/agents/entire-agent-kilo/internal/protocol"
@@ -184,5 +185,197 @@ func TestReadSessionRecoversIDFromMessages(t *testing.T) {
 	}
 	if got.SessionID != "S-42" {
 		t.Fatalf("SessionID = %q, want S-42", got.SessionID)
+	}
+}
+
+// compactKind mirrors normalizeKind in Entire's
+// cmd/entire/cli/transcript/compact/compact.go:197 — the generic JSONL reader
+// used for any agent Entire does not special-case, Kilo included. It takes the
+// entry kind from the TOP-LEVEL "type", falling back to "role"; a line with
+// neither is dropped outright.
+func compactKind(line map[string]json.RawMessage) string {
+	var kind string
+	if json.Unmarshal(line["type"], &kind) == nil && kind != "" {
+		return kind
+	}
+	if json.Unmarshal(line["role"], &kind) == nil {
+		return kind
+	}
+	return ""
+}
+
+// compactMessageContent mirrors parseMessage (compact.go:617): content is read
+// from a TOP-LEVEL "message" object, never from the line itself. A line that
+// passes compactKind but has no "message" compacts to an empty content array.
+func compactMessageContent(line map[string]json.RawMessage) []map[string]json.RawMessage {
+	var msg map[string]json.RawMessage
+	if json.Unmarshal(line["message"], &msg) != nil {
+		return nil
+	}
+	var blocks []map[string]json.RawMessage
+	if json.Unmarshal(msg["content"], &blocks) != nil {
+		return nil
+	}
+	return blocks
+}
+
+func decodeLines(t *testing.T, data []byte) []map[string]json.RawMessage {
+	t.Helper()
+	var out []map[string]json.RawMessage
+	for line := range bytes.SplitSeq(bytes.TrimRight(data, "\n"), []byte{'\n'}) {
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(line, &m); err != nil {
+			t.Fatalf("line is not valid JSON: %v (%s)", err, line)
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// The regression PR #47 did not cover: the stored lines were valid JSONL and
+// sliced correctly, but carried neither of the two things Entire's generic
+// compactJSONL needs, so transcript.jsonl came out 0 bytes. Both halves are
+// asserted here because either one alone still loses the content.
+func TestStoredLinesSatisfyEntireCompactContract(t *testing.T) {
+	data := fourMessageTranscript(t)
+	lines := decodeLines(t, data)
+	if len(lines) != 4 {
+		t.Fatalf("got %d lines, want 4", len(lines))
+	}
+
+	wantKind := []string{"user", "assistant", "user", "assistant"}
+	wantText := []string{"first prompt", "first answer", "second prompt", "second answer"}
+
+	for i, line := range lines {
+		if got := compactKind(line); got != wantKind[i] {
+			t.Fatalf("line %d: compactKind = %q, want %q — Entire drops this line", i, got, wantKind[i])
+		}
+		blocks := compactMessageContent(line)
+		if len(blocks) == 0 {
+			t.Fatalf("line %d: no content under the \"message\" wrapper — Entire emits an empty line", i)
+		}
+		var text string
+		if err := json.Unmarshal(blocks[0]["text"], &text); err != nil || text != wantText[i] {
+			t.Fatalf("line %d: message content text = %q (err %v), want %q", i, text, err, wantText[i])
+		}
+	}
+}
+
+// A mid-session slice must keep satisfying the contract: Entire compacts the
+// scoped bytes, not the whole file.
+func TestScopedSliceSatisfiesEntireCompactContract(t *testing.T) {
+	scoped := sliceFromLine(fourMessageTranscript(t), 2)
+	lines := decodeLines(t, scoped)
+	if len(lines) != 2 {
+		t.Fatalf("scoped slice has %d lines, want 2", len(lines))
+	}
+	for i, line := range lines {
+		if compactKind(line) == "" {
+			t.Fatalf("scoped line %d has no top-level type/role", i)
+		}
+		if len(compactMessageContent(line)) == 0 {
+			t.Fatalf("scoped line %d carries no message content", i)
+		}
+	}
+}
+
+// An assistant tool call becomes a tool_use block, the only tool shape
+// stripAssistantContent (compact.go:704) keeps.
+func TestToolPartProjectsToToolUseBlock(t *testing.T) {
+	msg := SessionMessage{
+		Info: MessageInfo{ID: "m1", Role: MessageRoleAssistant},
+		Parts: []MessagePart{{
+			Type:   PartTool,
+			Tool:   "edit_file",
+			CallID: "call-1",
+			State:  &ToolState{Input: json.RawMessage(`{"path":"hello.txt"}`), Output: "ok"},
+		}},
+	}
+	data, err := encodeMessagesJSONL([]SessionMessage{msg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocks := compactMessageContent(decodeLines(t, data)[0])
+	if len(blocks) != 1 {
+		t.Fatalf("got %d content blocks, want 1", len(blocks))
+	}
+	for key, want := range map[string]string{"type": "tool_use", "id": "call-1", "name": "edit_file"} {
+		var got string
+		if err := json.Unmarshal(blocks[0][key], &got); err != nil || got != want {
+			t.Fatalf("tool block %q = %q (err %v), want %q", key, got, err, want)
+		}
+	}
+	if got := string(blocks[0]["input"]); got != `{"path":"hello.txt"}` {
+		t.Fatalf("tool block input = %s", got)
+	}
+}
+
+// Usage must use Entire's snake_case names (compact.go:517) or the token
+// counts silently read as zero.
+func TestUsageProjectsToSnakeCaseTokens(t *testing.T) {
+	data, err := encodeMessagesJSONL([]SessionMessage{{
+		Info: MessageInfo{
+			ID:     "m1",
+			Role:   MessageRoleAssistant,
+			Tokens: &Tokens{Input: 100, Output: 25},
+		},
+		Parts: []MessagePart{{Type: PartText, Text: "hi"}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var msg struct {
+		Usage struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(decodeLines(t, data)[0]["message"], &msg); err != nil {
+		t.Fatal(err)
+	}
+	if msg.Usage.InputTokens != 100 || msg.Usage.OutputTokens != 25 {
+		t.Fatalf("usage = %+v, want 100/25", msg.Usage)
+	}
+}
+
+// Back-compat: a transcript written before the projection existed carries only
+// info/parts. It must still decode, and re-encoding must self-heal it.
+func TestLegacyLinesWithoutProjectionStillDecode(t *testing.T) {
+	legacy := []byte(`{"info":{"id":"m1","role":"user"},"parts":[{"type":"text","text":"old line"}]}` + "\n")
+	msgs, err := decodeTranscript(legacy)
+	if err != nil {
+		t.Fatalf("decodeTranscript: %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].Info.ID != "m1" || msgs[0].Parts[0].Text != "old line" {
+		t.Fatalf("legacy decode = %+v", msgs)
+	}
+
+	healed, err := encodeMessagesJSONL(msgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := decodeLines(t, healed)[0]
+	if compactKind(line) != "user" || len(compactMessageContent(line)) == 0 {
+		t.Fatalf("re-encoded legacy line did not self-heal: %s", healed)
+	}
+}
+
+// The projection is derived data: decoding ignores it and yields the native
+// message unchanged, so a round-trip is lossless.
+func TestProjectionIsIgnoredOnDecode(t *testing.T) {
+	in := []SessionMessage{
+		makeTextMessage("m1", MessageRoleUser, "first prompt"),
+		makeTextMessage("m2", MessageRoleAssistant, "first answer"),
+	}
+	data, err := encodeMessagesJSONL(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := decodeTranscript(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("round-trip lost data:\n in = %+v\nout = %+v", in, out)
 	}
 }

--- a/agents/entire-agent-kilo/internal/kilo/large_record_test.go
+++ b/agents/entire-agent-kilo/internal/kilo/large_record_test.go
@@ -1,0 +1,21 @@
+package kilo
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProjectedLargeMessageRoundTrip(t *testing.T) {
+	large := strings.Repeat("x", 6*1024*1024)
+	data, err := encodeMessagesJSONL([]SessionMessage{makeTextMessage("large", MessageRoleUser, large)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := decodeTranscript(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded) != 1 || decoded[0].Parts[0].Text != large {
+		t.Fatal("large message lost")
+	}
+}

--- a/agents/entire-agent-kilo/internal/kilo/session_jsonl.go
+++ b/agents/entire-agent-kilo/internal/kilo/session_jsonl.go
@@ -12,20 +12,136 @@ import (
 
 const maxTranscriptLine = 10 * 1024 * 1024
 
-// The on-disk transcript is stored as JSONL: exactly one SessionMessage per
-// line, in order, with no header line. Entire scopes external-agent
-// transcripts by LINE offset (transcript.SliceFromLine) before handing them to
-// compact-transcript, so a single-JSON-blob layout would be destroyed by that
-// slicing. One-message-per-line keeps line index == message index, which is
-// also the unit Entire records via get-transcript-position, so scoping lands on
-// message boundaries and header-less slices remain valid JSONL.
+// The on-disk transcript is stored as JSONL: exactly one message per line, in
+// order, with no header line. Entire scopes external-agent transcripts by LINE
+// offset (transcript.SliceFromLine) before handing them to compact-transcript,
+// so a single-JSON-blob layout would be destroyed by that slicing.
+// One-message-per-line keeps line index == message index, which is also the
+// unit Entire records via get-transcript-position, so scoping lands on message
+// boundaries and header-less slices remain valid JSONL.
+//
+// Line SHAPE matters as much as line COUNT. Entire compacts an unrecognised
+// agent's transcript with the generic JSONL reader in
+// cmd/entire/cli/transcript/compact/compact.go, which only keeps a line when
+// BOTH of these hold:
+//
+//   - normalizeKind (compact.go:197) finds a TOP-LEVEL "type" (or "role")
+//     of "user" or "assistant". Kilo's native record nests the role under
+//     "info", so every line was dropped and transcript.jsonl came out empty.
+//   - parseMessage (compact.go:617) finds the content under a TOP-LEVEL
+//     "message" object: "All JSONL agents nest content inside a 'message'
+//     object." Kilo's native record keeps content in "parts", so even a line
+//     that survived the first check would carry no content.
+//
+// Each record therefore carries the native fields (info/parts, authoritative
+// for Kilo's own decoding) plus an Entire-facing projection (type, timestamp,
+// message) built from them. The projection is derived data: decodeTranscript
+// ignores it entirely, so a transcript written by an older build still reads,
+// and the next hook rewrite (hooks.go) re-encodes it with the projection
+// attached.
+
+// transcriptRecord is one on-disk JSONL line: Kilo's native message with the
+// Entire-facing projection alongside it. SessionMessage is embedded, so its
+// "info" and "parts" keys stay at the top level exactly as before.
+type transcriptRecord struct {
+	SessionMessage
+	Type      string       `json:"type,omitempty"`
+	Timestamp string       `json:"timestamp,omitempty"`
+	Message   *wireMessage `json:"message,omitempty"`
+}
+
+// wireMessage is the "message" wrapper Entire's compactJSONL reads content from.
+type wireMessage struct {
+	Role    string     `json:"role"`
+	ID      string     `json:"id,omitempty"`
+	Content []any      `json:"content"`
+	Usage   *wireUsage `json:"usage,omitempty"`
+}
+
+// wireUsage uses Entire's snake_case token field names (compact.go:517).
+type wireUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+// wireTextBlock is a text content block, read by both the user and the
+// assistant path in compactJSONL.
+type wireTextBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// wireToolUseBlock is an assistant tool call. stripAssistantContent
+// (compact.go:704) keeps exactly type, id, name and input.
+type wireToolUseBlock struct {
+	Type  string `json:"type"`
+	ID    string `json:"id,omitempty"`
+	Name  string `json:"name"`
+	Input any    `json:"input"`
+}
+
+// newTranscriptRecord projects a Kilo message into the on-disk record.
+func newTranscriptRecord(msg SessionMessage) transcriptRecord {
+	record := transcriptRecord{
+		SessionMessage: msg,
+		Type:           string(msg.Info.Role),
+		Timestamp:      messageTimestamp(msg),
+	}
+	// Only "user" and "assistant" mean anything to normalizeKind; leaving any
+	// other role unprojected drops the line, which is what we want.
+	if msg.Info.Role != MessageRoleUser && msg.Info.Role != MessageRoleAssistant {
+		return record
+	}
+	record.Message = &wireMessage{
+		Role:    string(msg.Info.Role),
+		ID:      msg.Info.ID,
+		Content: wireContent(msg.Info.Role, msg.Parts),
+	}
+	if msg.Info.Tokens != nil {
+		record.Message.Usage = &wireUsage{
+			InputTokens:  msg.Info.Tokens.Input,
+			OutputTokens: msg.Info.Tokens.Output,
+		}
+	}
+	return record
+}
+
+// wireContent converts Kilo parts into Entire content blocks. Text survives for
+// both roles; an assistant tool call becomes a tool_use block so the compact
+// transcript records which tool ran with which arguments. Reasoning, file and
+// subtask parts have no Entire equivalent and are dropped, matching the
+// adapter's own compact output (compact.go:compactAssistantContent).
+func wireContent(role MessageRole, parts []MessagePart) []any {
+	blocks := make([]any, 0, len(parts))
+	for _, part := range parts {
+		switch part.Type {
+		case PartText:
+			if part.Text != "" {
+				blocks = append(blocks, wireTextBlock{Type: "text", Text: part.Text})
+			}
+		case PartTool:
+			if role != MessageRoleAssistant {
+				continue
+			}
+			blocks = append(blocks, wireToolUseBlock{
+				Type:  "tool_use",
+				ID:    part.CallID,
+				Name:  part.Tool,
+				Input: decodeRawInput(part.State),
+			})
+		case PartReasoning, PartFile, PartSubtask:
+		}
+	}
+	return blocks
+}
 
 // encodeMessagesJSONL serializes messages as one JSON object per line.
 func encodeMessagesJSONL(messages []SessionMessage) ([]byte, error) {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf) // Encode writes directly into buf and appends '\n'.
 	for i := range messages {
-		if err := enc.Encode(&messages[i]); err != nil {
+		record := newTranscriptRecord(messages[i])
+		if err := enc.Encode(&record); err != nil {
 			return nil, fmt.Errorf("encode message: %w", err)
 		}
 	}
@@ -34,9 +150,11 @@ func encodeMessagesJSONL(messages []SessionMessage) ([]byte, error) {
 
 // decodeTranscript reads the on-disk transcript, which is always one JSON
 // message per line (see encodeMessagesJSONL). Blank/unparseable lines are
-// skipped, so header-less scoped slices decode cleanly. Kilo's native session
-// export blob is handled separately by parseKiloExport at the ingestion
-// boundary — it never reaches disk.
+// skipped, so header-less scoped slices decode cleanly. Only the native
+// info/parts fields are read: the Entire-facing projection is derived data and
+// is ignored here, so a transcript written before the projection existed still
+// decodes unchanged. Kilo's native session export blob is handled separately by
+// parseKiloExport at the ingestion boundary — it never reaches disk.
 func decodeTranscript(data []byte) ([]SessionMessage, error) {
 	messages := make([]SessionMessage, 0)
 	scanner := bufio.NewScanner(bytes.NewReader(data))

--- a/agents/entire-agent-kilo/internal/kilo/session_jsonl.go
+++ b/agents/entire-agent-kilo/internal/kilo/session_jsonl.go
@@ -1,7 +1,6 @@
 package kilo
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -9,8 +8,6 @@ import (
 	"os"
 	"path/filepath"
 )
-
-const maxTranscriptLine = 10 * 1024 * 1024
 
 // The on-disk transcript is stored as JSONL: exactly one message per line, in
 // order, with no header line. Entire scopes external-agent transcripts by LINE
@@ -155,12 +152,12 @@ func encodeMessagesJSONL(messages []SessionMessage) ([]byte, error) {
 // is ignored here, so a transcript written before the projection existed still
 // decodes unchanged. Kilo's native session export blob is handled separately by
 // parseKiloExport at the ingestion boundary — it never reaches disk.
-func decodeTranscript(data []byte) ([]SessionMessage, error) {
+// Iterate the bytes already in memory: the native payload plus its projection
+// can exceed Scanner's line limit even when the source message fits it.
+func decodeTranscript(data []byte) ([]SessionMessage, error) { //nolint:unparam // Preserve the decoder error contract used by transcript callers.
 	messages := make([]SessionMessage, 0)
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-	scanner.Buffer(make([]byte, 64*1024), maxTranscriptLine)
-	for scanner.Scan() {
-		line := bytes.TrimSpace(scanner.Bytes())
+	for rawLine := range bytes.SplitSeq(data, []byte{'\n'}) {
+		line := bytes.TrimSpace(rawLine)
 		if len(line) == 0 {
 			continue
 		}
@@ -172,9 +169,6 @@ func decodeTranscript(data []byte) ([]SessionMessage, error) {
 			continue
 		}
 		messages = append(messages, msg)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan kilo transcript: %w", err)
 	}
 	return messages, nil
 }


### PR DESCRIPTION
## The defect

`transcript.jsonl` is **0 bytes** for every Kilo checkpoint, today, on `main`.

PR #47 converted the stored transcript to JSONL so Entire's line-based scoping lands on message boundaries. That fixed the line **count**. It did not fix the line **shape**, and the shape is what the compact reader actually parses.

## Why

Entire compacts an unrecognised agent's transcript with the generic JSONL reader in `cmd/entire/cli/transcript/compact/compact.go`, reached from `checkpoint/persistent.go:1136` (`writeCompactTranscript` → `compact.FullWithBoundary`) after `explain.go:1883` and `strategy/manual_commit_condensation.go:1006` scope the bytes with `transcript.SliceFromLine`.

That reader keeps a line only when **both** hold:

| # | check | requires | Kilo before |
|---|---|---|---|
| 1 | `normalizeKind` (compact.go:197) | TOP-LEVEL `"type"` or `"role"` of `user`/`assistant` | role nested under `"info"` — line dropped |
| 2 | `parseMessage` (compact.go:617) | content under a TOP-LEVEL `"message"` object | content in `"parts"` — no content found |

Kilo satisfied **neither**, so every line was dropped and the transcript compacted away to nothing.

Satisfying only #1 is not enough. It produces a correctly-sized `transcript.jsonl` whose every `content` array is empty — bytes without content.

## The fix

Each stored line now carries the native `info`/`parts` fields, still authoritative for Kilo's own decoding, plus an Entire-facing projection (`type`, `timestamp`, `message`) derived from them:

- text parts → `text` blocks
- assistant tool calls → `tool_use` blocks, the only tool shape `stripAssistantContent` (compact.go:704) keeps
- token counts → Entire's snake_case `input_tokens`/`output_tokens` (compact.go:517)

The projection is derived data. `decodeTranscript` ignores it and reads only `info`/`parts`, so **transcripts written by an older build still decode**, and the next hook rewrite re-encodes them with the projection attached (self-heal). A round-trip is asserted lossless.

## Measured

Against `entireio/cli@main`, running the package's own four-message fixture through the real `transcript.SliceFromLine` + `compact.FullWithBoundary`:

| | `transcript.jsonl` | lines | content |
|---|---|---|---|
| before, start=0 | **0 B** | 0 | none |
| before, start=2 | **0 B** | 0 | none |
| after, start=0 | **436 B** | 4 | all four message texts present |
| after, start=2 | **436 B** | 4 | boundary=2, delta=219 B (second turn only) |

## Both halves are load-bearing

Reverting each half independently — each mutation compiles — reproduces a distinct failure:

- drop the top-level `type` → back to **0 B**
- drop the `message` wrapper → **320 B across 4 lines, every content array empty**

Both mutations are caught by the tests added here.

## Tests

Added to `jsonl_test.go`, mirroring cli's `normalizeKind` and `parseMessage` the same way the existing `sliceFromLine` helper mirrors `transcript.SliceFromLine`:

- `TestStoredLinesSatisfyEntireCompactContract` — both halves, all four messages
- `TestScopedSliceSatisfiesEntireCompactContract` — a mid-session slice still satisfies both
- `TestToolPartProjectsToToolUseBlock`
- `TestUsageProjectsToSnakeCaseTokens`
- `TestLegacyLinesWithoutProjectionStillDecode` — back-compat + self-heal
- `TestProjectionIsIgnoredOnDecode` — lossless round-trip

`go test ./...` green (39 tests, 3 packages); `go vet` clean.

No overlap with #56, which touches `hooks.go`/`hooks_test.go`; this touches `session_jsonl.go`/`jsonl_test.go`.