### PR TITLE
ci: pin lint jobs to the Go version the modules declare

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,9 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # Pin Go to the version the modules declare. "stable" floats, and a
+      # newer toolchain emits export data the pinned golangci-lint cannot read.
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "stable"
+          go-version-file: e2e/go.mod
 
       - name: Check formatting
         run: |
@@ -67,7 +69,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "stable"
+          go-version-file: ${{ matrix.dir }}/go.mod
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
@@ -82,7 +84,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "stable"
+          go-version-file: e2e/go.mod
 
       - name: Run golangci-lint (e2e)
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0


### PR DESCRIPTION
Every `lint` job in the repo is currently failing, on `main` and on every open PR. This is not caused by any code change.

## The failure

All seven `lint-agents` matrix jobs and `lint-e2e` fail with a wall of typecheck errors on stdlib imports:

```
could not import encoding/json (.../go/1.27.0/x64/src/encoding/json/v2_decode.go:13:2:
  could not import cmp (-: could not load export data: internal error in importing "cmp"
  (cannot decode "cmp", export data version 4 is greater than maximum supported version 2);
  please report an issue)) (typecheck)
```

## Root cause

`lint.yml` asks for `go-version: "stable"`. That floated to **Go 1.27.0**, which writes export data version 4. golangci-lint is pinned at v2.11.3, which supports version 2. It cannot read the toolchain's own stdlib, so every file fails to typecheck.

Every module in this repo declares `go 1.26.0`, so the linter was never meant to run under 1.27.

## Reproduction

Any PR, or a push to `main`. On the runner:

```
Setup go version spec stable
stable version resolved as 1.27.0
go version go1.27.0 linux/amd64
```

Then golangci-lint v2.11.3 fails on the first stdlib import it sees. It reproduces locally with `mise x golangci-lint@2.11.3 -- golangci-lint run ./...` under a Go 1.27 toolchain.

The tell that it is environmental: the jobs fail identically for agents that have no pending changes at all — amp, goose, kiro, omp, qwen, kilo. `fmt` and all `test-agents` jobs pass, because they do not run golangci-lint.

## Fix

Replace `go-version: "stable"` with `go-version-file` in all three `setup-go` steps, so each job gets the Go version its own module declares:

- `fmt` and `lint-e2e` -> `e2e/go.mod`
- `lint-agents` matrix -> `${{ matrix.dir }}/go.mod`

The matrix form means a newly added agent is covered automatically, with no further workflow edits.

This keeps the toolchain and the pinned linter in step. A future move to Go 1.27 is then a deliberate bump of both `go.mod` and the golangci-lint pin together, rather than something that lands on its own whenever upstream retags `stable`.

## Notes

Extracted from #64, where it was found. That PR carries no workflow change, so it stays red on lint until this merges; re-running its checks afterwards is enough, since `pull_request` workflows execute from the merge commit and will pick this up from `main`. No rebase needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change; no runtime or application code paths affected.
> 
> **Overview**
> Fixes failing **lint** workflow jobs by stopping `actions/setup-go` from using floating **`go-version: "stable"`** (which resolved to Go 1.27). That toolchain’s stdlib export data is incompatible with pinned **golangci-lint v2.11.3**, so every `lint-agents` and `lint-e2e` run was failing on stdlib typecheck errors without any code changes.
> 
> The workflow now uses **`go-version-file`** so each job installs the Go version declared in the relevant module: **`e2e/go.mod`** for `fmt` and `lint-e2e`, and **`${{ matrix.dir }}/go.mod`** for each `lint-agents` matrix entry (modules declare **go 1.26.0**). A short comment on the `fmt` step documents why pinning matters. Future Go upgrades stay deliberate via `go.mod` and the linter pin together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ef3709a8db8adb666e4a1bc65bfdb94c5e821a0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->