### PR TITLE
fix(goose): store the transcript as JSONL so checkpoint scoping keeps its content

### DIFF
--- a/agents/entire-agent-goose/AGENT.md
+++ b/agents/entire-agent-goose/AGENT.md
@@ -69,7 +69,21 @@ real captured payloads unless marked `(unverified)`.
   goose session and TurnEnd checkpoints would be skipped (found the hard way).
 - Transcript positions/offsets are **message indexes**, not bytes: each export
   rewrites the whole JSON document, so byte offsets would not be stable.
-- Format: single JSON object with session metadata + `conversation` array of messages.
+- Stored format: **JSONL, one conversation message per line.** The native export
+  is an ingestion format only — `prepare-transcript` converts it before writing.
+  Entire slices external-agent transcripts by LINE offset
+  (`transcript.SliceFromLine`) before compacting them, so a single JSON document
+  is cut mid-value and every checkpoint's `transcript.jsonl` came out empty. One
+  message per line makes line index == message index == the unit
+  `get-transcript-position` reports.
+- Each stored record carries goose's native message fields, the export's
+  session-level header under `session` (stamped on every record, because a
+  scoped slice has no header), and an Entire-facing projection (`type`,
+  `timestamp`, `message`) built from them. Entire's generic JSONL compactor
+  needs a top-level `type`/`role` AND content under a top-level `message`
+  wrapper; goose's own `content` array is where Entire does not look.
+- Native export format (input to the conversion): single JSON object with
+  session metadata + `conversation` array of messages.
 - Export top-level fields **(verified)**: `id`, `working_dir`, `name`, `session_type`, `created_at`/`updated_at` (RFC 3339), `total_tokens`, `input_tokens`, `output_tokens`, `accumulated_total_tokens`, `accumulated_input_tokens`, `accumulated_output_tokens`, `accumulated_cost`, `conversation`, `message_count`, `provider_name`, `model_config` (has `model_name`).
 - Message schema (camelCase content, unlike snake_case hook payloads) **(verified)**:
   ```json
@@ -110,11 +124,11 @@ real captured payloads unless marked `(unverified)`.
 | `install-hooks` | project plugin | write `<repo>/.agents/plugins/entire/hooks/hooks.json` calling the entire hook handler | hooks |
 | `uninstall-hooks` | — | remove that plugin dir | hooks |
 | `are-hooks-installed` | — | check plugin dir + hooks.json content | hooks |
-| `get-transcript-position` | export size | file size (re-export shifts bytes; position resets via prepare) | transcript_analyzer |
+| `get-transcript-position` | message count | number of stored JSONL lines (== `len(conversation)`) | transcript_analyzer |
 | `extract-modified-files` | `toolRequest` entries | parse `conversation` for write/edit tool calls | transcript_analyzer |
 | `extract-prompts` | user text messages | parse `conversation` | transcript_analyzer |
 | `extract-summary` | session `name` | auto-generated session name (`"File verification request"`) as summary | transcript_analyzer |
-| `prepare-transcript` | `goose session export` | shell out: `goose session export --session-id <id> --format json -o <path>` | transcript_preparer |
+| `prepare-transcript` | `goose session export` | shell out: `goose session export --session-id <id> --format json -o <scratch>`, then materialize as JSONL and write atomically to `session_ref` | transcript_preparer |
 | `calculate-tokens` | export token fields | `accumulated_input/output_tokens`; `api_call_count` = assistant message count | token_calculator |
 
 ## Selected Capabilities

--- a/agents/entire-agent-goose/internal/goose/compact.go
+++ b/agents/entire-agent-goose/internal/goose/compact.go
@@ -82,7 +82,7 @@ func compactTranscriptBytes(data []byte) ([]byte, error) {
 	var buf bytes.Buffer
 	for _, msg := range export.Conversation {
 		switch msg.Role {
-		case "user":
+		case roleUser:
 			// User messages carrying only toolResponse blocks are tool
 			// results, not prompts; they surface attached to the assistant's
 			// tool_use blocks instead.
@@ -94,13 +94,13 @@ func compactTranscriptBytes(data []byte) ([]byte, error) {
 				V:          1,
 				Agent:      compactTranscriptAgent,
 				CLIVersion: cliVersion,
-				Type:       "user",
+				Type:       roleUser,
 				TS:         compactTimestamp(msg.Created),
 				Content:    content,
 			}); err != nil {
 				return nil, err
 			}
-		case "assistant":
+		case roleAssistant:
 			content := compactAssistantContent(msg.Content, results)
 			if len(content) == 0 {
 				continue
@@ -109,7 +109,7 @@ func compactTranscriptBytes(data []byte) ([]byte, error) {
 				V:          1,
 				Agent:      compactTranscriptAgent,
 				CLIVersion: cliVersion,
-				Type:       "assistant",
+				Type:       roleAssistant,
 				TS:         compactTimestamp(msg.Created),
 				ID:         msg.ID,
 				Content:    content,
@@ -138,11 +138,11 @@ func compactAssistantContent(blocks []gooseContent, results map[string]compactTo
 	out := []any{}
 	for _, block := range blocks {
 		switch block.Type {
-		case "text":
+		case contentTypeText:
 			if block.Text != "" {
-				out = append(out, compactAssistantTextBlock{Type: "text", Text: block.Text})
+				out = append(out, compactAssistantTextBlock{Type: contentTypeText, Text: block.Text})
 			}
-		case "toolRequest":
+		case contentTypeToolRequest:
 			if block.ToolCall == nil {
 				continue
 			}
@@ -167,7 +167,7 @@ func collectToolResults(messages []gooseMessage) map[string]compactToolResultJSO
 	results := map[string]compactToolResultJSON{}
 	for _, msg := range messages {
 		for _, block := range msg.Content {
-			if block.Type != "toolResponse" || block.ToolResult == nil || block.ID == "" {
+			if block.Type != contentTypeToolResponse || block.ToolResult == nil || block.ID == "" {
 				continue
 			}
 			status := "success"
@@ -176,7 +176,7 @@ func collectToolResults(messages []gooseMessage) map[string]compactToolResultJSO
 			}
 			var parts []string
 			for _, content := range block.ToolResult.Value.Content {
-				if content.Type == "text" && content.Text != "" {
+				if content.Type == contentTypeText && content.Text != "" {
 					parts = append(parts, content.Text)
 				}
 			}

--- a/agents/entire-agent-goose/internal/goose/compact.go
+++ b/agents/entire-agent-goose/internal/goose/compact.go
@@ -127,7 +127,7 @@ func compactTranscriptBytes(data []byte) ([]byte, error) {
 func compactUserContent(blocks []gooseContent) []compactUserTextBlock {
 	out := []compactUserTextBlock{}
 	for _, block := range blocks {
-		if block.Type == "text" && block.Text != "" {
+		if block.Type == contentTypeText && block.Text != "" {
 			out = append(out, compactUserTextBlock{Text: block.Text})
 		}
 	}

--- a/agents/entire-agent-goose/internal/goose/hooks.go
+++ b/agents/entire-agent-goose/internal/goose/hooks.go
@@ -116,20 +116,49 @@ func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, e
 	}
 }
 
+// exportSession runs `goose session export` into a scratch directory and
+// materializes the result at sessionRef as JSONL, one conversation message per
+// line. The native export is an ingestion format only: writing its single JSON
+// document to sessionRef is what made every checkpoint's compact transcript
+// empty, because Entire slices external-agent transcripts by line before
+// compacting them (see session_jsonl.go).
+//
+// The write is atomic, so a concurrent reader never sees a half-written
+// transcript, and an export this build cannot parse is stored verbatim rather
+// than discarded — an unrecognised goose version must not break checkpointing.
 func (a *Agent) exportSession(sessionID, sessionRef string) error {
 	if sessionID == "" || sessionRef == "" {
 		return errors.New("session id and session ref are required")
 	}
-	if err := os.MkdirAll(filepath.Dir(sessionRef), 0o750); err != nil {
+	dir := filepath.Dir(sessionRef)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return err
 	}
 	runner := a.CommandRunner
 	if runner == nil {
 		runner = &DefaultCommandRunner{}
 	}
+	scratch, err := os.MkdirTemp(dir, ".goose-export-")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(scratch) }()
+
+	nativePath := filepath.Join(scratch, sessionID+".json")
 	ctx, cancel := context.WithTimeout(context.Background(), exportTimeout)
 	defer cancel()
-	return runner.ExportSession(ctx, sessionID, sessionRef)
+	if err := runner.ExportSession(ctx, sessionID, nativePath); err != nil {
+		return err
+	}
+	native, err := os.ReadFile(nativePath)
+	if err != nil {
+		return err
+	}
+	data, ok := materializeExport(native)
+	if !ok {
+		data = native
+	}
+	return atomicWriteFile(sessionRef, data, 0o600)
 }
 
 // hooksFileContent renders the goose plugin hooks.json forwarding native

--- a/agents/entire-agent-goose/internal/goose/hooks.go
+++ b/agents/entire-agent-goose/internal/goose/hooks.go
@@ -63,6 +63,9 @@ func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, e
 		return nil, nil
 	}
 
+	if !validSessionID(payload.SessionID) {
+		return nil, errors.New("invalid goose session ID")
+	}
 	sessionID := payload.SessionID
 	sessionRef := transcriptPath(sessionID)
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -127,8 +130,8 @@ func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, e
 // transcript, and an export this build cannot parse is stored verbatim rather
 // than discarded — an unrecognised goose version must not break checkpointing.
 func (a *Agent) exportSession(sessionID, sessionRef string) error {
-	if sessionID == "" || sessionRef == "" {
-		return errors.New("session id and session ref are required")
+	if !validSessionID(sessionID) || sessionRef == "" {
+		return errors.New("valid session id and session ref are required")
 	}
 	dir := filepath.Dir(sessionRef)
 	if err := os.MkdirAll(dir, 0o750); err != nil {
@@ -144,7 +147,7 @@ func (a *Agent) exportSession(sessionID, sessionRef string) error {
 	}
 	defer func() { _ = os.RemoveAll(scratch) }()
 
-	nativePath := filepath.Join(scratch, sessionID+".json")
+	nativePath := filepath.Join(scratch, "export.json")
 	ctx, cancel := context.WithTimeout(context.Background(), exportTimeout)
 	defer cancel()
 	if err := runner.ExportSession(ctx, sessionID, nativePath); err != nil {

--- a/agents/entire-agent-goose/internal/goose/jsonl_test.go
+++ b/agents/entire-agent-goose/internal/goose/jsonl_test.go
@@ -1,0 +1,421 @@
+package goose
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/entireio/external-agents/agents/entire-agent-goose/internal/protocol"
+)
+
+// sliceFromLine mirrors Entire's transcript.SliceFromLine
+// (cmd/entire/cli/transcript/parse.go:130): return the bytes starting after the
+// Nth newline, or nil when there aren't that many lines. This is what
+// cmd/entire/cli/explain.go:1883 (scopeTranscriptForCheckpoint) and
+// cmd/entire/cli/strategy/manual_commit_condensation.go:1006 apply to every
+// agent that is not one of Entire's built-ins — goose included.
+func sliceFromLine(content []byte, startLine int) []byte {
+	if len(content) == 0 || startLine <= 0 {
+		return content
+	}
+	count, offset := 0, 0
+	for i, b := range content {
+		if b == '\n' {
+			count++
+			if count == startLine {
+				offset = i + 1
+				break
+			}
+		}
+	}
+	if count < startLine || offset >= len(content) {
+		return nil
+	}
+	return content[offset:]
+}
+
+// storedTranscript materializes the committed native export through the real
+// write path (materializeExport -> encodeSessionJSONL), so every assertion
+// below exercises the encoder rather than a checked-in expected constant.
+func storedTranscript(t *testing.T) []byte {
+	t.Helper()
+	data, ok := materializeExport([]byte(exportFixture))
+	if !ok {
+		t.Fatal("exportFixture did not materialize")
+	}
+	return data
+}
+
+func storedTranscriptFile(t *testing.T, data []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "20260611_1.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func decodeLines(t *testing.T, data []byte) []map[string]json.RawMessage {
+	t.Helper()
+	var out []map[string]json.RawMessage
+	for line := range bytes.SplitSeq(bytes.TrimRight(data, "\n"), []byte{'\n'}) {
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(line, &m); err != nil {
+			t.Fatalf("line is not valid JSON: %v (%s)", err, line)
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// compactKind mirrors normalizeKind in Entire's
+// cmd/entire/cli/transcript/compact/compact.go:197: the entry kind comes from
+// the TOP-LEVEL "type", falling back to "role".
+func compactKind(line map[string]json.RawMessage) string {
+	var kind string
+	if json.Unmarshal(line["type"], &kind) == nil && kind != "" {
+		return kind
+	}
+	if json.Unmarshal(line["role"], &kind) == nil {
+		return kind
+	}
+	return ""
+}
+
+// compactMessageContent mirrors parseMessage (compact.go:617): content is read
+// from a TOP-LEVEL "message" object, never from the line's own "content" array.
+// This is the half goose was missing — its lines carried content where Entire
+// does not look, so transcript.jsonl came out empty.
+func compactMessageContent(line map[string]json.RawMessage) []map[string]json.RawMessage {
+	var msg map[string]json.RawMessage
+	if json.Unmarshal(line["message"], &msg) != nil {
+		return nil
+	}
+	var blocks []map[string]json.RawMessage
+	if json.Unmarshal(msg["content"], &blocks) != nil {
+		return nil
+	}
+	return blocks
+}
+
+func blockString(t *testing.T, block map[string]json.RawMessage, key string) string {
+	t.Helper()
+	var s string
+	if err := json.Unmarshal(block[key], &s); err != nil {
+		t.Fatalf("block[%q] = %s: %v", key, block[key], err)
+	}
+	return s
+}
+
+// The regression this change exists for: a single JSON document cannot survive
+// Entire's line-offset scoping, so the transcript must be one message per line.
+func TestStoredTranscriptIsOneMessagePerLine(t *testing.T) {
+	data := storedTranscript(t)
+	if bytes.HasPrefix(bytes.TrimSpace(data), []byte(`{"id": "20260611_1"`)) {
+		t.Fatalf("native single-document export stored verbatim: %s", data)
+	}
+	if lines := bytes.Count(data, []byte{'\n'}); lines != 4 {
+		t.Fatalf("expected 4 newline-terminated lines, got %d: %s", lines, data)
+	}
+	export, err := parseGooseExport(data)
+	if err != nil {
+		t.Fatalf("parseGooseExport: %v", err)
+	}
+	if len(export.Conversation) != 4 || export.Conversation[0].ID != "msg_1" || export.Conversation[3].ID != "msg_4" {
+		t.Fatalf("round-trip conversation = %+v", export.Conversation)
+	}
+}
+
+// Storing JSONL makes Entire keep the lines; it does not make them carry
+// anything. Both halves of the contract are asserted because satisfying only
+// the first yields a correctly-sized transcript.jsonl full of empty content.
+func TestStoredLinesSatisfyEntireCompactContract(t *testing.T) {
+	lines := decodeLines(t, storedTranscript(t))
+	if len(lines) != 4 {
+		t.Fatalf("got %d lines, want 4", len(lines))
+	}
+	wantKind := []string{"user", "assistant", "user", "assistant"}
+	for i, line := range lines {
+		if got := compactKind(line); got != wantKind[i] {
+			t.Fatalf("line %d: compactKind = %q, want %q — Entire drops this line", i, got, wantKind[i])
+		}
+		if len(compactMessageContent(line)) == 0 {
+			t.Fatalf("line %d: no content under the %q wrapper — Entire emits an empty line", i, "message")
+		}
+	}
+	if got := blockString(t, compactMessageContent(lines[0])[0], "text"); got != "Create a file named verify.txt" {
+		t.Fatalf("user text = %q", got)
+	}
+	if got := blockString(t, compactMessageContent(lines[3])[0], "text"); got != "ENTIRE_VERIFY_OK" {
+		t.Fatalf("assistant text = %q", got)
+	}
+}
+
+// A mid-session slice must keep satisfying the contract: Entire compacts the
+// scoped bytes, not the whole file.
+func TestScopedSliceSatisfiesEntireCompactContract(t *testing.T) {
+	scoped := sliceFromLine(storedTranscript(t), 2)
+	lines := decodeLines(t, scoped)
+	if len(lines) != 2 {
+		t.Fatalf("scoped slice has %d lines, want 2", len(lines))
+	}
+	for i, line := range lines {
+		if compactKind(line) == "" {
+			t.Fatalf("scoped line %d has no top-level type/role", i)
+		}
+		if len(compactMessageContent(line)) == 0 {
+			t.Fatalf("scoped line %d carries no message content", i)
+		}
+	}
+	if got := blockString(t, compactMessageContent(lines[1])[0], "text"); got != "ENTIRE_VERIFY_OK" {
+		t.Fatalf("scoped assistant text = %q", got)
+	}
+}
+
+// Tool calls and their results must land in the shapes Entire matches on:
+// tool_use keeps type/id/name/input (compact.go:704), and a user tool_result
+// uses snake_case tool_use_id with a string "content" (compact.go:665) so
+// Entire inlines the output into the preceding assistant's tool_use.
+func TestToolBlocksProjectToEntireShapes(t *testing.T) {
+	lines := decodeLines(t, storedTranscript(t))
+
+	toolUse := compactMessageContent(lines[1])[0]
+	for key, want := range map[string]string{"type": "tool_use", "id": "toolu_1", "name": "write"} {
+		if got := blockString(t, toolUse, key); got != want {
+			t.Fatalf("tool_use %q = %q, want %q", key, got, want)
+		}
+	}
+	var input map[string]any
+	if err := json.Unmarshal(toolUse["input"], &input); err != nil {
+		t.Fatalf("tool_use input = %s: %v", toolUse["input"], err)
+	}
+	if input["path"] != "/tmp/workspace/verify.txt" {
+		t.Fatalf("tool_use input = %+v", input)
+	}
+
+	toolResult := compactMessageContent(lines[2])[0]
+	for key, want := range map[string]string{"type": "tool_result", "tool_use_id": "toolu_1"} {
+		if got := blockString(t, toolResult, key); got != want {
+			t.Fatalf("tool_result %q = %q, want %q", key, got, want)
+		}
+	}
+	if _, ok := toolResult["content"]; !ok {
+		t.Fatal("tool_result has no content key — Entire reads it as a string")
+	}
+}
+
+// A goose toolResult's text parts must reach the tool_result block, and a
+// failed call must be flagged so Entire records it as an error.
+func TestToolResultTextAndErrorProject(t *testing.T) {
+	export, ok := legacyGooseExport([]byte(`{
+	  "id": "20260611_2",
+	  "conversation": [
+	    {"id":"m1","role":"assistant","created":1781175772,"content":[
+	      {"type":"toolRequest","id":"t1","toolCall":{"status":"success","value":{"name":"write","arguments":{"path":"a.txt"}}}}]},
+	    {"id":"m2","role":"user","created":1781175773,"content":[
+	      {"type":"toolResponse","id":"t1","toolResult":{"status":"error","value":{"content":[{"type":"text","text":"permission denied"}],"isError":true}}}]}
+	  ]
+	}`))
+	if !ok {
+		t.Fatal("fixture is not a goose export")
+	}
+	data, err := encodeSessionJSONL(export)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block := compactMessageContent(decodeLines(t, data)[1])[0]
+	if got := blockString(t, block, "content"); got != "permission denied" {
+		t.Fatalf("tool_result content = %q", got)
+	}
+	var isError bool
+	if err := json.Unmarshal(block["is_error"], &isError); err != nil || !isError {
+		t.Fatalf("tool_result is_error = %s (%v)", block["is_error"], err)
+	}
+}
+
+// get-transcript-position is what Entire records as the next checkpoint's start
+// line, so it must equal the stored line count or scoping cuts in the wrong
+// place.
+func TestGetTranscriptPositionMatchesLineCount(t *testing.T) {
+	data := storedTranscript(t)
+	path := storedTranscriptFile(t, data)
+	pos, err := (&Agent{}).GetTranscriptPosition(path)
+	if err != nil {
+		t.Fatalf("GetTranscriptPosition: %v", err)
+	}
+	if lines := bytes.Count(data, []byte{'\n'}); pos != lines {
+		t.Fatalf("position %d != newline count %d (Entire slices by line)", pos, lines)
+	}
+}
+
+// A scoped slice has no header, so the session-level fields every analyzer
+// depends on must travel on the records themselves.
+func TestScopedSliceRemainsAnalyzable(t *testing.T) {
+	t.Setenv("ENTIRE_REPO_ROOT", t.TempDir())
+	scoped := sliceFromLine(storedTranscript(t), 2)
+	path := storedTranscriptFile(t, scoped)
+	a := &Agent{}
+
+	if pos, err := a.GetTranscriptPosition(path); err != nil || pos != 2 {
+		t.Fatalf("scoped position = (%d, %v), want 2", pos, err)
+	}
+	summary, ok, err := a.ExtractSummary(path)
+	if err != nil || !ok || summary != "File verification request" {
+		t.Fatalf("scoped summary = (%q, %v, %v)", summary, ok, err)
+	}
+	if model := modelFromSessionRef(path); model != "anthropic/claude-opus-4.6" {
+		t.Fatalf("scoped model = %q", model)
+	}
+	usage, err := a.CalculateTokens(scoped, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage.InputTokens != 5650 || usage.OutputTokens != 124 {
+		t.Fatalf("scoped tokens = %+v", usage)
+	}
+	session, err := a.ReadSession(&protocol.HookInputJSON{SessionRef: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.SessionID != "20260611_1" {
+		t.Fatalf("scoped session id = %q, want 20260611_1 (recovered from a record)", session.SessionID)
+	}
+	if session.StartTime != "2026-06-11T11:02:34Z" {
+		t.Fatalf("scoped start time = %q", session.StartTime)
+	}
+}
+
+// The native export is an ingestion format: prepare-transcript must convert it
+// before storing, never write it to session_ref as-is.
+func TestPrepareTranscriptStoresJSONL(t *testing.T) {
+	runner := &stubRunner{export: []byte(exportFixture)}
+	a := &Agent{CommandRunner: runner}
+	ref := filepath.Join(t.TempDir(), "20260611_1.json")
+	if err := a.PrepareTranscript(ref); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lines := bytes.Count(data, []byte{'\n'}); lines != 4 {
+		t.Fatalf("stored %d lines, want 4: %s", lines, data)
+	}
+	for i, line := range decodeLines(t, data) {
+		if compactKind(line) == "" || len(compactMessageContent(line)) == 0 {
+			t.Fatalf("stored line %d does not satisfy the compact contract: %s", i, data)
+		}
+	}
+}
+
+// An export this build cannot parse must still be stored, so an unrecognised
+// goose version degrades to today's behaviour instead of breaking checkpoints.
+func TestPrepareTranscriptStoresUnparseableExportVerbatim(t *testing.T) {
+	runner := &stubRunner{export: []byte("not json")}
+	a := &Agent{CommandRunner: runner}
+	ref := filepath.Join(t.TempDir(), "20260611_1.json")
+	if err := a.PrepareTranscript(ref); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "not json" {
+		t.Fatalf("stored = %q", data)
+	}
+}
+
+// Session files written before the JSONL layout existed must keep reading; the
+// next export rewrites them.
+func TestParseGooseExportAcceptsLegacyDocument(t *testing.T) {
+	export, err := parseGooseExport([]byte(exportFixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if export.ID != "20260611_1" || len(export.Conversation) != 4 || export.Name != "File verification request" {
+		t.Fatalf("legacy export = %+v", export.gooseSessionMeta)
+	}
+}
+
+// A JSONL transcript written before the projection existed carries only the
+// native fields. It must still decode, and re-encoding self-heals it.
+func TestLegacyJSONLWithoutProjectionStillDecodes(t *testing.T) {
+	legacy := []byte(`{"id":"m1","role":"user","created":1781175769,"content":[{"type":"text","text":"old line"}]}` + "\n")
+	export, err := parseGooseExport(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(export.Conversation) != 1 || export.Conversation[0].Content[0].Text != "old line" {
+		t.Fatalf("legacy decode = %+v", export.Conversation)
+	}
+	healed, err := encodeSessionJSONL(export)
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := decodeLines(t, healed)[0]
+	if compactKind(line) != "user" || len(compactMessageContent(line)) == 0 {
+		t.Fatalf("re-encoded legacy line did not self-heal: %s", healed)
+	}
+}
+
+// The projection is derived data: decoding ignores it and yields the native
+// conversation unchanged, so a round-trip through the stored layout is lossless.
+func TestProjectionIsIgnoredOnDecode(t *testing.T) {
+	in, ok := legacyGooseExport([]byte(exportFixture))
+	if !ok {
+		t.Fatal("exportFixture is not a goose export")
+	}
+	data, err := encodeSessionJSONL(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := parseGooseExport(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Compared as JSON values: raw tool arguments keep their source
+	// whitespace, which is not part of the data.
+	if inJSON, outJSON := jsonValue(t, in.Conversation), jsonValue(t, out.Conversation); !reflect.DeepEqual(inJSON, outJSON) {
+		t.Fatalf("round-trip lost data:\n in = %v\nout = %v", inJSON, outJSON)
+	}
+	if !reflect.DeepEqual(in.gooseSessionMeta, out.gooseSessionMeta) {
+		t.Fatalf("round-trip lost the session header:\n in = %+v\nout = %+v", in.gooseSessionMeta, out.gooseSessionMeta)
+	}
+}
+
+// A role Entire has no representation for stays unprojected, so the line is
+// dropped rather than emitted empty.
+func TestUnknownRolesAreNotProjected(t *testing.T) {
+	data, err := encodeSessionJSONL(&gooseExport{Conversation: []gooseMessage{
+		{ID: "m1", Role: "system", Content: []gooseContent{{Type: "text", Text: "boot"}}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := decodeLines(t, data)[0]
+	if _, ok := line["message"]; ok {
+		t.Fatalf("system message was projected: %s", data)
+	}
+	if kind := compactKind(line); kind != "system" {
+		t.Fatalf("compactKind = %q, want system (which Entire drops)", kind)
+	}
+}
+
+// jsonValue normalizes a Go value to its JSON shape, so comparisons ignore
+// source formatting inside embedded json.RawMessage fields.
+func jsonValue(t *testing.T, v any) any {
+	t.Helper()
+	encoded, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out any
+	if err := json.Unmarshal(encoded, &out); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}

--- a/agents/entire-agent-goose/internal/goose/large_record_test.go
+++ b/agents/entire-agent-goose/internal/goose/large_record_test.go
@@ -1,0 +1,22 @@
+package goose
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProjectedLargeMessageRoundTrip(t *testing.T) {
+	large := strings.Repeat("x", 6*1024*1024)
+	export := &gooseExport{Conversation: []gooseMessage{{Role: "user", Content: []gooseContent{{Type: "text", Text: large}}}}}
+	data, err := encodeSessionJSONL(export)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := decodeSessionJSONL(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.Conversation) != 1 || decoded.Conversation[0].Content[0].Text != large {
+		t.Fatal("large message lost")
+	}
+}

--- a/agents/entire-agent-goose/internal/goose/paths.go
+++ b/agents/entire-agent-goose/internal/goose/paths.go
@@ -3,6 +3,7 @@ package goose
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Goose stores sessions in a SQLite database (sessions.db) inside its data
@@ -36,6 +37,9 @@ func (a *Agent) GetSessionDir(_ string) (string, error) {
 }
 
 func (a *Agent) ResolveSessionFile(sessionDirPath, sessionID string) string {
+	if !validSessionID(sessionID) {
+		return ""
+	}
 	return filepath.Join(sessionDirPath, sessionID+".json")
 }
 
@@ -46,5 +50,12 @@ func transcriptPath(sessionID string) string {
 	if err != nil {
 		return ""
 	}
-	return filepath.Join(dir, sessionID+".json")
+	return a.ResolveSessionFile(dir, sessionID)
+}
+
+// Session IDs are opaque identifiers, never paths. Reject both platform
+// separators so hook payloads cannot redirect exports outside session storage.
+func validSessionID(id string) bool {
+	return strings.TrimSpace(id) != "" && id != "." && id != ".." &&
+		!strings.ContainsAny(id, "/\\\x00:")
 }

--- a/agents/entire-agent-goose/internal/goose/review_regression_test.go
+++ b/agents/entire-agent-goose/internal/goose/review_regression_test.go
@@ -1,0 +1,53 @@
+package goose
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExportRejectsSessionPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	victim := filepath.Join(dir, "victim.json")
+	if err := os.WriteFile(victim, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runner := &stubRunner{export: []byte(exportFixture)}
+	a := testAgent(t, runner)
+	if err := a.exportSession("../victim", filepath.Join(dir, "safe.json")); err == nil {
+		t.Error("expected invalid session ID error")
+	}
+	data, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "keep" {
+		t.Error("export overwrote a file outside its scratch directory")
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("export invoked for invalid ID: %v", runner.calls)
+	}
+}
+
+func TestEmptyExportRetainsSessionMetadata(t *testing.T) {
+	runner := &stubRunner{export: []byte(`{"id":"empty","name":"New session","model_config":{"model_name":"test-model"},"conversation":[]}`)}
+	a := testAgent(t, runner)
+	path := filepath.Join(t.TempDir(), "empty.json")
+	if err := a.exportSession("empty", path); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	export, err := parseGooseExport(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if export.ID != "empty" || export.Name != "New session" {
+		t.Errorf("lost metadata: %+v", export)
+	}
+	if modelFromSessionRef(path) != "test-model" {
+		t.Error("lost model")
+	}
+}

--- a/agents/entire-agent-goose/internal/goose/session_jsonl.go
+++ b/agents/entire-agent-goose/internal/goose/session_jsonl.go
@@ -1,0 +1,306 @@
+package goose
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const maxTranscriptLine = 10 * 1024 * 1024
+
+// The materialized transcript is stored as JSONL: exactly one conversation
+// message per line, in order, with no header line. Entire scopes
+// external-agent transcripts by LINE offset (transcript.SliceFromLine,
+// cmd/entire/cli/transcript/parse.go:130) before compacting them — see
+// cmd/entire/cli/explain.go:1883 and
+// cmd/entire/cli/strategy/manual_commit_condensation.go:1006 — so goose's
+// native single-JSON-document export was destroyed by that slicing: every
+// checkpoint compacted a fragment of a pretty-printed object and produced
+// nothing. One message per line keeps line index == message index, which is
+// also the unit get-transcript-position reports (len(Conversation)), so scoping
+// lands on message boundaries and header-less slices stay valid JSONL.
+//
+// Line SHAPE matters as much as line COUNT. An external agent's transcript is
+// compacted by the generic JSONL reader in
+// cmd/entire/cli/transcript/compact/compact.go, which keeps a line only when
+// BOTH of these hold:
+//
+//   - normalizeKind (compact.go:197) finds a TOP-LEVEL "type", falling back to
+//     "role", of "user" or "assistant". Goose messages already carry "role", so
+//     JSONL alone satisfies this half.
+//   - parseMessage (compact.go:617) finds the content under a TOP-LEVEL
+//     "message" object: "All JSONL agents nest content inside a 'message'
+//     object." Goose keeps content in a top-level "content" array, so a line
+//     that survived the first check would still compact to an empty content
+//     array — the right number of lines, carrying nothing.
+//
+// Each record therefore carries the native gooseMessage fields, authoritative
+// for goose's own decoding, plus an Entire-facing projection (type, timestamp,
+// message) built from them. The projection is derived data: parseGooseExport
+// ignores it, so a transcript written by an older build still reads, and the
+// next export rewrites it with the projection attached.
+//
+// The export's session-level fields (name, accumulated token totals,
+// model_config) are stamped onto EVERY record, the way amp stamps its thread
+// id. They cannot live in a header: SliceFromLine hands a mid-session
+// checkpoint a slice that starts past line 0, and a header there is gone. With
+// the fields on each record, ExtractSummary, CalculateTokens and
+// modelFromSessionRef keep working on any scoped slice.
+
+// gooseSessionMeta is the export's session-level header. It is embedded in
+// gooseExport, so a native `goose session export --format json` document still
+// unmarshals with these keys at the top level, and it is stamped onto every
+// stored JSONL record under "session".
+type gooseSessionMeta struct {
+	ID                     string            `json:"id,omitempty"`
+	WorkingDir             string            `json:"working_dir,omitempty"`
+	Name                   string            `json:"name,omitempty"`
+	CreatedAt              string            `json:"created_at,omitempty"`
+	AccumulatedInputTokens int               `json:"accumulated_input_tokens,omitempty"`
+	AccumulatedOutput      int               `json:"accumulated_output_tokens,omitempty"`
+	ProviderName           string            `json:"provider_name,omitempty"`
+	ModelConfig            *gooseModelConfig `json:"model_config,omitempty"`
+}
+
+type gooseModelConfig struct {
+	ModelName string `json:"model_name,omitempty"`
+}
+
+// transcriptRecord is one on-disk JSONL line: goose's native message with the
+// stamped session header and the Entire-facing projection alongside it.
+// gooseMessage is embedded, so its id/role/created/content keys stay at the top
+// level exactly as they appear inside the native export's conversation array.
+type transcriptRecord struct {
+	gooseMessage
+	Session   *gooseSessionMeta `json:"session,omitempty"`
+	Type      string            `json:"type,omitempty"`
+	Timestamp string            `json:"timestamp,omitempty"`
+	Message   *wireMessage      `json:"message,omitempty"`
+}
+
+// wireMessage is the "message" wrapper Entire's compactJSONL reads content from
+// (compact.go:617).
+type wireMessage struct {
+	Role    string `json:"role"`
+	ID      string `json:"id,omitempty"`
+	Content []any  `json:"content"`
+}
+
+// wireTextBlock is a text content block, read by both the user and the
+// assistant path in compactJSONL.
+type wireTextBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// wireToolUseBlock is an assistant tool call. stripAssistantContent
+// (compact.go:704) keeps exactly type, id, name and input — anything else on
+// the block, a pre-computed result included, is discarded.
+type wireToolUseBlock struct {
+	Type  string `json:"type"`
+	ID    string `json:"id,omitempty"`
+	Name  string `json:"name"`
+	Input any    `json:"input"`
+}
+
+// wireToolResultBlock is a user tool result. extractUserContent (compact.go:665)
+// reads snake_case tool_use_id, a string "content" and is_error; Entire then
+// inlines the output into the preceding assistant's matching tool_use block,
+// exactly as it does for Claude Code. Goose already records the request and the
+// response as two separate conversation messages, so the pairing is natural and
+// keeps one message per line.
+type wireToolResultBlock struct {
+	Type      string `json:"type"`
+	ToolUseID string `json:"tool_use_id,omitempty"`
+	Content   string `json:"content"`
+	IsError   bool   `json:"is_error,omitempty"`
+}
+
+// newTranscriptRecord projects one conversation message into a stored record.
+func newTranscriptRecord(meta gooseSessionMeta, msg gooseMessage) transcriptRecord {
+	stamped := meta
+	record := transcriptRecord{
+		gooseMessage: msg,
+		Session:      &stamped,
+		Type:         msg.Role,
+		Timestamp:    recordTimestamp(msg.Created),
+	}
+	// Only "user" and "assistant" mean anything to normalizeKind; any other
+	// role stays unprojected, which drops the line — the same outcome
+	// compactTranscriptBytes gives it.
+	if msg.Role != "user" && msg.Role != "assistant" {
+		return record
+	}
+	record.Message = &wireMessage{
+		Role:    msg.Role,
+		ID:      msg.ID,
+		Content: wireContent(msg.Content),
+	}
+	return record
+}
+
+// wireContent converts goose content blocks into the blocks compactJSONL
+// understands. Goose records no per-message token usage (see CalculateTokens),
+// so no usage object is projected.
+func wireContent(blocks []gooseContent) []any {
+	out := make([]any, 0, len(blocks))
+	for _, block := range blocks {
+		switch block.Type {
+		case "text":
+			if block.Text != "" {
+				out = append(out, wireTextBlock{Type: "text", Text: block.Text})
+			}
+		case "toolRequest":
+			if block.ToolCall == nil {
+				continue
+			}
+			out = append(out, wireToolUseBlock{
+				Type:  "tool_use",
+				ID:    block.ID,
+				Name:  block.ToolCall.Value.Name,
+				Input: decodeToolInput(block.ToolCall.Value.Arguments),
+			})
+		case "toolResponse":
+			if block.ToolResult == nil {
+				continue
+			}
+			out = append(out, wireToolResultBlock{
+				Type:      "tool_result",
+				ToolUseID: block.ID,
+				Content:   toolResponseText(block),
+				IsError:   block.ToolResult.Status != "success" || block.ToolResult.Value.IsError,
+			})
+		}
+	}
+	return out
+}
+
+// toolResponseText flattens a goose toolResult's text parts, matching how
+// collectToolResults builds the adapter's own compact output.
+func toolResponseText(block gooseContent) string {
+	var parts []string
+	for _, content := range block.ToolResult.Value.Content {
+		if content.Type == "text" && content.Text != "" {
+			parts = append(parts, content.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func recordTimestamp(created int64) string {
+	if created <= 0 {
+		return ""
+	}
+	return time.Unix(created, 0).UTC().Format(time.RFC3339)
+}
+
+// encodeSessionJSONL serializes an export as one conversation message per line.
+func encodeSessionJSONL(export *gooseExport) ([]byte, error) {
+	if export == nil {
+		return nil, errors.New("nil goose export")
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf) // Encode writes into buf and appends '\n'.
+	for _, msg := range export.Conversation {
+		record := newTranscriptRecord(export.gooseSessionMeta, msg)
+		if err := enc.Encode(&record); err != nil {
+			return nil, fmt.Errorf("encode goose message: %w", err)
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// decodeSessionJSONL rebuilds an export from stored JSONL. The session header
+// comes from the records themselves (see the stamping note above); the last
+// record carrying one wins, so the most recent export's totals are used. Only
+// the native gooseMessage fields are read — the Entire-facing projection is
+// derived data and is ignored, so a transcript written before the projection
+// existed still decodes and the next export self-heals it.
+func decodeSessionJSONL(data []byte) (*gooseExport, error) {
+	export := &gooseExport{Conversation: []gooseMessage{}}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 64*1024), maxTranscriptLine)
+	line := 0
+	for scanner.Scan() {
+		line++
+		raw := bytes.TrimSpace(scanner.Bytes())
+		if len(raw) == 0 {
+			continue
+		}
+		var record transcriptRecord
+		if err := json.Unmarshal(raw, &record); err != nil {
+			return nil, fmt.Errorf("parse goose transcript line %d: %w", line, err)
+		}
+		if record.Session != nil {
+			export.gooseSessionMeta = *record.Session
+		}
+		if record.Role == "" && record.ID == "" && len(record.Content) == 0 {
+			continue
+		}
+		export.Conversation = append(export.Conversation, record.gooseMessage)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan goose transcript: %w", err)
+	}
+	return export, nil
+}
+
+// legacyGooseExport reports whether data is a native, whole-document
+// `goose session export --format json` result rather than stored JSONL. The
+// "conversation" key is the discriminator: a stored record never has one, and a
+// JSONL payload of two or more lines does not unmarshal as a single object.
+func legacyGooseExport(data []byte) (*gooseExport, bool) {
+	var probe struct {
+		Conversation *json.RawMessage `json:"conversation"`
+	}
+	if json.Unmarshal(data, &probe) != nil || probe.Conversation == nil {
+		return nil, false
+	}
+	var export gooseExport
+	if json.Unmarshal(data, &export) != nil {
+		return nil, false
+	}
+	return &export, true
+}
+
+// materializeExport converts a native export document into the stored JSONL
+// layout.
+func materializeExport(raw []byte) ([]byte, bool) {
+	export, ok := legacyGooseExport(bytes.TrimSpace(raw))
+	if !ok {
+		return nil, false
+	}
+	data, err := encodeSessionJSONL(export)
+	if err != nil {
+		return nil, false
+	}
+	return data, true
+}
+
+// atomicWriteFile writes data via a temp file + rename so a crash mid-write
+// cannot leave a partially-written transcript behind.
+func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".goose-write-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if err := tmp.Chmod(mode); err != nil {
+		return errors.Join(err, tmp.Close())
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return errors.Join(err, tmp.Close())
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/agents/entire-agent-goose/internal/goose/session_jsonl.go
+++ b/agents/entire-agent-goose/internal/goose/session_jsonl.go
@@ -1,7 +1,6 @@
 package goose
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -12,7 +11,7 @@ import (
 	"time"
 )
 
-const maxTranscriptLine = 10 * 1024 * 1024
+const contentTypeText = "text"
 
 // The materialized transcript is stored as JSONL: exactly one conversation
 // message per line, in order, with no header line. Entire scopes
@@ -152,7 +151,7 @@ func wireContent(blocks []gooseContent) []any {
 	out := make([]any, 0, len(blocks))
 	for _, block := range blocks {
 		switch block.Type {
-		case "text":
+		case contentTypeText:
 			if block.Text != "" {
 				out = append(out, wireTextBlock{Type: "text", Text: block.Text})
 			}
@@ -186,7 +185,7 @@ func wireContent(blocks []gooseContent) []any {
 func toolResponseText(block gooseContent) string {
 	var parts []string
 	for _, content := range block.ToolResult.Value.Content {
-		if content.Type == "text" && content.Text != "" {
+		if content.Type == contentTypeText && content.Text != "" {
 			parts = append(parts, content.Text)
 		}
 	}
@@ -222,14 +221,14 @@ func encodeSessionJSONL(export *gooseExport) ([]byte, error) {
 // the native gooseMessage fields are read — the Entire-facing projection is
 // derived data and is ignored, so a transcript written before the projection
 // existed still decodes and the next export self-heals it.
+// Iterate the bytes already in memory: the native payload plus its projection
+// can exceed Scanner's line limit even when the source message fits it.
 func decodeSessionJSONL(data []byte) (*gooseExport, error) {
 	export := &gooseExport{Conversation: []gooseMessage{}}
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-	scanner.Buffer(make([]byte, 64*1024), maxTranscriptLine)
 	line := 0
-	for scanner.Scan() {
+	for rawLine := range bytes.SplitSeq(data, []byte{'\n'}) {
 		line++
-		raw := bytes.TrimSpace(scanner.Bytes())
+		raw := bytes.TrimSpace(rawLine)
 		if len(raw) == 0 {
 			continue
 		}
@@ -244,9 +243,6 @@ func decodeSessionJSONL(data []byte) (*gooseExport, error) {
 			continue
 		}
 		export.Conversation = append(export.Conversation, record.gooseMessage)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan goose transcript: %w", err)
 	}
 	return export, nil
 }
@@ -273,7 +269,9 @@ func legacyGooseExport(data []byte) (*gooseExport, bool) {
 // layout.
 func materializeExport(raw []byte) ([]byte, bool) {
 	export, ok := legacyGooseExport(bytes.TrimSpace(raw))
-	if !ok {
+	if !ok || len(export.Conversation) == 0 {
+		// No message can carry the metadata yet. Keep the native empty
+		// export until the first message arrives, preserving ID/model/name.
 		return nil, false
 	}
 	data, err := encodeSessionJSONL(export)

--- a/agents/entire-agent-goose/internal/goose/session_jsonl.go
+++ b/agents/entire-agent-goose/internal/goose/session_jsonl.go
@@ -11,7 +11,13 @@ import (
 	"time"
 )
 
-const contentTypeText = "text"
+const (
+	contentTypeText         = "text"
+	contentTypeToolRequest  = "toolRequest"
+	contentTypeToolResponse = "toolResponse"
+	roleUser                = "user"
+	roleAssistant           = "assistant"
+)
 
 // The materialized transcript is stored as JSONL: exactly one conversation
 // message per line, in order, with no header line. Entire scopes
@@ -133,7 +139,7 @@ func newTranscriptRecord(meta gooseSessionMeta, msg gooseMessage) transcriptReco
 	// Only "user" and "assistant" mean anything to normalizeKind; any other
 	// role stays unprojected, which drops the line — the same outcome
 	// compactTranscriptBytes gives it.
-	if msg.Role != "user" && msg.Role != "assistant" {
+	if msg.Role != roleUser && msg.Role != roleAssistant {
 		return record
 	}
 	record.Message = &wireMessage{
@@ -153,9 +159,9 @@ func wireContent(blocks []gooseContent) []any {
 		switch block.Type {
 		case contentTypeText:
 			if block.Text != "" {
-				out = append(out, wireTextBlock{Type: "text", Text: block.Text})
+				out = append(out, wireTextBlock{Type: contentTypeText, Text: block.Text})
 			}
-		case "toolRequest":
+		case contentTypeToolRequest:
 			if block.ToolCall == nil {
 				continue
 			}
@@ -165,7 +171,7 @@ func wireContent(blocks []gooseContent) []any {
 				Name:  block.ToolCall.Value.Name,
 				Input: decodeToolInput(block.ToolCall.Value.Arguments),
 			})
-		case "toolResponse":
+		case contentTypeToolResponse:
 			if block.ToolResult == nil {
 				continue
 			}

--- a/agents/entire-agent-goose/internal/goose/transcript.go
+++ b/agents/entire-agent-goose/internal/goose/transcript.go
@@ -1,6 +1,7 @@
 package goose
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,19 +16,12 @@ import (
 
 // gooseExport models the output of `goose session export --format json`
 // (verified against goose 1.37.0). Message content is camelCase, unlike the
-// snake_case hook payloads.
+// snake_case hook payloads. The session-level fields live in gooseSessionMeta,
+// embedded so they stay at the top level of the native document and can also be
+// stamped onto every stored JSONL record (see session_jsonl.go).
 type gooseExport struct {
-	ID                     string         `json:"id"`
-	WorkingDir             string         `json:"working_dir"`
-	Name                   string         `json:"name"`
-	CreatedAt              string         `json:"created_at"`
-	AccumulatedInputTokens int            `json:"accumulated_input_tokens"`
-	AccumulatedOutput      int            `json:"accumulated_output_tokens"`
-	Conversation           []gooseMessage `json:"conversation"`
-	ProviderName           string         `json:"provider_name"`
-	ModelConfig            struct {
-		ModelName string `json:"model_name"`
-	} `json:"model_config"`
+	gooseSessionMeta
+	Conversation []gooseMessage `json:"conversation"`
 }
 
 type gooseMessage struct {
@@ -60,14 +54,26 @@ type gooseContent struct {
 	} `json:"toolResult,omitempty"`
 }
 
-// parseGooseExport is tolerant: any valid JSON object parses, and callers
-// check ID to decide whether it is a real goose export.
+// parseGooseExport reads a materialized transcript. Transcripts are stored as
+// JSONL (one conversation message per line, see session_jsonl.go), but a native
+// whole-document export written by an older build is still accepted so those
+// files keep reading; the next export rewrites them as JSONL.
+//
+// It stays tolerant: any valid JSON parses, and callers check ID to decide
+// whether it is a real goose session.
 func parseGooseExport(data []byte) (*gooseExport, error) {
-	var export gooseExport
-	if err := json.Unmarshal(data, &export); err != nil {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil, errors.New("parse goose export: empty transcript")
+	}
+	if export, ok := legacyGooseExport(trimmed); ok {
+		return export, nil
+	}
+	export, err := decodeSessionJSONL(trimmed)
+	if err != nil {
 		return nil, fmt.Errorf("parse goose export: %w", err)
 	}
-	return &export, nil
+	return export, nil
 }
 
 // tryParseGooseExport returns nil when data is not a goose export. For the
@@ -342,7 +348,7 @@ func modelFromSessionRef(sessionRef string) string {
 		return ""
 	}
 	export, err := parseGooseExport(data)
-	if err != nil {
+	if err != nil || export.ModelConfig == nil {
 		return ""
 	}
 	return export.ModelConfig.ModelName

--- a/agents/entire-agent-goose/internal/goose/transcript.go
+++ b/agents/entire-agent-goose/internal/goose/transcript.go
@@ -242,11 +242,11 @@ func (a *Agent) ExtractPrompts(sessionRef string, offset int) ([]string, error) 
 	}
 	prompts := []string{}
 	for _, msg := range messagesFromOffset(export, offset) {
-		if msg.Role != "user" {
+		if msg.Role != roleUser {
 			continue
 		}
 		for _, content := range msg.Content {
-			if content.Type == "text" && content.Text != "" {
+			if content.Type == contentTypeText && content.Text != "" {
 				prompts = append(prompts, content.Text)
 			}
 		}
@@ -281,7 +281,7 @@ func (a *Agent) CalculateTokens(data []byte, _ int) (protocol.TokenUsageResponse
 		OutputTokens: export.AccumulatedOutput,
 	}
 	for _, msg := range export.Conversation {
-		if msg.Role == "assistant" {
+		if msg.Role == roleAssistant {
 			usage.APICallCount++
 		}
 	}
@@ -311,7 +311,7 @@ func modifiedFilesFromExport(export *gooseExport, offset int) []string {
 	seen := map[string]bool{}
 	for _, msg := range messagesFromOffset(export, offset) {
 		for _, content := range msg.Content {
-			if content.Type != "toolRequest" || content.ToolCall == nil {
+			if content.Type != contentTypeToolRequest || content.ToolCall == nil {
 				continue
 			}
 			name := content.ToolCall.Value.Name


### PR DESCRIPTION
## The defect

Goose's transcript was written to `session_ref` as `goose session export --format json` produces it: one pretty-printed JSON document. Entire slices an external agent's transcript by **line** offset (`transcript.SliceFromLine`, `cmd/entire/cli/transcript/parse.go:130`, reached from `cmd/entire/cli/explain.go:1883` and `cmd/entire/cli/strategy/manual_commit_condensation.go:1006`) before compacting it, so every checkpoint compacted a fragment of that document.

Measured against cli@main, goose's `transcript.jsonl` was **0 bytes**.

Shipping a `compact-transcript` method does not avoid this: `checkpoint/persistent.go:1136` always runs Entire's generic compactor over the raw transcript.

## The contract

`cmd/entire/cli/transcript/compact/compact.go` keeps a JSONL line only when **both** hold:

| half | cli | goose before |
|---|---|---|
| kind | `normalizeKind` (compact.go:197) reads a **top-level** `type`, falling back to `role` | satisfied for free — goose messages carry `role` |
| content | `parseMessage` (compact.go:617) reads content from a **top-level `message` object** | missing — content lives in a top-level `content` array |

Satisfying only the first half is the trap: it yields a `transcript.jsonl` with the right number of lines and every content array empty.

## The change

`prepare-transcript` exports into a scratch directory and materializes the result at `session_ref` as **JSONL, one conversation message per line**, written atomically. Line index == message index == the unit `get-transcript-position` already reported (`len(conversation)`), so scoping lands on message boundaries.

Each record keeps goose's native message fields — still authoritative for the adapter's own decoding — and adds an Entire-facing projection built from them:

- text blocks stay text blocks
- `toolRequest` -> `tool_use` with `type`/`id`/`name`/`input`, the only shape `stripAssistantContent` (compact.go:704) preserves
- `toolResponse` -> a user `tool_result` with snake_case `tool_use_id` and a string `content` (compact.go:665), so Entire inlines the output into the preceding assistant's matching `tool_use`, exactly as it does for Claude Code

Goose already records a request and its response as two conversation messages, so that pairing costs no extra line and the 1 message = 1 line invariant holds.

### Where the session header went

`extract-summary` reads the session `name`, `calculate-tokens` reads `accumulated_*_tokens`, and the model lookup reads `model_config`. None of those live on a message, and a header line cannot carry them: a mid-session slice starts past line 0, so the header is gone.

They are **stamped onto every record** under `session` instead — the same reason amp stamps its thread id on every message. All three analyzers therefore keep working on a scoped slice, and there is a test that runs them against a slice taken from line 2.

## Back-compat

- A native whole-document export still parses, so session files written by an older build keep reading; the next export rewrites them as JSONL.
- A JSONL record written before the projection existed still decodes, and re-encoding self-heals it.
- An export this build cannot parse is stored verbatim rather than discarded, so an unrecognised goose version degrades to the old behaviour instead of breaking checkpointing.

## Measured

The committed `exportFixture` run through cli@main's `transcript.SliceFromLine` + `compact.FullWithBoundary`:

```
before  start=0  transcript.jsonl=0B    nothing survives the slicing
before  start=2  transcript.jsonl=0B
after   start=0  transcript.jsonl=612B  3 lines, all carrying content
after   start=2  transcript.jsonl=612B  boundary=2, delta=168B
```

The compacted lines now read:

```json
{"type":"user","ts":"2026-06-11T11:02:49Z","content":[{"text":"Create a file named verify.txt"}]}
{"type":"assistant","id":"msg_2","content":[{"id":"toolu_1","input":{"path":"/tmp/workspace/verify.txt","content":"ENTIRE_VERIFY_FILE"},"name":"write","result":{"output":"","status":"success"},"type":"tool_use"}]}
{"type":"assistant","id":"msg_4","content":[{"text":"ENTIRE_VERIFY_OK","type":"text"}]}
```

## Why the tests are shaped this way

Reverting the `message` wrapper reproduces the second failure mode exactly: **472 bytes across 4 lines, every content array empty**. A non-zero byte count would call that fixed. The tests therefore assert the message **text**, and they build their input from the committed fixture through the real encoder rather than comparing against a checked-in expected constant — so a mutation to the encoder cannot pass them.

Mutations tried, all caught, all compiling:

| mutation | caught by |
|---|---|
| drop the `message` wrapper | 3 contract tests |
| `tool_use_id` -> `toolUseId` | tool-shape test |
| `tool_use` `input` -> `arguments` | tool-shape test |
| stop stamping the session header | scoped-analyzer + round-trip tests |
| store one JSON document instead of JSONL | 4 tests, incl. the hook test |

`go test ./...` in `agents/entire-agent-goose`: 33 pass (was 20).

## Not in scope

`kiro` still measures 0 bytes; its paired `{"user":…,"assistant":…}` entries need two lines each plus a `get-transcript-position` change, which is a separate design decision.
