### PR TITLE
fix(kiro): store the transcript as JSONL so checkpoint scoping works

### DIFF
--- a/agents/entire-agent-kiro/AGENT.md
+++ b/agents/entire-agent-kiro/AGENT.md
@@ -49,7 +49,7 @@ Kiro has enough hook, session, and transcript surface area to fit the Entire ext
 - `kiro-active-turn` is a single repo-global file. Each prompt-submit overwrites it; each stop owner-checks before clearing. This is correct for the common cases — single chat, tab-switch mid-turn, sequential turns across tabs, and concurrent CLI+IDE activity (each side's payload lets the other flow stay isolated). It is best-effort under truly overlapping IDE turns (`A prompt → B prompt → A stop`): A's stop has no payload signal that distinguishes it from B's, so the resolver returns whichever IDE chat is currently in cache. The owner-check at clear time prevents A's stop from deleting B's binding, but A's session_id will still resolve to whatever the cache currently holds. Fixing this fully requires a per-turn signal in the hook payload from Kiro, which it does not provide today
 - For the same reason, post-tool-use hooks during a truly overlapping IDE turn fall back to mtime-based active-chat detection when the cache holds the wrong chat. CLI flows are unaffected because they short-circuit on payload `conversation_id`
 - Session directory: `.entire/tmp/` under the repo root
-- Session file format: cached JSON transcript, one file per session ID
+- Session file format: **JSONL, one message per line**, one file per session ID. The native CLI and IDE documents are ingestion formats only — they are converted before being written
 - Session file path: `.entire/tmp/<session-id>.json`
 - Native CLI session lookup: SQLite database at `~/Library/Application Support/kiro-cli/data.sqlite3` on macOS, `~/.local/share/kiro-cli/data.sqlite3` on Linux, or `%LOCALAPPDATA%/kiro-cli/data.sqlite3` on Windows
 - Native CLI lookup key: the current working directory is queried against `conversations_v2`
@@ -57,15 +57,38 @@ Kiro has enough hook, session, and transcript surface area to fit the Entire ext
 - IDE transcript source: the most recent entry in `sessions.json`, then `<sessionId>.json` in the same directory
 
 ## Transcript
-- CLI transcript format: JSON object with `conversation_id` and `history`
+- Stored format: **JSONL, one message per line.** Entire slices external-agent
+  transcripts by LINE offset (`transcript.SliceFromLine`) before compacting
+  them, so a single JSON document is cut mid-value and every checkpoint's
+  `transcript.jsonl` came out empty.
+- **A paired history entry becomes TWO lines.** Kiro's history entries are
+  `{"user":…,"assistant":…}` pairs, and Entire's `normalizeKind` yields exactly
+  one kind per line, so a pair cannot survive as one line without losing a half.
+  The two halves are emitted as separate records sharing an `entry` index.
+- Each stored record carries kiro's native `user`/`assistant` payload, the
+  session-level fields (`conversation_id`, `cli_version`) stamped on every
+  record because a scoped slice has no header, and an Entire-facing projection
+  (`type`, `timestamp`, `message`) built from them. Entire's generic JSONL
+  compactor needs a top-level `type`/`role` AND content under a top-level
+  `message` wrapper; kiro's own `user`/`assistant` keys are where Entire does
+  not look.
+- A record whose payload this build cannot project carries no `type`, so Entire
+  drops it rather than emitting an empty envelope, while kiro's own extractors
+  still see it.
+- Back-compat: a native whole-document transcript written by an older build
+  still parses, reported in its original history-entry unit; the next capture
+  rewrites it as JSONL and the unit moves with the bytes. A position and the
+  bytes it indexes are always stored together in one checkpoint, so historical
+  checkpoints are never re-scoped.
+- Native CLI transcript format (input to the conversion): JSON object with `conversation_id` and `history`
 - CLI history entries: paired user and assistant messages
 - User prompt shape: `history[].user.content` containing a tagged union such as `{"Prompt":{"prompt":"..."}}`
 - Assistant tool-call shape: `history[].assistant` containing `{"ToolUse": {...}}`
 - Assistant response shape: `history[].assistant` containing `{"Response": {...}}`
-- IDE transcript format: JSON object with `history`, where each entry contains a `message` object
+- Native IDE transcript format (input to the conversion): JSON object with `history`, where each entry contains a `message` object
 - IDE message shape: Anthropic-style `role` plus `content`
-- CLI transcript capture: fetched from SQLite at turn end and cached to `.entire/tmp/<session-id>.json`
-- IDE transcript capture: copied from the workspace session file into `.entire/tmp/<session-id>.json`
+- CLI transcript capture: fetched from SQLite at turn end, materialized as JSONL, and written atomically to `.entire/tmp/<session-id>.json`
+- IDE transcript capture: read from the workspace session file, converted to CLI shape, materialized as JSONL, and written atomically to `.entire/tmp/<session-id>.json`
 
 ## Protocol Mapping
 | Subcommand | Native Concept | Implementation Notes | Feasibility |
@@ -85,7 +108,7 @@ Kiro has enough hook, session, and transcript surface area to fit the Entire ext
 | `install-hooks` | `.kiro/agents/entire.json`, `.kiro/hooks/*.kiro.hook`, `.vscode/settings.json` | install both CLI and IDE support in one operation | If hooks capable |
 | `uninstall-hooks` | reverse hook installation | remove Entire-owned CLI and IDE hook files plus trusted commands | If hooks capable |
 | `are-hooks-installed` | config presence check | true when either CLI hooks or IDE hooks are present | If hooks capable |
-| `get-transcript-position` | transcript length | CLI uses history entry count; IDE uses history count from cached JSON | If transcript analyzer |
+| `get-transcript-position` | transcript length | number of stored JSONL lines (two per paired history entry); a legacy whole-document transcript still reports its history-entry count | If transcript analyzer |
 | `extract-modified-files` | transcript tool-use history | parse tool calls and file edits from cached transcript | If transcript analyzer |
 | `extract-prompts` | user prompt history | return prompt text from transcript history | If transcript analyzer |
 | `extract-summary` | last assistant response | return the final assistant response text | If transcript analyzer |

--- a/agents/entire-agent-kiro/internal/kiro/compact.go
+++ b/agents/entire-agent-kiro/internal/kiro/compact.go
@@ -104,7 +104,7 @@ func compactTranscriptBytes(data []byte) ([]byte, error) {
 				V:          1,
 				Agent:      compactTranscriptAgent,
 				CLIVersion: cliVersion,
-				Type:       "user",
+				Type:       roleUser,
 				TS:         entry.User.Timestamp,
 				Content:    []compactUserTextBlock{{Text: prompt}},
 			}); err != nil {
@@ -141,7 +141,7 @@ func compactAssistantEntry(entry kiroHistoryEntry, nextUserContent json.RawMessa
 		V:          1,
 		Agent:      compactTranscriptAgent,
 		CLIVersion: cliVersion,
-		Type:       "assistant",
+		Type:       roleAssistant,
 		TS:         entry.User.Timestamp,
 	}
 

--- a/agents/entire-agent-kiro/internal/kiro/jsonl_test.go
+++ b/agents/entire-agent-kiro/internal/kiro/jsonl_test.go
@@ -1,0 +1,716 @@
+package kiro
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// sliceFromLine mirrors Entire's transcript.SliceFromLine
+// (cmd/entire/cli/transcript/parse.go:130): return the bytes starting after the
+// Nth newline, or nil when there aren't that many lines. This is what
+// cmd/entire/cli/explain.go:1883 (scopeTranscriptForCheckpoint) and
+// cmd/entire/cli/strategy/manual_commit_condensation.go:1006 apply to every
+// agent that is not one of Entire's built-ins — kiro included.
+func sliceFromLine(content []byte, startLine int) []byte {
+	if len(content) == 0 || startLine <= 0 {
+		return content
+	}
+	count, offset := 0, 0
+	for i, b := range content {
+		if b == '\n' {
+			count++
+			if count == startLine {
+				offset = i + 1
+				break
+			}
+		}
+	}
+	if count < startLine || offset >= len(content) {
+		return nil
+	}
+	return content[offset:]
+}
+
+// compactKind mirrors normalizeKind in Entire's
+// cmd/entire/cli/transcript/compact/compact.go:197: the entry kind comes from
+// the TOP-LEVEL "type", falling back to "role". A line that yields neither
+// "user" nor "assistant" is dropped from the compact transcript entirely.
+func compactKind(line map[string]json.RawMessage) string {
+	var kind string
+	if json.Unmarshal(line["type"], &kind) == nil && kind != "" {
+		return kind
+	}
+	if json.Unmarshal(line["role"], &kind) == nil {
+		return kind
+	}
+	return ""
+}
+
+// compactMessageContent mirrors parseMessage (compact.go:617): content is read
+// from a TOP-LEVEL "message" object, never from the line's own payload keys.
+// This is the half kiro was missing — its content lived under "user"/"assistant"
+// keys of a paired history entry, where Entire does not look.
+func compactMessageContent(line map[string]json.RawMessage) []map[string]json.RawMessage {
+	var msg map[string]json.RawMessage
+	if json.Unmarshal(line["message"], &msg) != nil {
+		return nil
+	}
+	var blocks []map[string]json.RawMessage
+	if json.Unmarshal(msg["content"], &blocks) != nil {
+		return nil
+	}
+	return blocks
+}
+
+// storedTranscript materializes the committed fixture through the real write
+// path (materializeTranscript -> encodeTranscriptJSONL), so every assertion
+// below exercises the live encoder rather than a checked-in expected constant.
+func storedTranscript(t *testing.T) []byte {
+	t.Helper()
+	data, ok := materializeTranscript([]byte(testCLIAnalyzerTranscript))
+	if !ok {
+		t.Fatal("testCLIAnalyzerTranscript did not materialize")
+	}
+	return data
+}
+
+// sourceHistory is the fixture as kiro parses it natively — the ground truth
+// every expectation below is derived from.
+func sourceHistory(t *testing.T) []kiroHistoryEntry {
+	t.Helper()
+	parsed, err := parseTranscript([]byte(testCLIAnalyzerTranscript))
+	if err != nil {
+		t.Fatalf("parseTranscript(fixture) error = %v", err)
+	}
+	return parsed.History
+}
+
+func storedTranscriptFile(t *testing.T, data []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "session.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func decodeStoredLines(t *testing.T, data []byte) []map[string]json.RawMessage {
+	t.Helper()
+	var out []map[string]json.RawMessage
+	for _, line := range bytes.Split(bytes.TrimRight(data, "\n"), []byte{'\n'}) {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(line, &m); err != nil {
+			t.Fatalf("stored line is not valid JSON: %v (%s)", err, line)
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// mustParseStored reads a stored transcript through the real reader. Stored
+// transcripts are JSONL now, so tests that assert on the on-disk file must go
+// through parseTranscript rather than unmarshalling one JSON document.
+func mustParseStored(t *testing.T, data []byte) kiroTranscript {
+	t.Helper()
+	parsed, err := parseTranscript(data)
+	if err != nil {
+		t.Fatalf("parse cached transcript: %v", err)
+	}
+	return *parsed
+}
+
+// --- the two halves of Entire's compact contract ---
+
+func TestStoredTranscriptIsOneJSONObjectPerLine(t *testing.T) {
+	data := storedTranscript(t)
+	lines := decodeStoredLines(t, data)
+	if len(lines) == 0 {
+		t.Fatal("stored transcript has no lines")
+	}
+	if !bytes.HasSuffix(data, []byte("\n")) {
+		t.Error("stored transcript must end with a newline so slicing lands on a record boundary")
+	}
+	// The bug this format replaces: a pretty-printed document whose first line
+	// is a bare brace, which SliceFromLine cuts mid-value.
+	if bytes.HasPrefix(bytes.TrimSpace(data), []byte("{\n")) {
+		t.Error("stored transcript is a pretty-printed document, not JSONL")
+	}
+}
+
+func TestStoredLinesSatisfyBothHalvesOfCompactContract(t *testing.T) {
+	lines := decodeStoredLines(t, storedTranscript(t))
+
+	kinds := map[string]int{}
+	for i, line := range lines {
+		kind := compactKind(line)
+		if kind == "" {
+			// A line with no recognised kind is dropped by normalizeKind, which
+			// is deliberate for payloads this build cannot project. It must
+			// then carry no "message" either, or it would be an empty envelope.
+			if _, ok := line["message"]; ok {
+				t.Errorf("line %d has a message wrapper but no kind normalizeKind accepts", i)
+			}
+			continue
+		}
+		if kind != "user" && kind != "assistant" {
+			t.Errorf("line %d kind = %q, want user or assistant", i, kind)
+			continue
+		}
+		kinds[kind]++
+
+		blocks := compactMessageContent(line)
+		if len(blocks) == 0 {
+			t.Errorf("line %d (%s) has no content under the message wrapper — an empty envelope", i, kind)
+		}
+	}
+
+	if kinds["user"] == 0 {
+		t.Error("no user line survives normalizeKind")
+	}
+	if kinds["assistant"] == 0 {
+		t.Error("no assistant line survives normalizeKind")
+	}
+}
+
+// TestContentIsAbsentFromWhereEntireDoesNotLook guards the failure mode that
+// made kilo look fixed: the file was JSONL and non-empty, but its content sat
+// under keys Entire's compactor never reads, so transcript.jsonl stayed empty.
+func TestMessageWrapperCarriesContentNotOnlyNativeKeys(t *testing.T) {
+	lines := decodeStoredLines(t, storedTranscript(t))
+	for i, line := range lines {
+		if compactKind(line) == "" {
+			continue
+		}
+		if _, ok := line["message"]; !ok {
+			t.Fatalf("line %d has a kind but no top-level %q object; parseMessage (compact.go:617) would find nothing", i, "message")
+		}
+	}
+}
+
+// --- the paired-entry split ---
+
+func TestPairedHistoryEntryBecomesTwoRecordsSharingAnEntryIndex(t *testing.T) {
+	entries := sourceHistory(t)
+	lines := decodeStoredLines(t, storedTranscript(t))
+
+	// Every fixture entry has both halves, so the live encoder must emit two
+	// records per entry: normalizeKind yields one kind per line, so a paired
+	// entry cannot survive as one line without losing a half.
+	wantRecords := 0
+	for _, e := range entries {
+		if len(e.User.Content) > 0 {
+			wantRecords++
+		}
+		if len(e.Assistant) > 0 {
+			wantRecords++
+		}
+	}
+	if len(lines) != wantRecords {
+		t.Fatalf("stored records = %d, want %d (one per non-empty history half)", len(lines), wantRecords)
+	}
+
+	byEntry := map[int][]string{}
+	for i, line := range lines {
+		var idx int
+		if err := json.Unmarshal(line["entry"], &idx); err != nil {
+			t.Fatalf("line %d has no entry index: %v", i, err)
+		}
+		half := "user"
+		if _, ok := line["assistant"]; ok {
+			half = "assistant"
+		}
+		byEntry[idx] = append(byEntry[idx], half)
+	}
+	for idx, halves := range byEntry {
+		if !reflect.DeepEqual(halves, []string{"user", "assistant"}) {
+			t.Errorf("entry %d halves = %v, want [user assistant] in order", idx, halves)
+		}
+	}
+	if len(byEntry) != len(entries) {
+		t.Errorf("distinct entry indices = %d, want %d", len(byEntry), len(entries))
+	}
+}
+
+// --- content actually survives, not just envelopes ---
+
+func TestEveryUserPromptReachesTheMessageWrapper(t *testing.T) {
+	entries := sourceHistory(t)
+	stored := storedTranscript(t)
+
+	found := 0
+	for _, e := range entries {
+		prompt := extractUserPrompt(e.User.Content)
+		if prompt == "" {
+			continue
+		}
+		found++
+		var seen bool
+		for _, line := range decodeStoredLines(t, stored) {
+			if compactKind(line) != "user" {
+				continue
+			}
+			for _, block := range compactMessageContent(line) {
+				var text string
+				if json.Unmarshal(block["text"], &text) == nil && text == prompt {
+					seen = true
+				}
+			}
+		}
+		if !seen {
+			t.Errorf("prompt %q never reaches message.content[].text", prompt)
+		}
+	}
+	if found == 0 {
+		t.Fatal("fixture carries no user prompts; the assertion would be vacuous")
+	}
+}
+
+func TestEveryAssistantResponseReachesTheMessageWrapper(t *testing.T) {
+	entries := sourceHistory(t)
+	stored := storedTranscript(t)
+
+	found := 0
+	for _, e := range entries {
+		var response kiroResponseContent
+		if json.Unmarshal(e.Assistant, &response) != nil || response.Response.Content == "" {
+			continue
+		}
+		found++
+		var seen bool
+		for _, line := range decodeStoredLines(t, stored) {
+			if compactKind(line) != "assistant" {
+				continue
+			}
+			for _, block := range compactMessageContent(line) {
+				var text string
+				if json.Unmarshal(block["text"], &text) == nil && text == response.Response.Content {
+					seen = true
+				}
+			}
+		}
+		if !seen {
+			t.Errorf("response %q never reaches message.content[].text", response.Response.Content)
+		}
+	}
+	if found == 0 {
+		t.Fatal("fixture carries no assistant responses; the assertion would be vacuous")
+	}
+}
+
+// TestToolUseBlocksCarryTheFieldsStripAssistantContentKeeps pins the assistant
+// tool-call shape to what compact.go:704 preserves: type, id, name, input.
+func TestToolUseBlocksCarryTheFieldsStripAssistantContentKeeps(t *testing.T) {
+	entries := sourceHistory(t)
+	stored := decodeStoredLines(t, storedTranscript(t))
+
+	want := map[string]string{} // tool id -> tool name, from the source
+	for _, e := range entries {
+		var toolUse kiroToolUseContent
+		if json.Unmarshal(e.Assistant, &toolUse) != nil {
+			continue
+		}
+		for _, call := range toolUse.ToolUse.ToolUses {
+			want[call.ID] = call.Name
+		}
+	}
+	if len(want) == 0 {
+		t.Fatal("fixture carries no tool calls; the assertion would be vacuous")
+	}
+
+	got := map[string]string{}
+	for _, line := range stored {
+		if compactKind(line) != "assistant" {
+			continue
+		}
+		for _, block := range compactMessageContent(line) {
+			var typ string
+			if json.Unmarshal(block["type"], &typ) != nil || typ != "tool_use" {
+				continue
+			}
+			var id, name string
+			_ = json.Unmarshal(block["id"], &id)
+			_ = json.Unmarshal(block["name"], &name)
+			if _, ok := block["input"]; !ok {
+				t.Errorf("tool_use %q has no %q field; stripAssistantContent keeps input, not args", id, "input")
+			}
+			got[id] = name
+		}
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("tool_use blocks = %v, want %v", got, want)
+	}
+}
+
+// TestToolResultBlocksMatchExtractUserContent pins the user-side tool result
+// shape to what compact.go:665 reads: snake_case "tool_use_id" and a STRING
+// "content". inlineToolResults (compact.go:454) then matches it back onto the
+// assistant's tool_use block by that id.
+func TestToolResultBlocksMatchExtractUserContent(t *testing.T) {
+	entries := sourceHistory(t)
+	stored := decodeStoredLines(t, storedTranscript(t))
+
+	want := map[string]string{}
+	for _, e := range entries {
+		var results kiroToolUseResultsContent
+		if json.Unmarshal(e.User.Content, &results) != nil {
+			continue
+		}
+		for _, r := range results.ToolUseResults.ToolUseResults {
+			want[r.ID] = toolResultText(r.Result)
+		}
+	}
+	if len(want) == 0 {
+		t.Fatal("fixture carries no tool results; the assertion would be vacuous")
+	}
+
+	got := map[string]string{}
+	for _, line := range stored {
+		if compactKind(line) != "user" {
+			continue
+		}
+		for _, block := range compactMessageContent(line) {
+			var typ string
+			if json.Unmarshal(block["type"], &typ) != nil || typ != "tool_result" {
+				continue
+			}
+			var id, content string
+			if err := json.Unmarshal(block["tool_use_id"], &id); err != nil {
+				t.Errorf("tool_result has no snake_case %q: %v", "tool_use_id", err)
+				continue
+			}
+			if err := json.Unmarshal(block["content"], &content); err != nil {
+				t.Errorf("tool_result %q content is not a JSON string: %v", id, err)
+				continue
+			}
+			got[id] = content
+		}
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("tool_result blocks = %v, want %v", got, want)
+	}
+}
+
+// --- line-offset scoping ---
+
+func TestSliceFromLineKeepsEveryScopedSliceValidJSONL(t *testing.T) {
+	stored := storedTranscript(t)
+	total := countTranscriptLines(stored)
+	if total < 2 {
+		t.Fatalf("stored transcript has %d lines; need at least 2 to test scoping", total)
+	}
+
+	for start := 1; start < total; start++ {
+		scoped := sliceFromLine(stored, start)
+		if len(scoped) == 0 {
+			t.Fatalf("slice from line %d is empty", start)
+		}
+		if got := countTranscriptLines(scoped); got != total-start {
+			t.Errorf("slice from line %d has %d lines, want %d", start, got, total-start)
+		}
+		parsed, err := decodeTranscriptJSONL(scoped)
+		if err != nil {
+			t.Fatalf("slice from line %d does not decode: %v", start, err)
+		}
+		if len(parsed.History) == 0 {
+			t.Errorf("slice from line %d decodes to no history", start)
+		}
+		// Session-level fields are stamped per record, so a header-less slice
+		// still carries them.
+		if parsed.ConversationID == "" {
+			t.Errorf("slice from line %d lost conversation_id", start)
+		}
+	}
+}
+
+func TestScopedSliceStartingMidEntryKeepsTheSurvivingHalf(t *testing.T) {
+	stored := storedTranscript(t)
+	// Line 1 starts on an assistant record whose user half was cut away.
+	scoped := sliceFromLine(stored, 1)
+	parsed, err := decodeTranscriptJSONL(scoped)
+	if err != nil {
+		t.Fatalf("decode mid-entry slice: %v", err)
+	}
+	if len(parsed.History) == 0 {
+		t.Fatal("mid-entry slice decoded to no history")
+	}
+	first := parsed.History[0]
+	if len(first.Assistant) == 0 {
+		t.Error("mid-entry slice dropped the assistant half that survived the cut")
+	}
+	if len(first.User.Content) != 0 {
+		t.Error("mid-entry slice invented a user half that was sliced away")
+	}
+}
+
+func TestGetTranscriptPositionCountsStoredLines(t *testing.T) {
+	stored := storedTranscript(t)
+	path := storedTranscriptFile(t, stored)
+
+	pos, err := New().GetTranscriptPosition(path)
+	if err != nil {
+		t.Fatalf("GetTranscriptPosition() error = %v", err)
+	}
+	want := countTranscriptLines(stored)
+	if pos != want {
+		t.Fatalf("GetTranscriptPosition() = %d, want %d (stored line count)", pos, want)
+	}
+	// The unit must be lines, not history entries — that is the whole point of
+	// the change, and the two differ because entries are split in half.
+	if entries := len(sourceHistory(t)); pos == entries {
+		t.Fatalf("GetTranscriptPosition() = %d, which is the history-entry count; SliceFromLine consumes LINES", pos)
+	}
+}
+
+func TestExtractPromptsScopesByStoredLine(t *testing.T) {
+	stored := storedTranscript(t)
+	path := storedTranscriptFile(t, stored)
+	total := countTranscriptLines(stored)
+
+	all, err := New().ExtractPrompts(path, 0)
+	if err != nil {
+		t.Fatalf("ExtractPrompts(0) error = %v", err)
+	}
+	if len(all) == 0 {
+		t.Fatal("ExtractPrompts(0) returned nothing")
+	}
+
+	// Scoping by line must agree with what Entire itself would see after
+	// SliceFromLine at the same offset.
+	for start := 1; start < total; start++ {
+		got, err := New().ExtractPrompts(path, start)
+		if err != nil {
+			t.Fatalf("ExtractPrompts(%d) error = %v", start, err)
+		}
+		scopedPath := storedTranscriptFile(t, sliceFromLine(stored, start))
+		want, err := New().ExtractPrompts(scopedPath, 0)
+		if err != nil {
+			t.Fatalf("ExtractPrompts on pre-sliced file error = %v", err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("ExtractPrompts(offset=%d) = %v, but Entire's own slice yields %v", start, got, want)
+		}
+	}
+}
+
+func TestExtractModifiedFilesScopesByStoredLine(t *testing.T) {
+	stored := storedTranscript(t)
+	path := storedTranscriptFile(t, stored)
+
+	files, total, err := New().ExtractModifiedFiles(path, 0)
+	if err != nil {
+		t.Fatalf("ExtractModifiedFiles(0) error = %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("ExtractModifiedFiles(0) found no files")
+	}
+	if want := countTranscriptLines(stored); total != want {
+		t.Errorf("ExtractModifiedFiles total = %d, want %d (stored line count)", total, want)
+	}
+
+	// Scoping past the last write must drop it.
+	last, _, err := New().ExtractModifiedFiles(path, total)
+	if err != nil {
+		t.Fatalf("ExtractModifiedFiles(total) error = %v", err)
+	}
+	if len(last) != 0 {
+		t.Errorf("ExtractModifiedFiles at end-of-file = %v, want none", last)
+	}
+}
+
+// --- round trip and back-compat ---
+
+func TestStoredTranscriptRoundTripsBackToTheSourceHistory(t *testing.T) {
+	want := sourceHistory(t)
+	got, err := decodeTranscriptJSONL(storedTranscript(t))
+	if err != nil {
+		t.Fatalf("decodeTranscriptJSONL: %v", err)
+	}
+	if len(got.History) != len(want) {
+		t.Fatalf("round-tripped history = %d entries, want %d", len(got.History), len(want))
+	}
+	for i := range want {
+		// Compare semantically: the source fixture is pretty-printed, so the
+		// raw bytes differ by whitespace even when the payload is identical.
+		if !sameJSON(t, got.History[i].User.Content, want[i].User.Content) {
+			t.Errorf("entry %d user content = %s, want %s", i, got.History[i].User.Content, want[i].User.Content)
+		}
+		if !sameJSON(t, got.History[i].Assistant, want[i].Assistant) {
+			t.Errorf("entry %d assistant = %s, want %s", i, got.History[i].Assistant, want[i].Assistant)
+		}
+	}
+	if got.ConversationID == "" {
+		t.Error("round trip lost conversation_id")
+	}
+}
+
+// TestLegacyWholeDocumentTranscriptStillReads is the back-compat guarantee: a
+// transcript written by an older build keeps reading, in the history-entry unit
+// the positions recorded against it were taken in. The next capture rewrites it
+// as JSONL and the unit moves with the bytes.
+func TestLegacyWholeDocumentTranscriptStillReads(t *testing.T) {
+	path := storedTranscriptFile(t, []byte(testCLIAnalyzerTranscript))
+
+	pos, err := New().GetTranscriptPosition(path)
+	if err != nil {
+		t.Fatalf("GetTranscriptPosition(legacy) error = %v", err)
+	}
+	if want := len(sourceHistory(t)); pos != want {
+		t.Fatalf("GetTranscriptPosition(legacy) = %d, want %d history entries", pos, want)
+	}
+
+	prompts, err := New().ExtractPrompts(path, 0)
+	if err != nil {
+		t.Fatalf("ExtractPrompts(legacy) error = %v", err)
+	}
+	if len(prompts) == 0 {
+		t.Error("legacy transcript yielded no prompts")
+	}
+
+	files, _, err := New().ExtractModifiedFiles(path, 0)
+	if err != nil {
+		t.Fatalf("ExtractModifiedFiles(legacy) error = %v", err)
+	}
+	if len(files) == 0 {
+		t.Error("legacy transcript yielded no modified files")
+	}
+}
+
+func TestPlaceholderTranscriptStillReportsZero(t *testing.T) {
+	path := storedTranscriptFile(t, []byte("{}"))
+	pos, err := New().GetTranscriptPosition(path)
+	if err != nil {
+		t.Fatalf("GetTranscriptPosition(placeholder) error = %v", err)
+	}
+	if pos != 0 {
+		t.Fatalf("GetTranscriptPosition(placeholder) = %d, want 0", pos)
+	}
+}
+
+func TestMaterializeLeavesUnrecognisedDocumentsAlone(t *testing.T) {
+	for _, in := range []string{"{}", "", "not json at all", `{"history":[]}`} {
+		if _, ok := materializeTranscript([]byte(in)); ok {
+			t.Errorf("materializeTranscript(%q) claimed to convert an unrecognised document", in)
+		}
+	}
+}
+
+func TestSessionFieldsAreStampedOnEveryRecord(t *testing.T) {
+	for i, line := range decodeStoredLines(t, storedTranscript(t)) {
+		var conv string
+		if json.Unmarshal(line["conversation_id"], &conv) != nil || conv == "" {
+			t.Errorf("line %d has no conversation_id; a scoped slice past line 0 would lose it", i)
+		}
+	}
+}
+
+func TestIDETranscriptAlsoMaterializesAsJSONL(t *testing.T) {
+	data, ok := materializeTranscript([]byte(testIDEAnalyzerTranscript))
+	if !ok {
+		t.Fatal("IDE transcript did not materialize")
+	}
+	lines := decodeStoredLines(t, data)
+	if len(lines) == 0 {
+		t.Fatal("IDE transcript materialized to no lines")
+	}
+	var withContent int
+	for _, line := range lines {
+		if compactKind(line) != "" && len(compactMessageContent(line)) > 0 {
+			withContent++
+		}
+	}
+	if withContent == 0 {
+		t.Fatal("no IDE line survives both halves of the compact contract")
+	}
+	if !strings.Contains(string(data), "Open the workspace") {
+		t.Error("IDE prompt text did not survive materialization")
+	}
+}
+
+// sameJSON reports whether two raw JSON payloads are semantically equal,
+// ignoring formatting.
+func sameJSON(t *testing.T, a, b json.RawMessage) bool {
+	t.Helper()
+	if len(a) == 0 || len(b) == 0 {
+		return len(a) == len(b)
+	}
+	var av, bv any
+	if err := json.Unmarshal(a, &av); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(b, &bv); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(av, bv)
+}
+
+// TestEnsureCachedTranscriptStoresJSONLOnDisk is the end-to-end guard on the
+// write path: it is not enough for the encoder to be correct, the capture path
+// has to actually run the transcript through it before writing. Without that
+// call the file on disk stays a single JSON document and every checkpoint's
+// transcript.jsonl is empty again.
+func TestEnsureCachedTranscriptStoresJSONLOnDisk(t *testing.T) {
+	repoRoot := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("ENTIRE_REPO_ROOT", repoRoot)
+	t.Setenv("HOME", home)
+
+	stubData := buildTranscript("cli-session", 3)
+	createFakeKiroDB(t, home)
+	restore := stubSQLiteRunner(t, func(_ ...string) ([]byte, error) {
+		return stubData, nil
+	})
+	defer restore()
+
+	cachePath, err := New().ensureCachedTranscript(repoRoot, "stable-session", "")
+	if err != nil {
+		t.Fatalf("ensureCachedTranscript() error = %v", err)
+	}
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		t.Fatalf("read cached transcript: %v", err)
+	}
+
+	// The stored file must be JSONL, one record per line...
+	lines := decodeStoredLines(t, data)
+	if len(lines) < 2 {
+		t.Fatalf("stored transcript has %d lines; a single JSON document is what this replaces", len(lines))
+	}
+	// ...and every content-bearing line must satisfy both halves of Entire's
+	// compact contract.
+	survivors := 0
+	for i, line := range lines {
+		kind := compactKind(line)
+		if kind == "" {
+			continue
+		}
+		if len(compactMessageContent(line)) == 0 {
+			t.Errorf("stored line %d (%s) is an empty envelope", i, kind)
+			continue
+		}
+		survivors++
+	}
+	if survivors == 0 {
+		t.Fatal("no stored line satisfies normalizeKind + parseMessage")
+	}
+
+	// And the position Entire records must be the stored line count, because
+	// that is the unit SliceFromLine consumes.
+	pos, err := New().GetTranscriptPosition(cachePath)
+	if err != nil {
+		t.Fatalf("GetTranscriptPosition() error = %v", err)
+	}
+	if pos != len(lines) {
+		t.Fatalf("GetTranscriptPosition() = %d, want %d stored lines", pos, len(lines))
+	}
+	if !strings.Contains(string(data), "prompt 0") {
+		t.Error("prompt text did not survive the write path")
+	}
+}

--- a/agents/entire-agent-kiro/internal/kiro/large_record_test.go
+++ b/agents/entire-agent-kiro/internal/kiro/large_record_test.go
@@ -1,0 +1,26 @@
+package kiro
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestProjectedLargeMessageRoundTrip(t *testing.T) {
+	large := strings.Repeat("x", 6*1024*1024)
+	raw, err := json.Marshal(map[string]any{"conversation_id": "large", "history": []any{map[string]any{"user": map[string]any{"content": map[string]any{"Prompt": map[string]any{"prompt": large}}}}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, ok := materializeTranscript(raw)
+	if !ok {
+		t.Fatal("materialization failed")
+	}
+	decoded, err := decodeTranscriptJSONL(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.History) != 1 || extractUserPrompt(decoded.History[0].User.Content) != large {
+		t.Fatal("large message lost")
+	}
+}

--- a/agents/entire-agent-kiro/internal/kiro/session_jsonl.go
+++ b/agents/entire-agent-kiro/internal/kiro/session_jsonl.go
@@ -1,0 +1,411 @@
+package kiro
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const maxTranscriptLine = 10 * 1024 * 1024
+
+// roleUser and roleAssistant are the only two kinds normalizeKind
+// (cmd/entire/cli/transcript/compact/compact.go:197) accepts. A line that
+// yields neither is dropped from the compact transcript.
+const (
+	roleUser      = "user"
+	roleAssistant = "assistant"
+)
+
+// The materialized transcript is stored as JSONL: one message per line, in
+// order, with no header line. Entire scopes external-agent transcripts by LINE
+// offset (transcript.SliceFromLine, cmd/entire/cli/transcript/parse.go:130)
+// before compacting them — see cmd/entire/cli/explain.go:1883
+// (scopeTranscriptForCheckpoint) and
+// cmd/entire/cli/strategy/manual_commit_condensation.go:1006 — so kiro's native
+// single-JSON-document transcript was destroyed by that slicing: every
+// checkpoint compacted a fragment of one pretty-printed object and produced
+// nothing at all.
+//
+// Line SHAPE matters as much as line COUNT. An external agent's transcript is
+// compacted by the generic JSONL reader in
+// cmd/entire/cli/transcript/compact/compact.go, which keeps a line only when
+// BOTH of these hold:
+//
+//   - normalizeKind (compact.go:197) finds a TOP-LEVEL "type", falling back to
+//     "role", of "user" or "assistant".
+//   - parseMessage (compact.go:617) finds the content under a TOP-LEVEL
+//     "message" object: "All JSONL agents nest content inside a 'message'
+//     object."
+//
+// Kiro satisfied neither: its history entries carry content under "user" and
+// "assistant" keys of a paired entry, which is not where Entire looks, and
+// there is no top-level "type" at all.
+//
+// ONE HISTORY ENTRY BECOMES TWO LINES. A kiroHistoryEntry is PAIRED —
+// {"user":…,"assistant":…} — and normalizeKind yields exactly one kind per
+// line, so a paired entry cannot survive as a single line without discarding
+// one of its halves. The user half and the assistant half are therefore
+// emitted as separate records carrying the same "entry" index, which is what
+// decodeTranscriptJSONL groups them back by.
+//
+// That doubling is why get-transcript-position now reports a LINE count rather
+// than len(History). The unit change is safe because a position and the bytes
+// it indexes are always stored together: a checkpoint keeps its own transcript
+// blob (checkpoint.SessionContent.Transcript, api/checkpoint/metadata.go:376)
+// alongside its own CheckpointTranscriptStart, and Entire re-applies that
+// position only to that blob — "CheckpointTranscriptStart indexes the stored
+// format" (cmd/entire/cli/explain.go:2132). A historical checkpoint written by
+// an older build therefore keeps reading in its own units forever; nothing ever
+// applies an entry-count position to a line-counted file.
+//
+// The one window where units can cross is a session already in flight when the
+// binary is upgraded, whose live state still holds an entry-count
+// CheckpointTranscriptStart. Applying it to a line-counted file skips too few
+// lines, so that single checkpoint over-includes some already-checkpointed
+// content — the bounded head overlap Entire's own compactor documents as
+// tolerable (compact.go:139-147) — and never drops any. It self-heals at the
+// next condensation, which rewrites CheckpointTranscriptStart from the new
+// count (cmd/entire/cli/strategy/manual_commit_hooks.go:1529,1548).
+//
+// The transcript's session-level fields (conversation_id, cli_version) are
+// stamped onto EVERY record rather than kept in a header. They cannot live in a
+// header: SliceFromLine hands a mid-session checkpoint a slice that starts past
+// line 0, and a header there is gone.
+
+// transcriptRecord is one on-disk JSONL line: one half of a kiro history entry,
+// the stamped session-level fields, and the Entire-facing projection.
+//
+// User and Assistant hold kiro's native payloads verbatim and are authoritative
+// for kiro's own decoding. Type/Timestamp/Message are derived data for Entire's
+// compactor; parsing ignores them, so a record written by a different build
+// still reads.
+type transcriptRecord struct {
+	ConversationID string `json:"conversation_id,omitempty"`
+	CLIVersion     string `json:"cli_version,omitempty"`
+
+	// Entry is the index of the source history entry this record is one half
+	// of. It is a pointer with no omitempty so it is always emitted (entry 0
+	// included) and its absence is detectable: it is the marker that tells
+	// parseTranscript a document is JSONL rather than a legacy whole-document
+	// transcript.
+	Entry *int `json:"entry"`
+
+	User      *kiroUserMessage `json:"user,omitempty"`
+	Assistant json.RawMessage  `json:"assistant,omitempty"`
+
+	Type      string       `json:"type,omitempty"`
+	Timestamp string       `json:"timestamp,omitempty"`
+	Message   *wireMessage `json:"message,omitempty"`
+}
+
+// wireMessage is the "message" wrapper Entire's compactJSONL reads content from
+// (compact.go:617).
+type wireMessage struct {
+	Role    string `json:"role"`
+	ID      string `json:"id,omitempty"`
+	Content []any  `json:"content"`
+}
+
+// wireTextBlock is a text content block, read by both the user path
+// (extractUserContent, compact.go:665) and the assistant path
+// (stripAssistantContent, compact.go:704).
+type wireTextBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// wireToolUseBlock is an assistant tool call. stripAssistantContent
+// (compact.go:704) keeps exactly type/id/name/input from a "tool_use" block and
+// discards everything else, so those are the only fields worth emitting.
+type wireToolUseBlock struct {
+	Type  string          `json:"type"`
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name"`
+	Input json.RawMessage `json:"input,omitempty"`
+}
+
+// wireToolResultBlock is a user-side tool result. extractUserContent
+// (compact.go:665) reads snake_case "tool_use_id" and a STRING "content";
+// inlineToolResults (compact.go:454) then matches it back onto the assistant's
+// tool_use block by that id.
+type wireToolResultBlock struct {
+	Type      string `json:"type"`
+	ToolUseID string `json:"tool_use_id,omitempty"`
+	Content   string `json:"content"`
+	IsError   bool   `json:"is_error,omitempty"`
+}
+
+// materializeTranscript converts a native kiro transcript document into the
+// stored JSONL form. It reports false when data is not a transcript this build
+// understands, in which case callers store the bytes verbatim — an unrecognised
+// kiro version must not break checkpointing.
+func materializeTranscript(data []byte) ([]byte, bool) {
+	parsed, err := parseTranscript(data)
+	if err != nil || len(parsed.History) == 0 {
+		return nil, false
+	}
+	encoded, err := encodeTranscriptJSONL(parsed)
+	if err != nil || len(encoded) == 0 {
+		return nil, false
+	}
+	return encoded, true
+}
+
+// encodeTranscriptJSONL renders a transcript as JSONL, emitting the user half
+// and the assistant half of each history entry as separate records sharing an
+// "entry" index.
+//
+// A half with no native payload is skipped rather than emitted empty: a line
+// carrying a "type" but no content would compact into an empty envelope, which
+// is indistinguishable from the bug this format exists to fix. A half whose
+// payload this build cannot project into content blocks is still written (so
+// kiro's own extractors keep seeing it) but carries no "type", so normalizeKind
+// (compact.go:197) drops it instead of emitting an empty envelope.
+func encodeTranscriptJSONL(t *kiroTranscript) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+
+	for i := range t.History {
+		entry := t.History[i]
+		idx := i
+
+		if len(entry.User.Content) > 0 {
+			rec := transcriptRecord{
+				ConversationID: t.ConversationID,
+				CLIVersion:     t.CLIVersion,
+				Entry:          &idx,
+				User:           &entry.User,
+				Timestamp:      entry.User.Timestamp,
+			}
+			if blocks := userContentBlocks(entry.User.Content); len(blocks) > 0 {
+				rec.Type = roleUser
+				rec.Message = &wireMessage{Role: roleUser, Content: blocks}
+			}
+			if err := enc.Encode(rec); err != nil {
+				return nil, fmt.Errorf("encode kiro transcript: %w", err)
+			}
+		}
+
+		if len(entry.Assistant) > 0 {
+			rec := transcriptRecord{
+				ConversationID: t.ConversationID,
+				CLIVersion:     t.CLIVersion,
+				Entry:          &idx,
+				Assistant:      entry.Assistant,
+				Timestamp:      entry.User.Timestamp,
+			}
+			if blocks, id := assistantContentBlocks(entry.Assistant); len(blocks) > 0 {
+				rec.Type = roleAssistant
+				rec.Message = &wireMessage{Role: roleAssistant, ID: id, Content: blocks}
+			}
+			if err := enc.Encode(rec); err != nil {
+				return nil, fmt.Errorf("encode kiro transcript: %w", err)
+			}
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+// userContentBlocks projects a kiro user payload — a tagged union of Prompt and
+// ToolUseResults — into Claude content blocks.
+func userContentBlocks(content json.RawMessage) []any {
+	if prompt := extractUserPrompt(content); prompt != "" {
+		return []any{wireTextBlock{Type: "text", Text: prompt}}
+	}
+
+	var results kiroToolUseResultsContent
+	if err := json.Unmarshal(content, &results); err != nil {
+		return nil
+	}
+	var blocks []any
+	for _, r := range results.ToolUseResults.ToolUseResults {
+		blocks = append(blocks, wireToolResultBlock{
+			Type:      "tool_result",
+			ToolUseID: r.ID,
+			Content:   toolResultText(r.Result),
+			IsError:   r.IsError || r.Status == compactToolResultError,
+		})
+	}
+	return blocks
+}
+
+// toolResultText renders a kiro tool result payload as the plain string
+// extractUserContent (compact.go:665) expects under "content". A result that is
+// already a JSON string is unquoted; anything else is kept as its JSON text.
+func toolResultText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	return string(raw)
+}
+
+// assistantContentBlocks projects a kiro assistant payload — a tagged union of
+// Response and ToolUse — into Claude content blocks, returning the blocks and
+// kiro's message id.
+func assistantContentBlocks(raw json.RawMessage) ([]any, string) {
+	var response kiroResponseContent
+	if err := json.Unmarshal(raw, &response); err == nil && response.Response.Content != "" {
+		return []any{wireTextBlock{Type: "text", Text: response.Response.Content}}, response.Response.MessageID
+	}
+
+	var toolUse kiroToolUseContent
+	if err := json.Unmarshal(raw, &toolUse); err == nil && len(toolUse.ToolUse.ToolUses) > 0 {
+		var blocks []any
+		for _, call := range toolUse.ToolUse.ToolUses {
+			blocks = append(blocks, wireToolUseBlock{
+				Type:  "tool_use",
+				ID:    call.ID,
+				Name:  call.Name,
+				Input: call.Args,
+			})
+		}
+		return blocks, toolUse.ToolUse.MessageID
+	}
+
+	return nil, ""
+}
+
+var errNotTranscriptJSONL = errors.New("not kiro transcript JSONL")
+
+// decodeTranscriptJSONL reads the stored JSONL form back into a transcript,
+// regrouping records into paired history entries by their "entry" index.
+//
+// It tolerates a slice that starts mid-entry: SliceFromLine cuts on line
+// boundaries, not entry boundaries, so the first entry of a scoped transcript
+// may have lost its user half. Such an entry is reconstructed with only the
+// half that survived.
+func decodeTranscriptJSONL(data []byte) (*kiroTranscript, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 64*1024), maxTranscriptLine)
+
+	t := &kiroTranscript{}
+	var cur *kiroHistoryEntry
+	curEntry := 0
+	saw := false
+
+	flush := func() {
+		if cur != nil {
+			t.History = append(t.History, *cur)
+			cur = nil
+		}
+	}
+
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var rec transcriptRecord
+		if err := json.Unmarshal(line, &rec); err != nil {
+			return nil, errNotTranscriptJSONL
+		}
+		// The "entry" marker is what distinguishes this format from a legacy
+		// whole-document transcript that happens to fit on one line.
+		if rec.Entry == nil {
+			return nil, errNotTranscriptJSONL
+		}
+
+		if cur == nil || *rec.Entry != curEntry {
+			flush()
+			cur = &kiroHistoryEntry{}
+			curEntry = *rec.Entry
+		}
+		if rec.User != nil {
+			cur.User = *rec.User
+		}
+		if len(rec.Assistant) > 0 {
+			cur.Assistant = rec.Assistant
+		}
+		if t.ConversationID == "" {
+			t.ConversationID = rec.ConversationID
+		}
+		if t.CLIVersion == "" {
+			t.CLIVersion = rec.CLIVersion
+		}
+		saw = true
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read kiro transcript: %w", err)
+	}
+	flush()
+
+	if !saw {
+		return nil, errNotTranscriptJSONL
+	}
+	return t, nil
+}
+
+// countTranscriptLines counts the JSONL records in a stored transcript. This is
+// the unit get-transcript-position reports and the unit
+// transcript.SliceFromLine consumes.
+func countTranscriptLines(data []byte) int {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 64*1024), maxTranscriptLine)
+	n := 0
+	for scanner.Scan() {
+		if len(bytes.TrimSpace(scanner.Bytes())) > 0 {
+			n++
+		}
+	}
+	return n
+}
+
+// sliceTranscriptLines drops the first startLine records of a stored
+// transcript, mirroring transcript.SliceFromLine
+// (cmd/entire/cli/transcript/parse.go:130) so kiro's extractors scope to the
+// same content Entire checkpoints.
+func sliceTranscriptLines(data []byte, startLine int) []byte {
+	if startLine <= 0 {
+		return data
+	}
+	count, offset := 0, 0
+	for i, b := range data {
+		if b == '\n' {
+			count++
+			if count == startLine {
+				offset = i + 1
+				break
+			}
+		}
+	}
+	if count < startLine || offset >= len(data) {
+		return nil
+	}
+	return data[offset:]
+}
+
+// atomicWriteFile writes data to path via a temporary file in the same
+// directory and renames it into place, so a concurrent reader never observes a
+// half-written transcript.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, ".kiro-transcript-")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	defer func() { _ = os.Remove(tmp) }()
+
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Chmod(perm); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/agents/entire-agent-kiro/internal/kiro/session_jsonl.go
+++ b/agents/entire-agent-kiro/internal/kiro/session_jsonl.go
@@ -284,7 +284,6 @@ var errNotTranscriptJSONL = errors.New("not kiro transcript JSONL")
 // Iterate the bytes already in memory: the native payload plus its projection
 // can exceed Scanner's line limit even when the source message fits it.
 func decodeTranscriptJSONL(data []byte) (*kiroTranscript, error) {
-
 	t := &kiroTranscript{}
 	var cur *kiroHistoryEntry
 	curEntry := 0

--- a/agents/entire-agent-kiro/internal/kiro/session_jsonl.go
+++ b/agents/entire-agent-kiro/internal/kiro/session_jsonl.go
@@ -1,7 +1,6 @@
 package kiro
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -9,8 +8,6 @@ import (
 	"os"
 	"path/filepath"
 )
-
-const maxTranscriptLine = 10 * 1024 * 1024
 
 // roleUser and roleAssistant are the only two kinds normalizeKind
 // (cmd/entire/cli/transcript/compact/compact.go:197) accepts. A line that
@@ -284,9 +281,9 @@ var errNotTranscriptJSONL = errors.New("not kiro transcript JSONL")
 // boundaries, not entry boundaries, so the first entry of a scoped transcript
 // may have lost its user half. Such an entry is reconstructed with only the
 // half that survived.
+// Iterate the bytes already in memory: the native payload plus its projection
+// can exceed Scanner's line limit even when the source message fits it.
 func decodeTranscriptJSONL(data []byte) (*kiroTranscript, error) {
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-	scanner.Buffer(make([]byte, 0, 64*1024), maxTranscriptLine)
 
 	t := &kiroTranscript{}
 	var cur *kiroHistoryEntry
@@ -300,8 +297,8 @@ func decodeTranscriptJSONL(data []byte) (*kiroTranscript, error) {
 		}
 	}
 
-	for scanner.Scan() {
-		line := bytes.TrimSpace(scanner.Bytes())
+	for rawLine := range bytes.SplitSeq(data, []byte{'\n'}) {
+		line := bytes.TrimSpace(rawLine)
 		if len(line) == 0 {
 			continue
 		}
@@ -334,9 +331,6 @@ func decodeTranscriptJSONL(data []byte) (*kiroTranscript, error) {
 		}
 		saw = true
 	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("read kiro transcript: %w", err)
-	}
 	flush()
 
 	if !saw {
@@ -349,11 +343,9 @@ func decodeTranscriptJSONL(data []byte) (*kiroTranscript, error) {
 // the unit get-transcript-position reports and the unit
 // transcript.SliceFromLine consumes.
 func countTranscriptLines(data []byte) int {
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-	scanner.Buffer(make([]byte, 0, 64*1024), maxTranscriptLine)
 	n := 0
-	for scanner.Scan() {
-		if len(bytes.TrimSpace(scanner.Bytes())) > 0 {
+	for rawLine := range bytes.SplitSeq(data, []byte{'\n'}) {
+		if len(bytes.TrimSpace(rawLine)) > 0 {
 			n++
 		}
 	}

--- a/agents/entire-agent-kiro/internal/kiro/transcript.go
+++ b/agents/entire-agent-kiro/internal/kiro/transcript.go
@@ -274,7 +274,15 @@ func (a *Agent) ensureCachedTranscript(cwd string, sessionID string, conversatio
 		return "", errors.New("CLI transcript has no history entries")
 	}
 
-	if err := os.WriteFile(cachePath, data, 0o600); err != nil {
+	// Store as JSONL. The native document is an ingestion format only: writing
+	// it verbatim is what made every checkpoint's compact transcript empty,
+	// because Entire slices external-agent transcripts by line before
+	// compacting them (see session_jsonl.go). A transcript this build cannot
+	// parse is stored verbatim rather than discarded.
+	if jsonl, ok := materializeTranscript(data); ok {
+		data = jsonl
+	}
+	if err := atomicWriteFile(cachePath, data, 0o600); err != nil {
 		return "", fmt.Errorf("failed to write cached transcript: %w", err)
 	}
 	return cachePath, nil
@@ -464,7 +472,11 @@ func (a *Agent) ensureIDETranscript(cwd string, entireSessionID string, ideSessi
 	if err != nil {
 		return "", err
 	}
-	if err := os.WriteFile(cachePath, data, 0o600); err != nil {
+	// Stored as JSONL for the same reason as the CLI path above.
+	if jsonl, ok := materializeTranscript(data); ok {
+		data = jsonl
+	}
+	if err := atomicWriteFile(cachePath, data, 0o600); err != nil {
 		return "", fmt.Errorf("failed to write cached IDE transcript: %w", err)
 	}
 	return cachePath, nil
@@ -704,19 +716,27 @@ func escapeSQLString(s string) string {
 	return strings.ReplaceAll(s, "'", "''")
 }
 
+// GetTranscriptPosition reports the size of the stored transcript in the unit
+// Entire scopes by. For the JSONL form that unit is the LINE count, because
+// transcript.SliceFromLine (cmd/entire/cli/transcript/parse.go:130) is what
+// Entire applies to this file. A legacy whole-document transcript written by an
+// older build keeps reporting its history-entry count, which is the unit the
+// positions recorded against it were taken in; the next capture rewrites it as
+// JSONL and the unit moves with the bytes. See session_jsonl.go for why that
+// unit change is safe.
 func (a *Agent) GetTranscriptPosition(path string) (int, error) {
-	transcript, err := readAndParseTranscript(path)
+	scoped, err := readScopedTranscript(path, 0)
 	if errors.Is(err, os.ErrNotExist) {
 		return 0, nil
 	}
 	if err != nil {
 		return 0, err
 	}
-	return len(transcript.History), nil
+	return scoped.total, nil
 }
 
 func (a *Agent) ExtractModifiedFiles(path string, offset int) ([]string, int, error) {
-	transcript, err := readAndParseTranscript(path)
+	scoped, err := readScopedTranscript(path, offset)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil, 0, nil
 	}
@@ -724,16 +744,11 @@ func (a *Agent) ExtractModifiedFiles(path string, offset int) ([]string, int, er
 		return nil, 0, err
 	}
 
-	totalEntries := len(transcript.History)
-	if offset >= totalEntries {
-		return nil, totalEntries, nil
-	}
-
-	return extractModifiedFilesFromHistory(transcript.History[offset:]), totalEntries, nil
+	return extractModifiedFilesFromHistory(scoped.entries), scoped.total, nil
 }
 
 func (a *Agent) ExtractPrompts(path string, offset int) ([]string, error) {
-	transcript, err := readAndParseTranscript(path)
+	scoped, err := readScopedTranscript(path, offset)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil, nil
 	}
@@ -742,12 +757,53 @@ func (a *Agent) ExtractPrompts(path string, offset int) ([]string, error) {
 	}
 
 	var prompts []string
-	for i := offset; i < len(transcript.History); i++ {
-		if prompt := extractUserPrompt(transcript.History[i].User.Content); prompt != "" {
+	for i := range scoped.entries {
+		if prompt := extractUserPrompt(scoped.entries[i].User.Content); prompt != "" {
 			prompts = append(prompts, prompt)
 		}
 	}
 	return prompts, nil
+}
+
+// scopedTranscript is a transcript narrowed to the portion after a stored
+// offset, plus the total size of the file in the same unit that offset is
+// counted in.
+type scopedTranscript struct {
+	entries []kiroHistoryEntry
+	total   int
+}
+
+// readScopedTranscript reads a stored transcript and drops everything before
+// offset. The offset unit follows the stored format: JSONL is scoped by line
+// (matching transcript.SliceFromLine, which is what Entire applies to the same
+// file), a legacy whole-document transcript by history entry.
+func readScopedTranscript(path string, offset int) (scopedTranscript, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return scopedTranscript{}, err
+	}
+
+	if _, jsonlErr := decodeTranscriptJSONL(data); jsonlErr == nil {
+		total := countTranscriptLines(data)
+		if offset >= total {
+			return scopedTranscript{total: total}, nil
+		}
+		parsed, err := decodeTranscriptJSONL(sliceTranscriptLines(data, offset))
+		if err != nil {
+			return scopedTranscript{total: total}, fmt.Errorf("scope kiro transcript: %w", err)
+		}
+		return scopedTranscript{entries: parsed.History, total: total}, nil
+	}
+
+	transcript, err := parseTranscript(data)
+	if err != nil {
+		return scopedTranscript{}, err
+	}
+	total := len(transcript.History)
+	if offset >= total {
+		return scopedTranscript{total: total}, nil
+	}
+	return scopedTranscript{entries: transcript.History[offset:], total: total}, nil
 }
 
 func (a *Agent) ExtractSummary(path string) (string, bool, error) {
@@ -771,9 +827,17 @@ func readAndParseTranscript(path string) (*kiroTranscript, error) {
 	return parseTranscript(data)
 }
 
+// parseTranscript reads a stored kiro transcript. Transcripts are stored as
+// JSONL (see session_jsonl.go), but a native whole-document transcript written
+// by an older build is still accepted so those files keep reading; the next
+// capture rewrites them as JSONL.
 func parseTranscript(data []byte) (*kiroTranscript, error) {
 	if len(data) == 0 {
 		return &kiroTranscript{}, nil
+	}
+
+	if parsed, err := decodeTranscriptJSONL(data); err == nil {
+		return parsed, nil
 	}
 
 	var transcript kiroTranscript
@@ -816,12 +880,12 @@ func convertIDETranscript(ide *kiroIDETranscript) *kiroTranscript {
 	for i := range ide.History {
 		entry := &ide.History[i]
 		switch entry.Message.Role {
-		case "user":
+		case roleUser:
 			if pendingUser != nil {
 				transcript.History = append(transcript.History, ideEntryToPaired(pendingUser, nil))
 			}
 			pendingUser = entry
-		case "assistant":
+		case roleAssistant:
 			transcript.History = append(transcript.History, ideEntryToPaired(pendingUser, entry))
 			pendingUser = nil
 		}
@@ -1228,12 +1292,12 @@ func enrichIDETranscriptWithExecutionLogs(ideData []byte, execLogs map[string]*k
 		// Adapt meta entry to IDE entry (they share the same Message field)
 		ideEntry := &kiroIDEHistoryEntry{Message: meta.History[i].Message}
 		switch ideEntry.Message.Role {
-		case "user":
+		case roleUser:
 			if pendingUser != nil {
 				transcript.History = append(transcript.History, ideEntryToPaired(pendingUser, nil))
 			}
 			pendingUser = ideEntry
-		case "assistant":
+		case roleAssistant:
 			if execID := meta.History[i].ExecutionID; execID != "" {
 				if execLog, ok := execLogs[execID]; ok {
 					userEntry := ideEntryToPaired(pendingUser, nil)

--- a/agents/entire-agent-kiro/internal/kiro/transcript_test.go
+++ b/agents/entire-agent-kiro/internal/kiro/transcript_test.go
@@ -196,10 +196,7 @@ func TestEnsureCachedTranscriptWritesSQLiteTranscript(t *testing.T) {
 		t.Fatalf("read cached transcript: %v", err)
 	}
 
-	var result kiroTranscript
-	if err := json.Unmarshal(data, &result); err != nil {
-		t.Fatalf("parse cached transcript: %v", err)
-	}
+	result := mustParseStored(t, data)
 	if result.ConversationID != "cli-session" || len(result.History) != 2 || result.CLIVersion != "3.4.5" {
 		t.Fatalf("cached transcript conv=%q history=%d cli_version=%q, want cli-session/2/3.4.5", result.ConversationID, len(result.History), result.CLIVersion)
 	}
@@ -224,10 +221,7 @@ func TestEnsureCachedTranscriptWorksWithoutSQLite3BinaryOnPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read cached transcript: %v", err)
 	}
-	var result kiroTranscript
-	if err := json.Unmarshal(data, &result); err != nil {
-		t.Fatalf("parse cached transcript: %v", err)
-	}
+	result := mustParseStored(t, data)
 	if result.ConversationID != "native-session" || len(result.History) != 2 {
 		t.Fatalf("cached transcript conv=%q history=%d, want native-session/2", result.ConversationID, len(result.History))
 	}
@@ -273,11 +267,8 @@ func TestEnsureIDETranscriptCopiesLatestWorkspaceSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read cached IDE transcript: %v", err)
 	}
-	var result kiroIDETranscript
-	if err := json.Unmarshal(data, &result); err != nil {
-		t.Fatalf("parse cached IDE transcript: %v", err)
-	}
-	if result.CLIVersion != "4.5.6" || len(result.History) != 1 || result.History[0].Message.Content == nil {
+	result := mustParseStored(t, data)
+	if result.CLIVersion != "4.5.6" || len(result.History) != 1 || len(result.History[0].Assistant) == 0 {
 		t.Fatalf("cached IDE transcript = %+v", result)
 	}
 }
@@ -524,10 +515,7 @@ func TestParseHookStopPrefersSQLiteTranscript(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read cached transcript: %v", err)
 	}
-	var result kiroTranscript
-	if err := json.Unmarshal(data, &result); err != nil {
-		t.Fatalf("parse cached transcript: %v", err)
-	}
+	result := mustParseStored(t, data)
 	if result.ConversationID != "cli-session" || len(result.History) != 1 {
 		t.Fatalf("cached transcript conv=%q history=%d, want cli-session/1", result.ConversationID, len(result.History))
 	}
@@ -568,10 +556,7 @@ func TestParseHookStopFallsBackToIDETranscript(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read cached transcript: %v", err)
 	}
-	var result kiroIDETranscript
-	if err := json.Unmarshal(data, &result); err != nil {
-		t.Fatalf("parse cached IDE transcript: %v", err)
-	}
+	result := mustParseStored(t, data)
 	if result.CLIVersion != "4.5.6" || len(result.History) != 1 {
 		t.Fatalf("cached IDE transcript = %+v", result)
 	}
@@ -1028,10 +1013,7 @@ func TestEnsureCachedTranscriptTrimsWithOffset(t *testing.T) {
 		t.Fatalf("read cached transcript: %v", err)
 	}
 
-	var result kiroTranscript
-	if err := json.Unmarshal(data, &result); err != nil {
-		t.Fatalf("parse cached transcript: %v", err)
-	}
+	result := mustParseStored(t, data)
 
 	if len(result.History) != 4 {
 		t.Fatalf("history length = %d, want 4 (entries 4-7)", len(result.History))
@@ -1076,10 +1058,7 @@ func TestEnsureCachedTranscriptFirstCapture(t *testing.T) {
 		t.Fatalf("read cached transcript: %v", err)
 	}
 
-	var result kiroTranscript
-	if err := json.Unmarshal(data, &result); err != nil {
-		t.Fatalf("parse cached transcript: %v", err)
-	}
+	result := mustParseStored(t, data)
 
 	if len(result.History) != 4 {
 		t.Fatalf("history length = %d, want 4 (full transcript)", len(result.History))
@@ -1121,10 +1100,7 @@ func TestEnsureCachedTranscriptConversationIDChange(t *testing.T) {
 		t.Fatalf("read cached transcript: %v", err)
 	}
 
-	var result kiroTranscript
-	if err := json.Unmarshal(data, &result); err != nil {
-		t.Fatalf("parse cached transcript: %v", err)
-	}
+	result := mustParseStored(t, data)
 
 	// Full transcript (no trimming) since the new conversation gets its own
 	// per-key offset file independent of the old-conv bucket.
@@ -1174,10 +1150,7 @@ func TestEnsureCachedTranscriptOffsetExceedsLength(t *testing.T) {
 		t.Fatalf("read cached transcript: %v", err)
 	}
 
-	var result kiroTranscript
-	if err := json.Unmarshal(data, &result); err != nil {
-		t.Fatalf("parse cached transcript: %v", err)
-	}
+	result := mustParseStored(t, data)
 
 	// Full transcript (no trimming) since offset exceeds length.
 	if len(result.History) != 3 {
@@ -1221,10 +1194,7 @@ func TestEnsureCachedTranscriptNoNewEntriesReturnsFull(t *testing.T) {
 		t.Fatalf("read cached transcript: %v", err)
 	}
 
-	var result kiroTranscript
-	if err := json.Unmarshal(data, &result); err != nil {
-		t.Fatalf("parse cached transcript: %v", err)
-	}
+	result := mustParseStored(t, data)
 
 	// Full transcript returned (no trimming since offset == total).
 	if len(result.History) != 4 {
@@ -1472,9 +1442,8 @@ func TestEnsureIDETranscriptMergesToolCalls(t *testing.T) {
 	}
 
 	// Should be in CLI format with tool calls merged
-	var result kiroTranscript
-	if err := json.Unmarshal(data, &result); err != nil {
-		t.Fatalf("parse cached transcript: %v", err)
+	if result := mustParseStored(t, data); len(result.History) == 0 {
+		t.Fatal("cached transcript has no history entries")
 	}
 
 	// Extract modified files should find the tool call


### PR DESCRIPTION
## Summary

Kiro checkpoints were writing a **0-byte** `transcript.jsonl`. This is the last
of the six adapters with that failure (omp, kilo #70, amp #69, goose #71 and
qwen #72 cover the others).

Entire slices external-agent transcripts by **line offset** before compacting
them — `transcript.SliceFromLine` (`cmd/entire/cli/transcript/parse.go:130`),
applied at `cmd/entire/cli/explain.go:1883` and
`cmd/entire/cli/strategy/manual_commit_condensation.go:1006`. Kiro stored its
transcript as one pretty-printed JSON document, so every checkpoint compacted a
fragment of a single object and produced nothing.

Note that an adapter's own `compact-transcript` protocol method never runs on
this path: `cmd/entire/cli/checkpoint/persistent.go:1136` always uses Entire's
generic compactor. Kiro's `CompactTranscript` was correct and irrelevant.

## Both halves of the contract

The generic JSONL compactor keeps a line only when **both** hold:

| Requirement | cli reference | kiro before |
|---|---|---|
| top-level `type`, falling back to `role`, of `user`/`assistant` | `compact.go:197` `normalizeKind` | no top-level `type` at all |
| content under a top-level `message` object | `compact.go:617` `parseMessage` | content under the `user`/`assistant` keys of a paired entry |

Kiro failed both, so JSONL alone would have produced the right number of lines
carrying nothing.

## One history entry becomes two lines

`kiroHistoryEntry` is **paired** — `{"user":…,"assistant":…}` — and
`normalizeKind` yields exactly one kind per line, so a pair cannot survive as a
single line without discarding a half. The halves are emitted as separate
records sharing an `entry` index, which is what decoding groups them back by.

Session-level fields (`conversation_id`, `cli_version`) are stamped on **every**
record rather than kept in a header: `SliceFromLine` hands a mid-session
checkpoint a slice that starts past line 0, where a header is gone.

Payloads this build cannot project into content blocks are still written (so
kiro's own extractors keep seeing them) but carry no `type`, so `normalizeKind`
drops them instead of emitting an empty envelope.

## Why the position unit can change safely

`get-transcript-position` now reports a **line** count instead of `len(History)`.
That is the unit `SliceFromLine` consumes, and it matches every one of Entire's
built-in agents.

The reason this does not mis-scope existing checkpoints: **a position and the
bytes it indexes are always stored together.** A checkpoint keeps its own
transcript blob (`checkpoint.SessionContent.Transcript`,
`api/checkpoint/metadata.go:376`) alongside its own `CheckpointTranscriptStart`,
and Entire re-applies that position only to that blob —
"`CheckpointTranscriptStart` indexes the stored format"
(`cmd/entire/cli/explain.go:2132`). A historical checkpoint written by an older
build therefore keeps reading in its own units forever; nothing ever applies an
entry-count position to a line-counted file.

The one window where units can cross is a session already in flight when the
binary is upgraded, whose live state still holds an entry-count
`CheckpointTranscriptStart`. Applying it to a line-counted file skips **too
few** lines, so that single checkpoint over-includes some already-checkpointed
content — the bounded head overlap Entire's own compactor documents as tolerable
(`compact.go:139-147`) — and never drops any. It self-heals at the next
condensation, which rewrites the position in the new unit
(`manual_commit_hooks.go:1529,1548`).

A whole-document transcript written by an older build still parses, reported in
its original history-entry unit, so nothing breaks before that rewrite happens.

## Measured

Kiro's own committed fixture (`testCLIAnalyzerTranscript`) run through
cli@`main`'s real `SliceFromLine` + `compact.FullWithBoundary`:

| | raw | `transcript.jsonl` | lines carrying content |
|---|---|---|---|
| before | 1116 B | **0 B** | 0 |
| after | 2412 B | **1084 B** | 6 / 6 |

Content assertion, not just byte count — every prompt and response survives, and
tool results are inlined onto their `tool_use` blocks by `tool_use_id`
(`inlineToolResults`, `compact.go:454`):

```
{"v":1,"agent":"kiro",…,"type":"user","content":[{"text":"Create a hello.go file"}]}
{"v":1,"agent":"kiro",…,"type":"assistant","id":"msg-1","content":[{"text":"I'll create that file for you.","type":"text"}]}
…
{"v":1,"agent":"kiro",…,"type":"assistant","id":"msg-2","content":[{"id":"tu-1","input":{"path":"/repo/hello.go",…},"name":"fs_write","result":{"output":"ok","status":"success"},"type":"tool_use"}]}
```

Scoping works too: at `StartLine=4` the compactor reports `boundary=4` and a
387 B delta that still carries the final response.

## Testing

Every assertion runs the fixture through the **live encoder**, never against a
checked-in expected constant, so the tests fail when the encoder changes rather
than when a fixture drifts. The suite mirrors `normalizeKind`, `parseMessage`
and `SliceFromLine`, and asserts real message **text** reaches
`message.content` — a non-empty file of empty envelopes is the failure mode
these tests exist to catch, so a line with a kind but no content is an explicit
error.

Also covered: the two-record split and its shared `entry` index; `tool_use`
blocks carrying the `type`/`id`/`name`/`input` that `stripAssistantContent`
keeps; `tool_result` blocks carrying the snake_case `tool_use_id` and string
`content` that `extractUserContent` reads; every scoped slice staying valid
JSONL and keeping the half that survived a mid-entry cut; position and
extraction agreeing with what Entire itself sees after slicing at the same
offset; legacy whole-document transcripts still reading; and the capture path
actually writing JSONL to disk rather than the encoder merely being correct in
isolation.

Verified by mutation — each of these compiles and is caught:

| mutation | caught by |
|---|---|
| drop the top-level `type` (half 1) | 4 tests |
| rename the `message` wrapper (half 2) | 8 tests |
| collapse a paired entry back to one line | 12 tests |
| report position in entry units | 3 tests |
| camelCase `toolUseId` | 1 test |
| write path skips materialization | 1 test |

`go test ./...` 127 pass, `go vet` clean, `golangci-lint` (repo config, 2.11.3)
0 issues — `main` is also 0 for this agent.

## Compatibility

No protocol or CLI contract changes. Reads are back-compatible; the stored
format changes on the next capture. Tests that assert on the on-disk file now
read it through `parseTranscript` rather than unmarshalling one JSON document,
because the stored format is what this change replaces.

## Relationship to #58

No file overlap. #58 touches `kiro/paths.go` and `kiro/paths_test.go`; this
touches `transcript.go`, `compact.go`, `AGENT.md` and two new/one modified test
files. They compose: #58 sanitizes `ResolveSessionFile`, which is upstream of
`cacheTranscriptPath`, and the atomic write introduced here creates its
temporary file inside that same sanitized directory.
