### PR TITLE
fix(qwen): give sidecar lines the shape Entire's compact reader needs

### DIFF
--- a/agents/entire-agent-qwen/AGENT.md
+++ b/agents/entire-agent-qwen/AGENT.md
@@ -38,6 +38,35 @@ Qwen Code exposes command hooks in `.qwen/settings.json` and stores project-scop
 | `extract-summary` | `Stop`/failure | Reads final assistant/error message |
 | `compact-transcript` | Sidecar JSONL | Emits base64 Entire Transcript Format JSONL |
 
+## Sidecar Record Shape
+
+Every sidecar record carries Qwen's own hook fields plus an Entire-facing
+projection, because Entire compacts an external agent's transcript with the
+generic JSONL reader in `cmd/entire/cli/transcript/compact/compact.go`, which
+keeps a line only when **both** of these hold. An adapter's own
+`compact-transcript` method does not change this: `checkpoint/persistent.go`
+always runs the generic compactor over the raw transcript.
+
+| half | what cli reads | native record |
+|---|---|---|
+| kind | `normalizeKind` (compact.go:197) reads a top-level `type`, falling back to `role` | had neither — the discriminator is `event`, so every line was dropped |
+| content | `parseMessage` (compact.go:617) reads content from a top-level `message` **object** | `message` was a **string** (Qwen's notification text), so nothing was found |
+
+The projection is derived data — `readSidecarRecords` ignores `type` and
+`message` — so a sidecar written before it existed still reads.
+
+| event | projected as | content |
+|---|---|---|
+| `UserPromptSubmit` | `user` | text block with the prompt |
+| `PreToolUse` | `assistant` | `tool_use` (`type`/`id`/`name`/`input`, the only fields `stripAssistantContent` keeps) |
+| `PostToolUse` / `PostToolUseFailure` | `user` | `tool_result` with snake_case `tool_use_id`, so cli inlines the output into the preceding `tool_use` |
+| `Stop` / `StopFailure` | `assistant` | text block with the final message or error details |
+| everything else | not projected | dropped from the compact transcript |
+
+`message` is stored as raw JSON so a record round-trips whichever shape it
+carries. Typed as a string, a projected line would fail to unmarshal and take
+the whole sidecar read with it.
+
 ## Lifecycle Mapping
 
 | Qwen Hook | Entire Hook Verb | Entire Event |
@@ -49,9 +78,9 @@ Qwen Code exposes command hooks in `.qwen/settings.json` and stores project-scop
 | `SessionEnd` | `session-end` | `SessionEnd` |
 | `PreCompact` | `pre-compact` | `Compaction` |
 | `PostCompact` | `post-compact` | `Compaction` |
-| `PreToolUse` | `pre-tool-use` | sidecar metadata only |
-| `PostToolUse` | `post-tool-use` | sidecar metadata only |
-| `PostToolUseFailure` | `post-tool-use-failure` | sidecar metadata only |
+| `PreToolUse` | `pre-tool-use` | sidecar only; projected as an assistant `tool_use` |
+| `PostToolUse` | `post-tool-use` | sidecar only; projected as a user `tool_result` |
+| `PostToolUseFailure` | `post-tool-use-failure` | sidecar only; projected as a failed user `tool_result` |
 | `Notification` | `notification` | sidecar metadata only |
 | `PermissionRequest` | `permission-request` | sidecar metadata only |
 | `SubagentStart` | `subagent-start` | sidecar metadata only |

--- a/agents/entire-agent-qwen/internal/qwen/jsonl_test.go
+++ b/agents/entire-agent-qwen/internal/qwen/jsonl_test.go
@@ -1,0 +1,351 @@
+package qwen
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// sliceFromLine mirrors Entire's transcript.SliceFromLine
+// (cmd/entire/cli/transcript/parse.go:130): return the bytes starting after the
+// Nth newline, or nil when there aren't that many lines. This is what
+// cmd/entire/cli/explain.go:1883 (scopeTranscriptForCheckpoint) and
+// cmd/entire/cli/strategy/manual_commit_condensation.go:1006 apply to every
+// agent that is not one of Entire's built-ins — Qwen included.
+func sliceFromLine(content []byte, startLine int) []byte {
+	if len(content) == 0 || startLine <= 0 {
+		return content
+	}
+	count, offset := 0, 0
+	for i, b := range content {
+		if b == '\n' {
+			count++
+			if count == startLine {
+				offset = i + 1
+				break
+			}
+		}
+	}
+	if count < startLine || offset >= len(content) {
+		return nil
+	}
+	return content[offset:]
+}
+
+// compactKind mirrors normalizeKind in Entire's
+// cmd/entire/cli/transcript/compact/compact.go:197: the entry kind comes from
+// the TOP-LEVEL "type", falling back to "role". A native sidecar record has
+// neither — its discriminator is "event" — so every line was dropped.
+func compactKind(line map[string]json.RawMessage) string {
+	var kind string
+	if json.Unmarshal(line["type"], &kind) == nil && kind != "" {
+		return kind
+	}
+	if json.Unmarshal(line["role"], &kind) == nil {
+		return kind
+	}
+	return ""
+}
+
+// compactMessageContent mirrors parseMessage (compact.go:617): content is read
+// from a TOP-LEVEL "message" OBJECT. The sidecar's "message" was a STRING, so
+// this half failed too.
+func compactMessageContent(line map[string]json.RawMessage) []map[string]json.RawMessage {
+	var msg map[string]json.RawMessage
+	if json.Unmarshal(line["message"], &msg) != nil {
+		return nil
+	}
+	var blocks []map[string]json.RawMessage
+	if json.Unmarshal(msg["content"], &blocks) != nil {
+		return nil
+	}
+	return blocks
+}
+
+func decodeLines(t *testing.T, data []byte) []map[string]json.RawMessage {
+	t.Helper()
+	var out []map[string]json.RawMessage
+	for line := range bytes.SplitSeq(bytes.TrimRight(data, "\n"), []byte{'\n'}) {
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(line, &m); err != nil {
+			t.Fatalf("line is not valid JSON: %v (%s)", err, line)
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func blockString(t *testing.T, block map[string]json.RawMessage, key string) string {
+	t.Helper()
+	var s string
+	if err := json.Unmarshal(block[key], &s); err != nil {
+		t.Fatalf("block[%q] = %s: %v", key, block[key], err)
+	}
+	return s
+}
+
+// hookSequence drives real hook payloads through ParseHook and returns the
+// sidecar the agent wrote, so every assertion below exercises the live writer
+// rather than a checked-in expected constant.
+func hookSequence(t *testing.T, sessionID string, hooks ...[2]string) (*Agent, []byte) {
+	t.Helper()
+	t.Setenv("ENTIRE_REPO_ROOT", t.TempDir())
+	agent := New()
+	for _, hook := range hooks {
+		if _, err := agent.ParseHook(hook[0], []byte(hook[1])); err != nil {
+			t.Fatalf("ParseHook(%s): %v", hook[0], err)
+		}
+	}
+	data, err := os.ReadFile(agent.sidecarPath(sessionID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return agent, data
+}
+
+// A full turn: prompt, tool call, tool result, answer. Qwen fires PreToolUse
+// before a call and PostToolUse after it, so the pair maps onto Entire's
+// assistant tool_use / user tool_result and each hook still costs one line.
+func fullTurn(t *testing.T) (*Agent, []byte) {
+	t.Helper()
+	return hookSequence(t, "qwen-shape",
+		[2]string{HookNameUserPromptSubmit, `{"session_id":"qwen-shape","timestamp":"2026-05-20T12:00:00Z","prompt":"Create hello.txt"}`},
+		[2]string{HookNamePreToolUse, `{"session_id":"qwen-shape","timestamp":"2026-05-20T12:00:01Z","tool_name":"write_file","tool_use_id":"tool-1","tool_input":{"file_path":"hello.txt"}}`},
+		[2]string{HookNamePostToolUse, `{"session_id":"qwen-shape","timestamp":"2026-05-20T12:00:02Z","tool_name":"write_file","tool_use_id":"tool-1","tool_input":{"file_path":"hello.txt"},"tool_response":{"ok":true}}`},
+		[2]string{HookNameStop, `{"session_id":"qwen-shape","timestamp":"2026-05-20T12:00:03Z","last_assistant_message":"Created hello.txt"}`},
+	)
+}
+
+// The regression this change exists for. Both halves are asserted because
+// satisfying only the first yields a correctly-sized transcript.jsonl full of
+// empty content — the failure mode a byte count alone would call fixed.
+func TestSidecarLinesSatisfyEntireCompactContract(t *testing.T) {
+	_, data := fullTurn(t)
+	lines := decodeLines(t, data)
+	if len(lines) != 4 {
+		t.Fatalf("got %d lines, want 4", len(lines))
+	}
+
+	wantKind := []string{"user", "assistant", "user", "assistant"}
+	for i, line := range lines {
+		if got := compactKind(line); got != wantKind[i] {
+			t.Fatalf("line %d: compactKind = %q, want %q — Entire drops this line", i, got, wantKind[i])
+		}
+		if len(compactMessageContent(line)) == 0 {
+			t.Fatalf("line %d: no content under the %q wrapper — Entire emits an empty line", i, "message")
+		}
+	}
+	if got := blockString(t, compactMessageContent(lines[0])[0], "text"); got != "Create hello.txt" {
+		t.Fatalf("prompt text = %q", got)
+	}
+	if got := blockString(t, compactMessageContent(lines[3])[0], "text"); got != "Created hello.txt" {
+		t.Fatalf("answer text = %q", got)
+	}
+}
+
+// A mid-session slice must keep satisfying the contract: Entire compacts the
+// scoped bytes, not the whole file.
+func TestScopedSliceSatisfiesEntireCompactContract(t *testing.T) {
+	_, data := fullTurn(t)
+	lines := decodeLines(t, sliceFromLine(data, 2))
+	if len(lines) != 2 {
+		t.Fatalf("scoped slice has %d lines, want 2", len(lines))
+	}
+	for i, line := range lines {
+		if compactKind(line) == "" {
+			t.Fatalf("scoped line %d has no top-level type/role", i)
+		}
+		if len(compactMessageContent(line)) == 0 {
+			t.Fatalf("scoped line %d carries no message content", i)
+		}
+	}
+	if got := blockString(t, compactMessageContent(lines[1])[0], "text"); got != "Created hello.txt" {
+		t.Fatalf("scoped answer text = %q", got)
+	}
+}
+
+// tool_use keeps type/id/name/input (compact.go:704), and a user tool_result
+// uses snake_case tool_use_id with a string "content" (compact.go:665) so
+// Entire inlines the output into the preceding assistant's matching tool_use
+// (inlineToolResults, compact.go:454).
+func TestToolBlocksProjectToEntireShapes(t *testing.T) {
+	_, data := fullTurn(t)
+	lines := decodeLines(t, data)
+
+	toolUse := compactMessageContent(lines[1])[0]
+	for key, want := range map[string]string{"type": "tool_use", "id": "tool-1", "name": "write_file"} {
+		if got := blockString(t, toolUse, key); got != want {
+			t.Fatalf("tool_use %q = %q, want %q", key, got, want)
+		}
+	}
+	var input map[string]any
+	if err := json.Unmarshal(toolUse["input"], &input); err != nil {
+		t.Fatalf("tool_use input = %s: %v", toolUse["input"], err)
+	}
+	if input["file_path"] != "hello.txt" {
+		t.Fatalf("tool_use input = %+v", input)
+	}
+
+	toolResult := compactMessageContent(lines[2])[0]
+	for key, want := range map[string]string{"type": "tool_result", "tool_use_id": "tool-1", "content": `{"ok":true}`} {
+		if got := blockString(t, toolResult, key); got != want {
+			t.Fatalf("tool_result %q = %q, want %q", key, got, want)
+		}
+	}
+}
+
+// A failed call must be flagged so Entire records the result as an error rather
+// than a success.
+func TestPostToolUseFailureIsFlaggedAsError(t *testing.T) {
+	_, data := hookSequence(t, "qwen-fail",
+		[2]string{HookNamePreToolUse, `{"session_id":"qwen-fail","timestamp":"2026-05-20T12:00:01Z","tool_name":"write_file","tool_use_id":"tool-1","tool_input":{"file_path":"hello.txt"}}`},
+		[2]string{HookNamePostToolUseFailure, `{"session_id":"qwen-fail","timestamp":"2026-05-20T12:00:02Z","tool_name":"write_file","tool_use_id":"tool-1","error":"EACCES","error_details":"permission denied"}`},
+	)
+	block := compactMessageContent(decodeLines(t, data)[1])[0]
+	if got := blockString(t, block, "content"); got != "EACCES permission denied" {
+		t.Fatalf("tool_result content = %q", got)
+	}
+	var isError bool
+	if err := json.Unmarshal(block["is_error"], &isError); err != nil || !isError {
+		t.Fatalf("tool_result is_error = %s (%v)", block["is_error"], err)
+	}
+}
+
+// A tool_response that is already a JSON string must reach Entire as that
+// string, not as its quoted JSON text.
+func TestStringToolResponseIsNotDoubleEncoded(t *testing.T) {
+	_, data := hookSequence(t, "qwen-str",
+		[2]string{HookNamePostToolUse, `{"session_id":"qwen-str","timestamp":"2026-05-20T12:00:02Z","tool_name":"read_file","tool_use_id":"tool-1","tool_response":"file contents"}`},
+	)
+	block := compactMessageContent(decodeLines(t, data)[0])[0]
+	if got := blockString(t, block, "content"); got != "file contents" {
+		t.Fatalf("tool_result content = %q", got)
+	}
+}
+
+// get-transcript-position is what Entire records as the next checkpoint's start
+// line, so it must equal the sidecar's line count.
+func TestGetTranscriptPositionMatchesLineCount(t *testing.T) {
+	agent, data := fullTurn(t)
+	pos, err := agent.GetTranscriptPosition(agent.sidecarPath("qwen-shape"))
+	if err != nil {
+		t.Fatalf("GetTranscriptPosition: %v", err)
+	}
+	if lines := bytes.Count(data, []byte{'\n'}); pos != lines {
+		t.Fatalf("position %d != newline count %d (Entire slices by line)", pos, lines)
+	}
+}
+
+// The projection travels on the same record the adapter reads back. "message"
+// carries an object now, so a record typed with a string "message" would fail
+// to unmarshal and take the whole sidecar read with it.
+func TestProjectedRecordsStillReadBack(t *testing.T) {
+	agent, _ := fullTurn(t)
+	ref := agent.sidecarPath("qwen-shape")
+
+	records, err := readSidecarRecords(ref)
+	if err != nil {
+		t.Fatalf("readSidecarRecords: %v", err)
+	}
+	if len(records) != 4 {
+		t.Fatalf("read %d records, want 4", len(records))
+	}
+	prompts, err := agent.ExtractPrompts(ref, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prompts) != 1 || prompts[0] != "Create hello.txt" {
+		t.Fatalf("prompts = %#v", prompts)
+	}
+	files, _, err := agent.ExtractModifiedFiles(ref, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 || files[0] != "hello.txt" {
+		t.Fatalf("modified files = %#v", files)
+	}
+	summary, ok, err := agent.ExtractSummary(ref)
+	if err != nil || !ok || summary != "Created hello.txt" {
+		t.Fatalf("summary = (%q, %v, %v)", summary, ok, err)
+	}
+}
+
+// A sidecar written before the projection existed carries neither key. It must
+// still read, and later hooks append projected records alongside it.
+func TestLegacySidecarWithoutProjectionStillReads(t *testing.T) {
+	t.Setenv("ENTIRE_REPO_ROOT", t.TempDir())
+	agent := New()
+	ref := agent.sidecarPath("qwen-legacy")
+	if err := os.MkdirAll(filepath.Dir(ref), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	legacy := `{"v":1,"agent":"qwen","event":"UserPromptSubmit","session_id":"qwen-legacy","ts":"2026-05-20T12:00:00Z","prompt":"old prompt"}` + "\n"
+	if err := os.WriteFile(ref, []byte(legacy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agent.ParseHook(HookNameStop, []byte(`{"session_id":"qwen-legacy","timestamp":"2026-05-20T12:00:01Z","last_assistant_message":"new answer"}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	prompts, err := agent.ExtractPrompts(ref, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prompts) != 1 || prompts[0] != "old prompt" {
+		t.Fatalf("prompts = %#v", prompts)
+	}
+	data, err := os.ReadFile(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := decodeLines(t, data)
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2", len(lines))
+	}
+	if compactKind(lines[0]) != "" {
+		t.Fatal("the legacy line must stay as written")
+	}
+	if compactKind(lines[1]) != "assistant" || len(compactMessageContent(lines[1])) == 0 {
+		t.Fatalf("the appended line was not projected: %s", data)
+	}
+}
+
+// Qwen's own notification text also lives under "message". It is only sent on
+// events Entire has no representation for, so those records stay unprojected
+// and the string is left exactly as it was written.
+func TestNotificationMessageStaysAString(t *testing.T) {
+	_, data := hookSequence(t, "qwen-note",
+		[2]string{HookNameNotification, `{"session_id":"qwen-note","timestamp":"2026-05-20T12:00:00Z","notification_type":"info","message":"waiting for input"}`},
+	)
+	line := decodeLines(t, data)[0]
+	var text string
+	if err := json.Unmarshal(line["message"], &text); err != nil {
+		t.Fatalf("message is no longer a string: %s (%v)", line["message"], err)
+	}
+	if text != "waiting for input" {
+		t.Fatalf("message = %q", text)
+	}
+	if kind := compactKind(line); kind != "" {
+		t.Fatalf("notification was projected as %q; Entire has no representation for it", kind)
+	}
+}
+
+// Lifecycle events carry no conversation content, so they stay unprojected and
+// Entire drops them rather than emitting empty lines.
+func TestLifecycleEventsAreNotProjected(t *testing.T) {
+	_, data := hookSequence(t, "qwen-life",
+		[2]string{HookNameSessionStart, `{"session_id":"qwen-life","timestamp":"2026-05-20T12:00:00Z","source":"startup"}`},
+		[2]string{HookNameUserPromptSubmit, `{"session_id":"qwen-life","timestamp":"2026-05-20T12:00:01Z","prompt":""}`},
+		[2]string{HookNameSessionEnd, `{"session_id":"qwen-life","timestamp":"2026-05-20T12:00:02Z","reason":"exit"}`},
+	)
+	for i, line := range decodeLines(t, data) {
+		if kind := compactKind(line); kind != "" {
+			t.Fatalf("line %d projected as %q: %s", i, kind, line["event"])
+		}
+		if _, ok := line["message"]; ok {
+			t.Fatalf("line %d carries a message wrapper: %s", i, line["event"])
+		}
+	}
+}

--- a/agents/entire-agent-qwen/internal/qwen/review_regression_test.go
+++ b/agents/entire-agent-qwen/internal/qwen/review_regression_test.go
@@ -1,0 +1,43 @@
+package qwen
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSidecarOffsetsIncludeMalformedAndBlankLines(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	data := `{"event":"UserPromptSubmit","prompt":"first"}` + "\n" +
+		`{"event":"UserPromptSubmit","prompt":"must not survive","v":"invalid"}` + "\n\n" +
+		`{"event":"UserPromptSubmit","prompt":"second"}` + "\n"
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	a := New()
+	pos, err := a.GetTranscriptPosition(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pos != 4 {
+		t.Errorf("position = %d, want physical line count 4", pos)
+	}
+	prompts, err := a.ExtractPrompts(path, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prompts) != 1 || prompts[0] != "second" {
+		t.Errorf("prompts after line 3 = %v, want second", prompts)
+	}
+	prompts, err = a.ExtractPrompts(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prompts) != 2 {
+		t.Errorf("malformed record leaked partial data: %v", prompts)
+	}
+	_, current, err := a.ExtractModifiedFiles(path, 3)
+	if err != nil || current != 4 {
+		t.Errorf("current = %d, err = %v, want 4", current, err)
+	}
+}

--- a/agents/entire-agent-qwen/internal/qwen/sidecar_jsonl.go
+++ b/agents/entire-agent-qwen/internal/qwen/sidecar_jsonl.go
@@ -1,0 +1,200 @@
+package qwen
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+// The sidecar is already JSONL — one hook record per line, and
+// get-transcript-position reports the record count — so Entire's line-offset
+// scoping (transcript.SliceFromLine, cmd/entire/cli/transcript/parse.go:130,
+// reached from cmd/entire/cli/explain.go:1883 and
+// cmd/entire/cli/strategy/manual_commit_condensation.go:1006) already lands on
+// record boundaries. The line COUNT was never the problem.
+//
+// The line SHAPE was. An external agent's transcript is compacted by the
+// generic JSONL reader in cmd/entire/cli/transcript/compact/compact.go, which
+// keeps a line only when BOTH of these hold, and a native sidecar record failed
+// both, so transcript.jsonl came out at 0 bytes:
+//
+//   - normalizeKind (compact.go:197) reads a TOP-LEVEL "type", falling back to
+//     "role". A sidecar record has neither: its discriminator is "event"
+//     ("UserPromptSubmit", "PostToolUse", ...), which normalizeKind does not
+//     recognise, so every line was dropped.
+//   - parseMessage (compact.go:617) reads content from a TOP-LEVEL "message"
+//     OBJECT: "All JSONL agents nest content inside a 'message' object." The
+//     sidecar's "message" is a STRING (Qwen's notification text), so even a
+//     line that had passed the first check would have carried nothing.
+//
+// Each record therefore keeps its native fields, authoritative for the
+// adapter's own decoding, and gains an Entire-facing projection built from
+// them: a top-level "type" and a "message" wrapper. The projection is derived
+// data — readSidecarRecords ignores both — so a sidecar written by an older
+// build still reads, and later hooks append projected records alongside it.
+//
+// An adapter-side compact-transcript method does not avoid any of this:
+// checkpoint/persistent.go:1136 always runs Entire's generic compactor over the
+// raw transcript.
+
+// wireMessage is the "message" wrapper Entire's compactJSONL reads content from
+// (compact.go:617).
+type wireMessage struct {
+	Role    string `json:"role"`
+	ID      string `json:"id,omitempty"`
+	Content []any  `json:"content"`
+}
+
+// wireTextBlock is a text content block, read by both the user and the
+// assistant path in compactJSONL.
+type wireTextBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// wireToolUseBlock is an assistant tool call. stripAssistantContent
+// (compact.go:704) keeps exactly type, id, name and input — anything else on
+// the block, a pre-computed result included, is discarded, which is why the
+// result travels on its own record instead.
+type wireToolUseBlock struct {
+	Type  string `json:"type"`
+	ID    string `json:"id,omitempty"`
+	Name  string `json:"name"`
+	Input any    `json:"input"`
+}
+
+// wireToolResultBlock is a user tool result. extractUserContent (compact.go:665)
+// reads snake_case tool_use_id, a string "content" and is_error; Entire then
+// inlines the output into the preceding assistant's matching tool_use block
+// (inlineToolResults, compact.go:454), exactly as it does for Claude Code.
+type wireToolResultBlock struct {
+	Type      string `json:"type"`
+	ToolUseID string `json:"tool_use_id,omitempty"`
+	Content   string `json:"content"`
+	IsError   bool   `json:"is_error,omitempty"`
+}
+
+// projectSidecarRecord builds the Entire-facing view of a hook record: the
+// top-level kind normalizeKind needs, and the message wrapper parseMessage
+// needs. It returns ("", nil) for events Entire has no representation for,
+// which leaves the record unprojected and therefore dropped from the compact
+// transcript — the same outcome compactTranscriptBytes gives them.
+//
+// Qwen fires PreToolUse before a call and PostToolUse after it, so the pair maps
+// onto Entire's assistant tool_use / user tool_result the way Claude Code's own
+// transcript does, and each hook still costs exactly one line.
+func projectSidecarRecord(record sidecarRecord, nativeMessage string) (string, *wireMessage) {
+	switch record.Event {
+	case "UserPromptSubmit":
+		if strings.TrimSpace(record.Prompt) == "" {
+			return "", nil
+		}
+		return "user", &wireMessage{
+			Role:    "user",
+			Content: textContent(nativeMessage, record.Prompt),
+		}
+
+	case "PreToolUse":
+		if strings.TrimSpace(record.ToolName) == "" {
+			return "", nil
+		}
+		content := textContent(nativeMessage)
+		content = append(content, wireToolUseBlock{
+			Type:  "tool_use",
+			ID:    record.ToolUseID,
+			Name:  record.ToolName,
+			Input: decodeRawObject(record.ToolInput),
+		})
+		return "assistant", &wireMessage{Role: "assistant", ID: record.ToolUseID, Content: content}
+
+	case "PostToolUse", "PostToolUseFailure":
+		output, isError := toolOutcome(record)
+		content := textContent(nativeMessage)
+		content = append(content, wireToolResultBlock{
+			Type:      "tool_result",
+			ToolUseID: record.ToolUseID,
+			Content:   output,
+			IsError:   isError,
+		})
+		return "user", &wireMessage{Role: "user", Content: content}
+
+	case "Stop", "StopFailure":
+		text := record.LastAssistantMessage
+		if text == "" {
+			text = record.ErrorDetails
+		}
+		if strings.TrimSpace(text) == "" {
+			return "", nil
+		}
+		return "assistant", &wireMessage{
+			Role:    "assistant",
+			Content: textContent(nativeMessage, text),
+		}
+
+	default:
+		return "", nil
+	}
+}
+
+// toolOutcome renders a tool result as the string Entire expects, and reports
+// whether the call failed. tool_response is raw JSON: a JSON string is used as
+// its value, anything else as its compact JSON text.
+func toolOutcome(record sidecarRecord) (string, bool) {
+	if record.Error != "" || record.ErrorDetails != "" {
+		return strings.TrimSpace(record.Error + " " + record.ErrorDetails), true
+	}
+	failed := record.Event == "PostToolUseFailure" || record.IsTimeout || record.IsInterrupt
+	return rawMessageText(record.ToolResponse), failed
+}
+
+// rawMessageText renders raw JSON as a string: an encoded string keeps its
+// value, anything else keeps its JSON text.
+func rawMessageText(raw json.RawMessage) string {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return ""
+	}
+	var text string
+	if json.Unmarshal(trimmed, &text) == nil {
+		return text
+	}
+	return string(trimmed)
+}
+
+// textContent builds the leading text blocks of a projected message, skipping
+// empty ones. The record's native "message" text is carried first: the wrapper
+// takes over the "message" key, so folding the text into the content is what
+// keeps it in the transcript instead of losing it. Qwen only sets it on
+// Notification records, which are never projected.
+func textContent(texts ...string) []any {
+	content := make([]any, 0, len(texts)+1)
+	for _, text := range texts {
+		if strings.TrimSpace(text) == "" {
+			continue
+		}
+		content = append(content, wireTextBlock{Type: "text", Text: text})
+	}
+	return content
+}
+
+// jsonString encodes s as a JSON string, or nil when it is empty.
+func jsonString(s string) json.RawMessage {
+	if s == "" {
+		return nil
+	}
+	encoded, err := json.Marshal(s)
+	if err != nil {
+		return nil
+	}
+	return encoded
+}
+
+// jsonObject encodes v, returning nil when it cannot be encoded. A record whose
+// projection fails to marshal is written unprojected rather than not at all.
+func jsonObject(v any) json.RawMessage {
+	encoded, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	return encoded
+}

--- a/agents/entire-agent-qwen/internal/qwen/transcript.go
+++ b/agents/entire-agent-qwen/internal/qwen/transcript.go
@@ -211,7 +211,7 @@ func (a *Agent) appendSidecar(raw qwenHookInputRaw) error {
 		StopHookActive:       raw.StopHookActive,
 		Trigger:              raw.Trigger,
 		NotificationType:     raw.NotificationType,
-		Message:              raw.Message,
+		Message:              jsonString(raw.Message),
 		AgentID:              raw.AgentID,
 		AgentType:            raw.AgentType,
 		AgentTranscriptPath:  raw.AgentTranscriptPath,
@@ -227,6 +227,16 @@ func (a *Agent) appendSidecar(raw qwenHookInputRaw) error {
 		LastAssistantMessage: raw.LastAssistantMessage,
 		CustomInstructions:   raw.CustomInstructions,
 		CompactSummary:       raw.CompactSummary,
+	}
+	// Give the line the shape Entire's compact reader needs; see
+	// sidecar_jsonl.go. The projection is derived from the fields above and is
+	// ignored on read, so it never changes what the adapter itself sees.
+	if kind, message := projectSidecarRecord(record, raw.Message); message != nil {
+		if encoded := jsonObject(message); encoded != nil {
+			record.Type = kind
+			record.Timestamp = record.TS
+			record.Message = encoded
+		}
 	}
 	data, err := json.Marshal(record)
 	if err != nil {

--- a/agents/entire-agent-qwen/internal/qwen/transcript.go
+++ b/agents/entire-agent-qwen/internal/qwen/transcript.go
@@ -316,6 +316,18 @@ func safeFilename(name string) string {
 	return out
 }
 
+// maxSidecarLine bounds a single sidecar record. One record embeds a whole
+// tool_input/tool_response, so 64 KB (bufio.Scanner's default) is far too
+// small: a single large file read or write would make every transcript
+// operation on that session fail with "token too long", permanently, because
+// the oversized record stays on disk. 10 MB matches the limit the other JSONL
+// transcript scanners use.
+const maxSidecarLine = 10 * 1024 * 1024
+
+// readSidecarRecords parses the append-only JSONL sidecar. Unparseable lines
+// are skipped rather than failing the whole read: the sidecar can be read
+// while Qwen is mid-turn, and a single torn or foreign line must not destroy
+// the rest of the session.
 func readSidecarRecords(path string) ([]sidecarRecord, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -325,14 +337,15 @@ func readSidecarRecords(path string) ([]sidecarRecord, error) {
 
 	var records []sidecarRecord
 	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), maxSidecarLine)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
 			continue
 		}
 		var record sidecarRecord
-		if err := json.Unmarshal([]byte(line), &record); err != nil {
-			return nil, err
+		if json.Unmarshal([]byte(line), &record) != nil {
+			continue
 		}
 		records = append(records, record)
 	}

--- a/agents/entire-agent-qwen/internal/qwen/transcript.go
+++ b/agents/entire-agent-qwen/internal/qwen/transcript.go
@@ -325,7 +325,7 @@ func safeFilename(name string) string {
 const maxSidecarLine = 10 * 1024 * 1024
 
 // readSidecarRecords parses the append-only JSONL sidecar. Unparseable lines
-// are skipped rather than failing the whole read: the sidecar can be read
+// retain empty placeholders rather than failing the whole read: the sidecar can be read
 // while Qwen is mid-turn, and a single torn or foreign line must not destroy
 // the rest of the session.
 func readSidecarRecords(path string) ([]sidecarRecord, error) {
@@ -340,12 +340,12 @@ func readSidecarRecords(path string) ([]sidecarRecord, error) {
 	scanner.Buffer(make([]byte, 64*1024), maxSidecarLine)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
-		}
 		var record sidecarRecord
 		if json.Unmarshal([]byte(line), &record) != nil {
-			continue
+			// Keep a placeholder for every physical line: Entire slices the
+			// original bytes by newline, including blank and malformed lines.
+			// Reset partial fields populated before a JSON type error, too.
+			record = sidecarRecord{}
 		}
 		records = append(records, record)
 	}

--- a/agents/entire-agent-qwen/internal/qwen/transcript_test.go
+++ b/agents/entire-agent-qwen/internal/qwen/transcript_test.go
@@ -1,0 +1,109 @@
+package qwen
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// A single Qwen hook record is not bounded by 64 KB: tool_response for a large
+// file read, or tool_input for a large write, routinely exceeds it. Every
+// transcript operation must still see the whole session.
+func TestSidecarRecordLargerThanScannerDefault(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repo)
+	agent := New()
+
+	big, err := json.Marshal(strings.Repeat("x", 128*1024))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inputs := []string{
+		`{"session_id":"big","timestamp":"2026-05-20T12:00:00Z","prompt":"Read the file"}`,
+		`{"session_id":"big","timestamp":"2026-05-20T12:00:01Z","tool_name":"write_file","tool_use_id":"tool-1","tool_input":{"file_path":"hello.txt"},"tool_response":` + string(big) + `}`,
+		`{"session_id":"big","timestamp":"2026-05-20T12:00:02Z","last_assistant_message":"done"}`,
+	}
+	hooks := []string{HookNameUserPromptSubmit, HookNamePostToolUse, HookNameStop}
+	for i, hook := range hooks {
+		if _, err := agent.ParseHook(hook, []byte(inputs[i])); err != nil {
+			t.Fatalf("ParseHook(%s): %v", hook, err)
+		}
+	}
+
+	sessionRef := agent.sidecarPath("big")
+
+	position, err := agent.GetTranscriptPosition(sessionRef)
+	if err != nil {
+		t.Fatalf("GetTranscriptPosition: %v", err)
+	}
+	if position != 3 {
+		t.Fatalf("expected 3 records, got %d", position)
+	}
+
+	files, current, err := agent.ExtractModifiedFiles(sessionRef, 0)
+	if err != nil {
+		t.Fatalf("ExtractModifiedFiles: %v", err)
+	}
+	if current != 3 {
+		t.Fatalf("expected current position 3, got %d", current)
+	}
+	if len(files) != 1 || files[0] != "hello.txt" {
+		t.Fatalf("unexpected modified files: %#v", files)
+	}
+
+	prompts, err := agent.ExtractPrompts(sessionRef, 0)
+	if err != nil {
+		t.Fatalf("ExtractPrompts: %v", err)
+	}
+	if len(prompts) != 1 || prompts[0] != "Read the file" {
+		t.Fatalf("unexpected prompts: %#v", prompts)
+	}
+
+	summary, ok, err := agent.ExtractSummary(sessionRef)
+	if err != nil {
+		t.Fatalf("ExtractSummary: %v", err)
+	}
+	if !ok || summary != "done" {
+		t.Fatalf("unexpected summary %q ok=%v", summary, ok)
+	}
+}
+
+// The sidecar is append-only and is read while Qwen is still running, so a
+// torn final line is normal. It must not destroy the records already written.
+func TestSidecarSkipsUnparseableLine(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repo)
+	agent := New()
+
+	if _, err := agent.ParseHook(HookNameUserPromptSubmit,
+		[]byte(`{"session_id":"torn","timestamp":"2026-05-20T12:00:00Z","prompt":"Create hello.txt"}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionRef := agent.sidecarPath("torn")
+	f, err := os.OpenFile(sessionRef, os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A record whose write was interrupted mid-line.
+	if _, err := f.WriteString(`{"v":1,"agent":"qwen","event":"PostToolUse","tool_inp` + "\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	prompts, err := agent.ExtractPrompts(sessionRef, 0)
+	if err != nil {
+		t.Fatalf("ExtractPrompts: %v", err)
+	}
+	if len(prompts) != 1 || prompts[0] != "Create hello.txt" {
+		t.Fatalf("unexpected prompts: %#v", prompts)
+	}
+
+	if _, err := agent.GetTranscriptPosition(sessionRef); err != nil {
+		t.Fatalf("GetTranscriptPosition: %v", err)
+	}
+}

--- a/agents/entire-agent-qwen/internal/qwen/types.go
+++ b/agents/entire-agent-qwen/internal/qwen/types.go
@@ -109,23 +109,40 @@ type qwenHookInputRaw struct {
 	} `json:"llm_request,omitempty"`
 }
 
+// sidecarRecord is one line of the append-only sidecar. Alongside Qwen's own
+// hook fields it carries the Entire-facing projection Type and Message, which
+// the generic compact reader needs to keep the line and read its content — see
+// sidecar_jsonl.go for the contract those two satisfy.
 type sidecarRecord struct {
-	V                    int             `json:"v"`
-	Agent                string          `json:"agent"`
-	Event                string          `json:"event"`
-	SessionID            string          `json:"session_id"`
-	TS                   string          `json:"ts"`
-	CWD                  string          `json:"cwd,omitempty"`
-	NativeTranscriptPath string          `json:"native_transcript_path,omitempty"`
-	Prompt               string          `json:"prompt,omitempty"`
-	Model                string          `json:"model,omitempty"`
-	Reason               string          `json:"reason,omitempty"`
-	Source               string          `json:"source,omitempty"`
-	PermissionMode       string          `json:"permission_mode,omitempty"`
-	StopHookActive       bool            `json:"stop_hook_active,omitempty"`
-	Trigger              string          `json:"trigger,omitempty"`
-	NotificationType     string          `json:"notification_type,omitempty"`
-	Message              string          `json:"message,omitempty"`
+	V     int    `json:"v"`
+	Agent string `json:"agent"`
+	// Type is the projected kind ("user" or "assistant") read by normalizeKind
+	// (compact.go:197). Empty for events Entire has no representation for,
+	// which drops the line from the compact transcript.
+	Type string `json:"type,omitempty"`
+	// Timestamp mirrors TS under the key parseLine reads (compact.go:391), so
+	// the compact transcript carries the time of each turn. Qwen's own "ts" is
+	// left alone.
+	Timestamp            string `json:"timestamp,omitempty"`
+	Event                string `json:"event"`
+	SessionID            string `json:"session_id"`
+	TS                   string `json:"ts"`
+	CWD                  string `json:"cwd,omitempty"`
+	NativeTranscriptPath string `json:"native_transcript_path,omitempty"`
+	Prompt               string `json:"prompt,omitempty"`
+	Model                string `json:"model,omitempty"`
+	Reason               string `json:"reason,omitempty"`
+	Source               string `json:"source,omitempty"`
+	PermissionMode       string `json:"permission_mode,omitempty"`
+	StopHookActive       bool   `json:"stop_hook_active,omitempty"`
+	Trigger              string `json:"trigger,omitempty"`
+	NotificationType     string `json:"notification_type,omitempty"`
+	// Message holds either Qwen's notification text (a JSON string) or the
+	// projected wrapper object parseMessage reads content from
+	// (compact.go:617). It is raw JSON so a record round-trips through
+	// readSidecarRecords whichever shape it carries: typed as a string, a
+	// projected line would fail to unmarshal and the whole sidecar read with it.
+	Message              json.RawMessage `json:"message,omitempty"`
 	AgentID              string          `json:"agent_id,omitempty"`
 	AgentType            string          `json:"agent_type,omitempty"`
 	AgentTranscriptPath  string          `json:"agent_transcript_path,omitempty"`


### PR DESCRIPTION
## The defect

Qwen's sidecar is already JSONL and `get-transcript-position` already reports the record count, so Entire's line-offset scoping (`transcript.SliceFromLine`, `cmd/entire/cli/transcript/parse.go:130`) already lands on record boundaries. The line **count** was never the problem.

The line **shape** was. Measured against cli@main, qwen's `transcript.jsonl` came out at **0 bytes**.

Entire compacts an external agent's transcript with the generic JSONL reader in `cmd/entire/cli/transcript/compact/compact.go`. Shipping a `compact-transcript` method does not avoid it — `checkpoint/persistent.go:1136` always runs the generic compactor over the raw transcript.

That reader keeps a line only when **both** hold, and a native sidecar record failed **both**:

| half | what cli reads | native record |
|---|---|---|
| kind | `normalizeKind` (compact.go:197) reads a top-level `type`, falling back to `role` | has neither — the discriminator is `event` (`UserPromptSubmit`, `PostToolUse`, …), so every line was dropped |
| content | `parseMessage` (compact.go:617) reads content from a top-level `message` **object** | `message` is a **string** (Qwen's notification text), so even a line that passed the first check would carry nothing |

qwen is not listed in #67 — its table implies qwen is fine. It is not; I have commented there.

## The change

Each record keeps its native fields and gains a projection built from them: a top-level `type`, a `timestamp` under the key `parseLine` reads (compact.go:391), and the `message` wrapper.

| event | projected as | content |
|---|---|---|
| `UserPromptSubmit` | `user` | text block with the prompt |
| `PreToolUse` | `assistant` | `tool_use` with `type`/`id`/`name`/`input` — the only fields `stripAssistantContent` (compact.go:704) preserves |
| `PostToolUse` / `PostToolUseFailure` | `user` | `tool_result` with snake_case `tool_use_id` and a string `content` (compact.go:665) |
| `Stop` / `StopFailure` | `assistant` | text block with the final message or error details |
| everything else | not projected | dropped, as before |

Qwen fires `PreToolUse` before a call and `PostToolUse` after it, so that pairing is Claude Code's own tool_use/tool_result shape: `inlineToolResults` (compact.go:454) folds the output into the preceding `tool_use`. Each hook still costs exactly one line, so `position == line count` is preserved. An unpaired `tool_result` is dropped by compact.go:288, which is cli's own behaviour for Claude Code; `install-hooks` registers both hooks together, so the pair is present in any session Entire set up.

### `message` is now raw JSON, and that is load-bearing

`sidecarRecord.Message` was `string`. With an object under that key, `json.Unmarshal` in `readSidecarRecords` fails — and on main that error aborts the **whole sidecar read**, so prompts, modified files and summaries all disappear. Typing it as `json.RawMessage` is what makes a projected record round-trip.

This also interacts with #65, which changes `readSidecarRecords` to skip unparseable lines instead of erroring: without this type change, a projected line would be **silently skipped** there. The two changes touch different hunks of `transcript.go` and merge cleanly in either order.

Qwen's notification text is the only thing that used `message`, and it is only sent on events that are never projected, so it is written exactly as before — there is a test pinning that. A projected record that also carried one would keep it as the first text block of its content.

## Back-compat

The projection is derived data and is ignored on read, so a sidecar written by an older build still parses and later hooks append projected records alongside it. Test: a legacy line plus a freshly projected one, read together.

## Measured

A full hook sequence (session-start, notification, prompt, pre-tool-use, post-tool-use, stop, session-end) driven through `ParseHook`, then run through cli@main's `transcript.SliceFromLine` + `compact.FullWithBoundary`:

```
before  start=0  raw 1032B / 7 lines   transcript.jsonl=0B
after   start=0  raw 1674B / 7 lines   transcript.jsonl=574B, 3 lines all carrying content
after   start=3  boundary=1, delta=439B
```

The compacted lines now read:

```json
{"type":"user","ts":"2026-05-20T12:00:02Z","content":[{"text":"Create hello.txt"}]}
{"type":"assistant","ts":"2026-05-20T12:00:03Z","id":"tool-1","content":[{"id":"tool-1","input":{"content":"hi","file_path":"hello.txt"},"name":"write_file","result":{"output":"{\"ok\":true}","status":"success"},"type":"tool_use"}]}
{"type":"assistant","ts":"2026-05-20T12:00:05Z","content":[{"text":"Created hello.txt","type":"text"}]}
```

Lifecycle and notification records are correctly dropped rather than emitted empty.

## Why the tests are shaped this way

Reverting **only** the message wrapper — keeping the top-level `type` — reproduces the other failure mode exactly: **468 bytes across 4 lines, every content array empty**. A non-zero byte count would call that fixed. The tests therefore assert the message **text**, and they drive real hook payloads through `ParseHook` and read what the agent actually wrote, rather than comparing against a checked-in expected constant.

Mutations tried, all caught, all compiling:

| mutation | caught by |
|---|---|
| drop the `message` wrapper (keep `type`) | 3 contract tests |
| drop the top-level `type` (keep the wrapper) | 3 tests |
| `tool_use_id` -> `toolUseId` | tool-shape test |
| `tool_use` `input` -> `arguments` | tool-shape test |
| `message` typed as a string again | 3 tests (the read-back guard) |
| `PostToolUse` carries no tool output | 3 tests |
| notification `message` dropped | notification test |

`go test ./...` in `agents/entire-agent-qwen`: 33 pass (was 23).

## Overlap with my other open qwen PRs

- **#65** (sidecar scanner buffer) touches `readSidecarRecords` in `transcript.go` and adds `transcript_test.go`. This PR touches `appendSidecar` in the same file and adds `sidecar_jsonl.go` + `jsonl_test.go`. Different hunks, different new files — no conflict. The semantic interaction is described above.
- **#66** (hook command PATH) touches `hooks.go` / `hooks_test.go` only — no overlap.
