### PR TITLE
Add entire-agent-zcode: ZCode external agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /agents/entire-agent-kiro/entire-agent-kiro
 /agents/entire-agent-kilo/entire-agent-kilo
 bin/
+/agents/entire-agent-zcode/entire-agent-zcode

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ External agents communicate with Entire CLI via subcommands that accept and retu
 | [Qwen Code](agents/entire-agent-qwen/) | `agents/entire-agent-qwen/` | Implemented — hooks + transcript analysis + compact transcripts |
 | [Oh My Pi](agents/entire-agent-omp/) | `agents/entire-agent-omp/` | Implemented — hooks + transcript analysis + compact transcripts |
 | [Kilo](agents/entire-agent-kilo/) | `agents/entire-agent-kilo/` | Implemented (preview) — hooks + transcript analysis + token calculation + compact transcripts |
+| [ZCode](agents/entire-agent-zcode/) | `agents/entire-agent-zcode/` | Implemented (preview) — hooks + transcript analysis + token calculation; desktop app, sessions read from local SQLite store |
 
 See each agent's own README for setup and usage instructions.
 
@@ -124,6 +125,7 @@ The lifecycle harness auto-discovers and builds all agents in `agents/` via `Tes
 | `E2E_KEEP_REPOS` | Preserve temp repos for debugging |
 | `E2E_CONCURRENT_TEST_LIMIT` | Override the per-agent lifecycle concurrency limit |
 | `QWEN_E2E` | Set to `1` with `E2E_AGENT=qwen` to run live Qwen Code lifecycle tests |
+| `ZCODE_E2E` | Set to `1` with `E2E_AGENT=zcode` to opt into ZCode lifecycle tests (desktop app; prompts are not automatable) |
 
 ## Repository Layout
 
@@ -134,6 +136,7 @@ agents/                          # Standalone external agent projects
   entire-agent-qwen/             # Qwen Code agent (Go binary)
   entire-agent-omp/              # Oh My Pi agent (Go binary)
   entire-agent-kilo/             # Kilo agent (Go binary)
+  entire-agent-zcode/            # ZCode agent (Go binary)
 e2e/                             # Lifecycle integration harness
 .github/workflows/               # CI, including protocol compliance via external-agents-tests
 .claude/skills/entire-external-agent/  # Skill files (research, test-writer, implementer)

--- a/agents/entire-agent-zcode/AGENT.md
+++ b/agents/entire-agent-zcode/AGENT.md
@@ -112,7 +112,7 @@
 | transcript_preparer | true | Transcripts must be exported from SQLite before reading (temp hook transcript is deleted) |
 | token_calculator | true | Per-message token usage stored in `message.data.tokens` |
 | text_generator | false | No headless CLI to invoke the model |
-| hook_response_writer | true | UserPromptSubmit `additionalContext` output schema documented |
+| hook_response_writer | false | UserPromptSubmit `additionalContext` output documented but not implemented in v1 |
 | subagent_aware_extractor | false | Deferred: DB supports it via `parent_id`, but subagent-dir contract doesn't map cleanly in v1 |
 
 ## Gaps & Limitations

--- a/agents/entire-agent-zcode/AGENT.md
+++ b/agents/entire-agent-zcode/AGENT.md
@@ -1,0 +1,139 @@
+# ZCode — External Agent Research
+
+## Verdict: COMPATIBLE (hooks + SQLite sessions verified on a live install; headless lifecycle NOT possible — desktop app only)
+
+## Static Checks
+| Check | Result | Notes |
+|-------|--------|-------|
+| Binary present | PASS | `/usr/bin/zcode` (symlink → `/etc/alternatives/zcode` → `/opt/ZCode/zcode`) |
+| Help available | WARN | `zcode --help` starts the Electron desktop app; no CLI help text |
+| Version info | PASS | User-agent strings in rollout log show `ZCode/3.10.2`; also `~/.zcode/v2/config.json` |
+| Hook keywords | PASS | Documented hooks system (7 events) — see below |
+| Session keywords | PASS | SQLite `session`/`message`/`part` tables with `parent_id` (subagents), resume via UI |
+| Config directory | PASS | `~/.zcode/cli/` (config.json, db/, exec/, rollout/, log/) |
+| Documentation | PASS | https://zcode.z.ai/en/docs/hooks (hook schema), /en/docs/welcome |
+
+## Binary
+- Name: `zcode`
+- Version: 3.10.2 (verified on this machine)
+- Install: Desktop app from https://zcode.z.ai (Electron; `.dmg`/Linux install under `/opt/ZCode`). No standalone headless CLI exists or is documented.
+
+## Hook Mechanism
+- Config file: `~/.zcode/cli/config.json` (user-wide — **the only executed configuration-file source**; project-level `.zcode/config.json` / `zcode.json` hooks are ignored for security)
+- Config format: JSON
+- Hook registration: top-level `hooks` key:
+  ```json
+  {
+    "hooks": {
+      "enabled": true,
+      "events": {
+        "SessionStart": [ { "matcher": "...", "hooks": [ { "type": "process", "command": "...", "args": [...], "timeoutMs": 60000 } ] } ]
+      }
+    }
+  }
+  ```
+  `hooks.enabled: true` is REQUIRED or nothing runs. `type: "process"` (command + args, no shell) or `type: "command"` (shell string). Matcher is a case-sensitive regex.
+- Hook names and protocol mapping:
+  | Native Hook Name | When It Fires | Protocol Event Type |
+  |-----------------|---------------|---------------------|
+  | `SessionStart` (source=startup/resume/clear) | Session begins | 1 = SessionStart |
+  | `SessionStart` (source=compact) | Context compaction | 4 = Compaction |
+  | `UserPromptSubmit` | User submits a prompt | 2 = TurnStart (prompt) |
+  | `Stop` | Assistant finished responding | 3 = TurnEnd (response_message) |
+  | `PreToolUse` | Before a tool call | not mapped (skip; no protocol tool event type) |
+  | `PostToolUse` | After a tool call | not mapped (skip) |
+  | `PermissionRequest` / `PostToolUseFailure` | permission/failure | not mapped (skip) |
+- Hook input format: **one line of JSON on stdin**, containing camelCase + Claude-style snake_case aliases:
+  - Common: `session_id`, `transcript_path`, `cwd`, `permission_mode`, `hook_event_name`
+  - SessionStart: `source` (startup/clear/compact), `agent_type`, `model`
+  - UserPromptSubmit: `prompt`
+  - PreToolUse/PostToolUse: `tool_name`, `tool_input`, `tool_use_id`
+  - Stop: `stop_hook_active`, `last_assistant_message`
+  - `transcript_path` is a **temp JSONL cleaned after the hook runs — NOT persistent storage**; real data lives in SQLite.
+  - Hook output: exit 0 = pass, 2 = block, stdout JSON parsed with a strict schema (we emit nothing — hooks are observe-only).
+- Env vars: `${CLAUDE_SESSION_ID}`, `${ZCODE_PROJECT_DIR}`/`${CLAUDE_PROJECT_DIR}` are expanded into the command/args. Config is snapshotted per session — hook changes need a new session.
+
+## Session Management
+- Session directory (native): `~/.zcode/cli/db/db.sqlite` (SQLite, WAL mode) — single DB, not per-session files
+- Session ID source: `session_id` in hook stdin (`sess_<uuid>`), e.g. `sess_58a1da30-14cb-4dda-99bf-82f56fb30881`
+- Session file format: tables `session(id, project_id, workspace_id, parent_id, directory, title, time_created, time_updated, ...)`, `message(id, session_id, sequence, data JSON)`, `part(id, message_id, session_id, sequence, data JSON)` (verified via schema dump)
+  - `message.data`: `{"role": "user"|"assistant", "time": {...}, "model": {...}, "tokens": {"total","input","output","reasoning","cache":{"read","write"}}, "semantics": {"origin","kind","transcriptVisibility"}, ...}`
+  - `part.data`: `{"type":"text","text":"..."}` or `{"type":"tool","callID":"...","tool":"Read|Bash|Edit|Write|...","state":{"status":"completed","input":{...},"output":"..."}}`
+  - `session.parent_id` links subagent sessions to their parent; `semantics.transcriptVisibility` distinguishes hidden/synthetic messages
+- Other storage: `~/.zcode/cli/rollout/model-io-sess_<id>.jsonl` (raw LLM request/response log), `~/.zcode/cli/exec/sess_<id>/` (tool exec logs) — supplementary only
+
+## Transcript
+- Location (effective): exported by our binary from SQLite into `<repo>/.entire/tmp/<session_id>.jsonl` (via `prepare-transcript`); raw transcript bytes read from that file
+- Format: JSONL, one message object per line (our export format: `{role, text, tool_name, tool_input, tool_output, tokens{...}, time}` filtered to `transcriptVisibility: "visible"`)
+- User prompt field: message with `role=user` + `semantics.kind="user_prompt"` + first text part
+- Modified files field: `part.data.type="tool"` with `tool` ∈ {Write, Edit, ApplyPatch} → `state.input.file_path`/`path`
+- Token usage field: `message.data.tokens.{input,output,cache.read,cache.write}` per assistant message
+- Example entry: `{"role":"assistant","text":"Found it.","tokens":{"input":15786,"output":163}}`
+
+## Data Storage Verification
+- Session files contain actual assistant content: YES — `part.data` holds full response text and tool inputs/outputs (verified by dumping rows from the live DB on this machine)
+- Secondary storage: none required; `rollout/model-io-sess_*.jsonl` and `exec/sess_*/` exist but are supplementary
+- Cross-reference key: `message.session_id` → `session.id`; `part.message_id` → `message.id`; `session.parent_id` for subagents
+- Hook data flow verified: YES per docs (stdin JSON with `session_id`, `prompt`, `tool_name`); `transcript_path` is temp-only so we ignore it and read from SQLite instead. Marked (unverified-by-capture) — no hook payload was captured live in this environment yet; see Captured Payloads.
+- Verification method: sqlite3 schema dump + row sampling on the live DB; official hooks docs; local zcode-guide plugin skill (`diagnosing-hooks`) cross-check
+
+## Protocol Mapping
+| Subcommand | Native Concept | Implementation Notes | Feasibility |
+|-----------|---------------|---------------------|-------------|
+| `info` | — | Static metadata | Required |
+| `detect` | binary + DB | `exec.LookPath("zcode")` or `~/.zcode/cli/db` exists | Required |
+| `get-session-id` | hook stdin `session_id` | Read HookInput / raw payload | Required |
+| `get-session-dir` | — | `<repo>/.entire/tmp` (protocol default) | Required |
+| `resolve-session-file` | — | `<session_dir>/<session_id>.jsonl` (our export) | Required |
+| `read-session` | SQLite | Query session+message+part, build AgentSession; native_data = session row JSON | Required |
+| `write-session` | sidecar | Persist AgentSession JSON snapshot to `<session_dir>/<id>.json` (never writes to ZCode's DB — resume-restore is GUI-driven) | Required (partial fidelity) |
+| `read-transcript` | export file | Raw bytes of exported JSONL | Required |
+| `chunk-transcript` / `reassemble-transcript` | — | Base64 chunking (generic) | Required |
+| `format-resume-command` | GUI resume | `zcode` (opens the app; session list resume) — no headless resume exists | Required (degraded) |
+| `parse-hook` | hook stdin JSON | Map SessionStart/UserPromptSubmit/Stop/compact as per table above | hooks |
+| `install-hooks` | user config.json | Backup, merge `hooks.events.{SessionStart,UserPromptSubmit,Stop}` + `enabled:true`, restore-able | hooks |
+| `uninstall-hooks` | reverse | Remove only entries we added | hooks |
+| `are-hooks-installed` | config check | Look for our marker command in config | hooks |
+| `get-transcript-position` | export file | Byte size of exported JSONL | transcript_analyzer |
+| `extract-modified-files` | tool parts | Parse Write/Edit/ApplyPatch parts from JSONL | transcript_analyzer |
+| `extract-prompts` | user messages | `role=user`, `kind=user_prompt` text parts | transcript_analyzer |
+| `extract-summary` | last assistant text | Last visible assistant text part | transcript_analyzer |
+| `prepare-transcript` | SQLite export | Stream session → JSONL file | transcript_preparer |
+| `calculate-tokens` | message tokens | Sum input/output/cache fields | token_calculator |
+| `write-hook-response` | UserPromptSubmit additionalContext | `{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":...}}` | hook_response_writer (optional) |
+| `generate-text` | none | No headless model invocation — NOT declared | — |
+| subagent extractors | `session.parent_id` | Possible via DB query; NOT declared in v1 | — |
+
+## Selected Capabilities
+| Capability | Declared | Justification |
+|-----------|----------|---------------|
+| hooks | true | Full documented hook system with stdin JSON carrying session_id/prompt |
+| transcript_analyzer | true | SQLite-exported JSONL is fully parseable |
+| transcript_preparer | true | Transcripts must be exported from SQLite before reading (temp hook transcript is deleted) |
+| token_calculator | true | Per-message token usage stored in `message.data.tokens` |
+| text_generator | false | No headless CLI to invoke the model |
+| hook_response_writer | true | UserPromptSubmit `additionalContext` output schema documented |
+| subagent_aware_extractor | false | Deferred: DB supports it via `parent_id`, but subagent-dir contract doesn't map cleanly in v1 |
+
+## Gaps & Limitations
+- **No headless CLI**: zcode is an Electron desktop app; there is no `-p`/`exec` mode. `format-resume-command` can only launch the GUI; lifecycle e2e prompts cannot be automated — the e2e adapter is opt-in (`ZCODE_E2E=1 && E2E_AGENT=zcode`) and documents the limitation.
+- **write-session does not restore into ZCode**: real sessions live in ZCode's SQLite DB with an internal schema; writing into it is unsafe. write-session persists an opaque snapshot for Entire's benefit only (resume happens through the GUI session list).
+- **Hook config is user-global** (`~/.zcode/cli/config.json`): install-hooks edits the user file (with backup + marker-scoped merge/uninstall) because workspace-level hook configs are ignored for security.
+- **Config snapshotted per session**: hook changes take effect in new ZCode sessions only.
+- Hook payloads documented but not captured live in this environment (would require manual GUI interaction) — mapping is doc-based, schema cross-checked against the local zcode-guide plugin skill.
+
+## Captured Payloads
+- Verification script: `agents/entire-agent-zcode/scripts/verify-zcode.sh`
+- Capture directory: `agents/entire-agent-zcode/.probe-zcode-*/captures/`
+- Verification status: PARTIAL — static checks + SQLite schema/rows verified on live install (ZCode 3.10.2, Linux); hook stdin payloads UNVERIFIED (doc-based; script captures them when the user runs a live session)
+- Notable differences from docs: none found between docs and local skill/plugin documentation
+
+## E2E Test Prerequisites
+- Entire CLI binary: `entire` from PATH or `E2E_ENTIRE_BIN`
+- Agent CLI binary: `zcode` (desktop app; GUI only)
+- Non-interactive prompt command: **NOT AVAILABLE** (no headless mode) — adapter returns an explanatory error
+- Interactive mode: GUI only (tmux cannot drive an Electron app) — interactive lifecycle tests skip
+- Expected prompt pattern: n/a
+- Timeout multiplier: n/a
+- Bootstrap steps: install ZCode desktop app and sign in; adapter registers only with `ZCODE_E2E=1` and `E2E_AGENT=zcode`
+- Transient error patterns: "429", "rate limit", "overloaded", "503", "timeout"

--- a/agents/entire-agent-zcode/AGENT.md
+++ b/agents/entire-agent-zcode/AGENT.md
@@ -63,7 +63,7 @@
 - Other storage: `~/.zcode/cli/rollout/model-io-sess_<id>.jsonl` (raw LLM request/response log), `~/.zcode/cli/exec/sess_<id>/` (tool exec logs) — supplementary only
 
 ## Transcript
-- Location (effective): exported by our binary from SQLite into `<repo>/.entire/tmp/<session_id>.jsonl` (via `prepare-transcript`); raw transcript bytes read from that file
+- Location (effective): exported by our binary from SQLite into `~/.zcode/entire/sessions/<session_id>.jsonl` (via `prepare-transcript`); raw transcript bytes read from that file
 - Format: JSONL, one message object per line (our export format: `{role, text, tool_name, tool_input, tool_output, tokens{...}, time}` filtered to `transcriptVisibility: "visible"`)
 - User prompt field: message with `role=user` + `semantics.kind="user_prompt"` + first text part
 - Modified files field: `part.data.type="tool"` with `tool` ∈ {Write, Edit, ApplyPatch} → `state.input.file_path`/`path`
@@ -83,7 +83,7 @@
 | `info` | — | Static metadata | Required |
 | `detect` | binary + DB | `exec.LookPath("zcode")` or `~/.zcode/cli/db` exists | Required |
 | `get-session-id` | hook stdin `session_id` | Read HookInput / raw payload | Required |
-| `get-session-dir` | — | `<repo>/.entire/tmp` (protocol default) | Required |
+| `get-session-dir` | — | `~/.zcode/entire/sessions` (outside the repo: Entire attributes transcripts by session-dir prefix, and `.entire/tmp` is claimed by other external agents like kilo/amp) | Required |
 | `resolve-session-file` | — | `<session_dir>/<session_id>.jsonl` (our export) | Required |
 | `read-session` | SQLite | Query session+message+part, build AgentSession; native_data = session row JSON | Required |
 | `write-session` | sidecar | Persist AgentSession JSON snapshot to `<session_dir>/<id>.json` (never writes to ZCode's DB — resume-restore is GUI-driven) | Required (partial fidelity) |

--- a/agents/entire-agent-zcode/README.md
+++ b/agents/entire-agent-zcode/README.md
@@ -14,7 +14,7 @@ ZCode's documented hook system (user-level `~/.zcode/cli/config.json`).
 |-----------|--------|
 | `hooks` | ✅ SessionStart / UserPromptSubmit / Stop (+ compaction via `source=compact`) |
 | `transcript_analyzer` | ✅ position, modified files, prompts, summary |
-| `transcript_preparer` | ✅ exports sessions from SQLite to `<repo>/.entire/tmp/zcode/<id>.jsonl` |
+| `transcript_preparer` | ✅ exports sessions from SQLite to `~/.zcode/entire/sessions/<id>.jsonl` |
 | `token_calculator` | ✅ sums per-message input/output/cache usage |
 | `text_generator` | ❌ no headless model invocation |
 | `hook_response_writer` | ❌ not implemented in v1 |
@@ -46,7 +46,9 @@ being available for transcript export.
   session after `entire enable --agent zcode`.
 - `format-resume-command` returns plain `zcode`; resuming a specific session
   happens through the app's session list.
-- `write-session` stores Entire's snapshot under `.entire/tmp/`; ZCode's own
-  database is never written to.
+- `write-session` stores Entire's snapshot under `~/.zcode/entire/sessions/`;
+  ZCode's own database is never written to. The session dir lives outside the
+  repo (under ZCode's home) so transcript ownership isn't misattributed to
+  other external agents whose session dirs root at `.entire/tmp`.
 
 See [AGENT.md](AGENT.md) for the full research notes and protocol mapping.

--- a/agents/entire-agent-zcode/README.md
+++ b/agents/entire-agent-zcode/README.md
@@ -1,0 +1,52 @@
+# entire-agent-zcode
+
+External agent binary integrating [ZCode](https://zcode.z.ai) — the Z.ai agentic
+development environment — with the Entire CLI.
+
+ZCode is an Electron desktop app with no headless CLI, so this integration is
+read-oriented: sessions and transcripts are read from ZCode's local SQLite
+store (`~/.zcode/cli/db/db.sqlite`), and lifecycle events arrive through
+ZCode's documented hook system (user-level `~/.zcode/cli/config.json`).
+
+## Capabilities
+
+| Capability | Status |
+|-----------|--------|
+| `hooks` | ✅ SessionStart / UserPromptSubmit / Stop (+ compaction via `source=compact`) |
+| `transcript_analyzer` | ✅ position, modified files, prompts, summary |
+| `transcript_preparer` | ✅ exports sessions from SQLite to `<repo>/.entire/tmp/zcode/<id>.jsonl` |
+| `token_calculator` | ✅ sums per-message input/output/cache usage |
+| `text_generator` | ❌ no headless model invocation |
+| `hook_response_writer` | ❌ not implemented in v1 |
+| `subagent_aware_extractor` | ❌ deferred (ZCode tracks subagents via `session.parent_id`) |
+
+## Build & test
+
+```bash
+mise run build   # → ./entire-agent-zcode
+mise run test    # unit tests
+```
+
+The binary is stateless and depends only on the `sqlite3` CLI (used read-only)
+being available for transcript export.
+
+## Environment
+
+- `ZCODE_HOME` — override ZCode's state root (default `~/.zcode`); useful for
+  tests and fixture environments. The hook config is expected at
+  `<ZCODE_HOME>/cli/config.json` and the session DB at
+  `<ZCODE_HOME>/cli/db/db.sqlite`.
+
+## Notes & limitations
+
+- `install-hooks` edits the **user-level** config because ZCode ignores
+  workspace-level hook configs for security. Only entries installed by this
+  binary are touched; everything else in the file is preserved.
+- Hook config changes are snapshotted per session by ZCode — start a new ZCode
+  session after `entire enable --agent zcode`.
+- `format-resume-command` returns plain `zcode`; resuming a specific session
+  happens through the app's session list.
+- `write-session` stores Entire's snapshot under `.entire/tmp/`; ZCode's own
+  database is never written to.
+
+See [AGENT.md](AGENT.md) for the full research notes and protocol mapping.

--- a/agents/entire-agent-zcode/cmd/entire-agent-zcode/main.go
+++ b/agents/entire-agent-zcode/cmd/entire-agent-zcode/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/entireio/external-agents/agents/entire-agent-zcode/internal/protocol"
+	"github.com/entireio/external-agents/agents/entire-agent-zcode/internal/zcode"
+)
+
+func main() {
+	agent := zcode.New()
+
+	if len(os.Args) < 2 {
+		fatalf("usage: entire-agent-zcode <subcommand> [args]")
+	}
+
+	var err error
+
+	switch os.Args[1] {
+	case "info":
+		err = protocol.WriteJSON(os.Stdout, agent.Info())
+	case "detect":
+		err = protocol.WriteJSON(os.Stdout, agent.Detect())
+	case "get-session-id":
+		err = protocol.HandleGetSessionID(os.Stdin, os.Stdout, agent)
+	case "get-session-dir":
+		err = protocol.HandleGetSessionDir(os.Args[2:], os.Stdout, agent)
+	case "resolve-session-file":
+		err = protocol.HandleResolveSessionFile(os.Args[2:], os.Stdout, agent)
+	case "read-session":
+		err = protocol.HandleReadSession(os.Stdin, os.Stdout, agent)
+	case "write-session":
+		err = protocol.HandleWriteSession(os.Stdin, agent)
+	case "read-transcript":
+		err = protocol.HandleReadTranscript(os.Args[2:], os.Stdout, agent)
+	case "chunk-transcript":
+		err = protocol.HandleChunkTranscript(os.Args[2:], os.Stdin, os.Stdout, agent)
+	case "reassemble-transcript":
+		err = protocol.HandleReassembleTranscript(os.Stdin, os.Stdout, agent)
+	case "prepare-transcript":
+		err = protocol.HandlePrepareTranscript(os.Args[2:], agent)
+	case "format-resume-command":
+		err = protocol.HandleFormatResumeCommand(os.Args[2:], os.Stdout, agent)
+	case "parse-hook":
+		err = protocol.HandleParseHook(os.Args[2:], os.Stdin, os.Stdout, agent)
+	case "install-hooks":
+		err = protocol.HandleInstallHooks(os.Args[2:], os.Stdout, agent)
+	case "uninstall-hooks":
+		err = agent.UninstallHooks()
+	case "are-hooks-installed":
+		err = protocol.WriteJSON(os.Stdout, protocol.AreHooksInstalledResponse{
+			Installed: agent.AreHooksInstalled(),
+		})
+	case "get-transcript-position":
+		err = protocol.HandleGetTranscriptPosition(os.Args[2:], os.Stdout, agent)
+	case "extract-modified-files":
+		err = protocol.HandleExtractModifiedFiles(os.Args[2:], os.Stdout, agent)
+	case "extract-prompts":
+		err = protocol.HandleExtractPrompts(os.Args[2:], os.Stdout, agent)
+	case "extract-summary":
+		err = protocol.HandleExtractSummary(os.Args[2:], os.Stdout, agent)
+	case "calculate-tokens":
+		err = protocol.HandleCalculateTokens(os.Args[2:], os.Stdin, os.Stdout, agent)
+	default:
+		fatalf("unknown subcommand: %s", os.Args[1])
+	}
+
+	if err != nil {
+		fatalf("%v", err)
+	}
+}
+
+func fatalf(format string, args ...any) {
+	_, _ = fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/agents/entire-agent-zcode/go.mod
+++ b/agents/entire-agent-zcode/go.mod
@@ -1,0 +1,3 @@
+module github.com/entireio/external-agents/agents/entire-agent-zcode
+
+go 1.26.0

--- a/agents/entire-agent-zcode/internal/protocol/handlers_test.go
+++ b/agents/entire-agent-zcode/internal/protocol/handlers_test.go
@@ -1,0 +1,50 @@
+package protocol
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+type testTranscriptCompactor struct {
+	response CompactTranscriptResponse
+	err      error
+}
+
+type testTranscriptPreparer struct {
+	sessionRef string
+	err        error
+}
+
+func (c testTranscriptCompactor) CompactTranscript(_ string) (CompactTranscriptResponse, error) {
+	return c.response, c.err
+}
+
+func (p *testTranscriptPreparer) PrepareTranscript(sessionRef string) error {
+	p.sessionRef = sessionRef
+	return p.err
+}
+
+func TestHandleCompactTranscript(t *testing.T) {
+	var stdout bytes.Buffer
+	err := HandleCompactTranscript([]string{"--session-ref", "/tmp/repo/.entire/tmp/abc123.json"}, &stdout, testTranscriptCompactor{
+		response: CompactTranscriptResponse{Transcript: "eyJ2IjoxfQo="},
+	})
+	if err != nil {
+		t.Fatalf("HandleCompactTranscript() error = %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, `"transcript":"eyJ2IjoxfQo="`) {
+		t.Fatalf("stdout = %s", got)
+	}
+}
+
+func TestHandlePrepareTranscript(t *testing.T) {
+	preparer := &testTranscriptPreparer{}
+	err := HandlePrepareTranscript([]string{"--session-ref", "/tmp/repo/.entire/tmp/amp/T-123.json"}, preparer)
+	if err != nil {
+		t.Fatalf("HandlePrepareTranscript() error = %v", err)
+	}
+	if preparer.sessionRef != "/tmp/repo/.entire/tmp/amp/T-123.json" {
+		t.Fatalf("sessionRef = %q", preparer.sessionRef)
+	}
+}

--- a/agents/entire-agent-zcode/internal/protocol/protocol.go
+++ b/agents/entire-agent-zcode/internal/protocol/protocol.go
@@ -1,0 +1,363 @@
+package protocol
+
+import (
+	"encoding/json"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type sessionDirResolver interface {
+	GetSessionDir(repoPath string) (string, error)
+}
+
+type sessionFileResolver interface {
+	ResolveSessionFile(sessionDir, sessionID string) string
+}
+
+type sessionIDProvider interface {
+	GetSessionID(*HookInputJSON) string
+}
+
+type sessionReader interface {
+	ReadSession(*HookInputJSON) (AgentSessionJSON, error)
+}
+
+type sessionWriter interface {
+	WriteSession(AgentSessionJSON) error
+}
+
+type transcriptReader interface {
+	ReadTranscript(sessionRef string) ([]byte, error)
+}
+
+type transcriptChunker interface {
+	ChunkTranscript(content []byte, maxSize int) ([][]byte, error)
+	ReassembleTranscript(chunks [][]byte) ([]byte, error)
+}
+
+type transcriptCompactor interface {
+	CompactTranscript(sessionRef string) (CompactTranscriptResponse, error)
+}
+
+type transcriptPreparer interface {
+	PrepareTranscript(sessionRef string) error
+}
+
+type resumeFormatter interface {
+	FormatResumeCommand(sessionID string) string
+}
+
+type hookParser interface {
+	ParseHook(hookName string, input []byte) (*EventJSON, error)
+	InstallHooks(localDev bool, force bool) (int, error)
+	UninstallHooks() error
+	AreHooksInstalled() bool
+}
+
+type transcriptAnalyzer interface {
+	GetTranscriptPosition(path string) (int, error)
+	ExtractModifiedFiles(path string, offset int) ([]string, int, error)
+	ExtractPrompts(sessionRef string, offset int) ([]string, error)
+	ExtractSummary(sessionRef string) (string, bool, error)
+}
+
+type tokenCalculator interface {
+	CalculateTokens(data []byte, offset int) (TokenUsageResponse, error)
+}
+
+func WriteJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(v)
+}
+
+func ReadJSON[T any](r io.Reader) (*T, error) {
+	var value T
+	if err := json.NewDecoder(r).Decode(&value); err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
+func RepoRoot() string {
+	if root := os.Getenv("ENTIRE_REPO_ROOT"); root != "" {
+		return root
+	}
+	root, _ := os.Getwd()
+	return root
+}
+
+func HandleGetSessionID(stdin io.Reader, stdout io.Writer, provider sessionIDProvider) error {
+	input, err := ReadJSON[HookInputJSON](stdin)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionIDResponse{SessionID: provider.GetSessionID(input)})
+}
+
+func HandleGetSessionDir(args []string, stdout io.Writer, resolver sessionDirResolver) error {
+	fs := flag.NewFlagSet("get-session-dir", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	repoPath := fs.String("repo-path", "", "repo path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	sessionDir, err := resolver.GetSessionDir(*repoPath)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionDirResponse{SessionDir: sessionDir})
+}
+
+func HandleResolveSessionFile(args []string, stdout io.Writer, resolver sessionFileResolver) error {
+	fs := flag.NewFlagSet("resolve-session-file", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionDir := fs.String("session-dir", "", "session dir")
+	sessionID := fs.String("session-id", "", "session id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return WriteJSON(stdout, SessionFileResponse{SessionFile: resolver.ResolveSessionFile(*sessionDir, *sessionID)})
+}
+
+func HandleReadSession(stdin io.Reader, stdout io.Writer, reader sessionReader) error {
+	input, err := ReadJSON[HookInputJSON](stdin)
+	if err != nil {
+		return err
+	}
+	session, err := reader.ReadSession(input)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, session)
+}
+
+func HandleWriteSession(stdin io.Reader, writer sessionWriter) error {
+	session, err := ReadJSON[AgentSessionJSON](stdin)
+	if err != nil {
+		return err
+	}
+	return writer.WriteSession(*session)
+}
+
+func HandleReadTranscript(args []string, stdout io.Writer, reader transcriptReader) error {
+	fs := flag.NewFlagSet("read-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	data, err := reader.ReadTranscript(*sessionRef)
+	if err != nil {
+		return err
+	}
+	_, err = stdout.Write(data)
+	return err
+}
+
+func HandleChunkTranscript(args []string, stdin io.Reader, stdout io.Writer, chunker transcriptChunker) error {
+	fs := flag.NewFlagSet("chunk-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	maxSize := fs.Int("max-size", 0, "max size")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	content, err := io.ReadAll(stdin)
+	if err != nil {
+		return err
+	}
+	chunks, err := chunker.ChunkTranscript(content, *maxSize)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ChunkResponse{Chunks: chunks})
+}
+
+func HandleReassembleTranscript(stdin io.Reader, stdout io.Writer, chunker transcriptChunker) error {
+	input, err := ReadJSON[ChunkResponse](stdin)
+	if err != nil {
+		return err
+	}
+	data, err := chunker.ReassembleTranscript(input.Chunks)
+	if err != nil {
+		return err
+	}
+	_, err = stdout.Write(data)
+	return err
+}
+
+func HandleCompactTranscript(args []string, stdout io.Writer, compactor transcriptCompactor) error {
+	fs := flag.NewFlagSet("compact-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	compacted, err := compactor.CompactTranscript(*sessionRef)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, compacted)
+}
+
+func HandlePrepareTranscript(args []string, preparer transcriptPreparer) error {
+	fs := flag.NewFlagSet("prepare-transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return preparer.PrepareTranscript(*sessionRef)
+}
+
+func HandleFormatResumeCommand(args []string, stdout io.Writer, formatter resumeFormatter) error {
+	fs := flag.NewFlagSet("format-resume-command", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionID := fs.String("session-id", "", "session id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ResumeCommandResponse{Command: formatter.FormatResumeCommand(*sessionID)})
+}
+
+func readStdinWithTimeout(r io.Reader, timeout time.Duration) ([]byte, error) {
+	type result struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		data, err := io.ReadAll(r)
+		ch <- result{data, err}
+	}()
+	select {
+	case res := <-ch:
+		return res.data, res.err
+	case <-time.After(timeout):
+		return nil, nil
+	}
+}
+
+func HandleParseHook(args []string, stdin io.Reader, stdout io.Writer, parser hookParser) error {
+	fs := flag.NewFlagSet("parse-hook", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	hook := fs.String("hook", "", "hook name")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	input, err := readStdinWithTimeout(stdin, 100*time.Millisecond)
+	if err != nil {
+		return err
+	}
+	event, err := parser.ParseHook(*hook, input)
+	if err != nil {
+		return err
+	}
+	if event == nil {
+		_, err = io.WriteString(stdout, "null\n")
+		return err
+	}
+	return WriteJSON(stdout, event)
+}
+
+func HandleInstallHooks(args []string, stdout io.Writer, parser hookParser) error {
+	fs := flag.NewFlagSet("install-hooks", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	localDev := fs.Bool("local-dev", false, "local dev")
+	force := fs.Bool("force", false, "force")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	count, err := parser.InstallHooks(*localDev, *force)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, HooksInstalledCountResponse{HooksInstalled: count})
+}
+
+func HandleGetTranscriptPosition(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("get-transcript-position", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	path := fs.String("path", "", "path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	position, err := analyzer.GetTranscriptPosition(*path)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, TranscriptPositionResponse{Position: position})
+}
+
+func HandleExtractModifiedFiles(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-modified-files", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	path := fs.String("path", "", "path")
+	offset := fs.Int("offset", 0, "offset")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	files, currentPosition, err := analyzer.ExtractModifiedFiles(*path, *offset)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractFilesResponse{Files: files, CurrentPosition: currentPosition})
+}
+
+func HandleExtractPrompts(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-prompts", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	offset := fs.Int("offset", 0, "offset")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	prompts, err := analyzer.ExtractPrompts(*sessionRef, *offset)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractPromptsResponse{Prompts: prompts})
+}
+
+func HandleExtractSummary(args []string, stdout io.Writer, analyzer transcriptAnalyzer) error {
+	fs := flag.NewFlagSet("extract-summary", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionRef := fs.String("session-ref", "", "session ref")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	summary, hasSummary, err := analyzer.ExtractSummary(*sessionRef)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, ExtractSummaryResponse{Summary: summary, HasSummary: hasSummary})
+}
+
+func HandleCalculateTokens(args []string, stdin io.Reader, stdout io.Writer, calculator tokenCalculator) error {
+	fs := flag.NewFlagSet("calculate-tokens", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	offset := fs.Int("offset", 0, "offset")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	data, err := io.ReadAll(stdin)
+	if err != nil {
+		return err
+	}
+	usage, err := calculator.CalculateTokens(data, *offset)
+	if err != nil {
+		return err
+	}
+	return WriteJSON(stdout, usage)
+}
+
+func DefaultSessionDir(repoPath string) string {
+	return filepath.Join(repoPath, ".entire", "tmp")
+}
+
+func ResolveSessionFile(sessionDir, sessionID string) string {
+	return filepath.Join(sessionDir, sessionID+".json")
+}

--- a/agents/entire-agent-zcode/internal/protocol/types.go
+++ b/agents/entire-agent-zcode/internal/protocol/types.go
@@ -1,0 +1,139 @@
+package protocol
+
+import "encoding/json"
+
+const ProtocolVersion = 1
+
+type DeclaredCapabilities struct {
+	Hooks                  bool `json:"hooks"`
+	TranscriptAnalyzer     bool `json:"transcript_analyzer"`
+	TranscriptPreparer     bool `json:"transcript_preparer"`
+	TokenCalculator        bool `json:"token_calculator"`
+	CompactTranscript      bool `json:"compact_transcript"`
+	TextGenerator          bool `json:"text_generator"`
+	HookResponseWriter     bool `json:"hook_response_writer"`
+	SubagentAwareExtractor bool `json:"subagent_aware_extractor"`
+	UsesTerminal           bool `json:"uses_terminal"`
+}
+
+type InfoResponse struct {
+	ProtocolVersion int                  `json:"protocol_version"`
+	Name            string               `json:"name"`
+	Type            string               `json:"type"`
+	Description     string               `json:"description"`
+	IsPreview       bool                 `json:"is_preview"`
+	ProtectedDirs   []string             `json:"protected_dirs"`
+	ProtectedFiles  []string             `json:"protected_files,omitempty"`
+	HookNames       []string             `json:"hook_names"`
+	Capabilities    DeclaredCapabilities `json:"capabilities"`
+}
+
+type DetectResponse struct {
+	Present bool `json:"present"`
+}
+
+type SessionIDResponse struct {
+	SessionID string `json:"session_id"`
+}
+
+type SessionDirResponse struct {
+	SessionDir string `json:"session_dir"`
+}
+
+type SessionFileResponse struct {
+	SessionFile string `json:"session_file"`
+}
+
+type ChunkResponse struct {
+	Chunks [][]byte `json:"chunks"`
+}
+
+type ResumeCommandResponse struct {
+	Command string `json:"command"`
+}
+
+type HooksInstalledCountResponse struct {
+	HooksInstalled int `json:"hooks_installed"`
+}
+
+type AreHooksInstalledResponse struct {
+	Installed bool `json:"installed"`
+}
+
+type TranscriptPositionResponse struct {
+	Position int `json:"position"`
+}
+
+type ExtractFilesResponse struct {
+	Files           []string `json:"files"`
+	CurrentPosition int      `json:"current_position"`
+}
+
+type ExtractPromptsResponse struct {
+	Prompts []string `json:"prompts"`
+}
+
+type ExtractSummaryResponse struct {
+	Summary    string `json:"summary"`
+	HasSummary bool   `json:"has_summary"`
+}
+
+type TokenUsageResponse struct {
+	InputTokens         int `json:"input_tokens"`
+	CacheCreationTokens int `json:"cache_creation_tokens"`
+	CacheReadTokens     int `json:"cache_read_tokens"`
+	OutputTokens        int `json:"output_tokens"`
+	APICallCount        int `json:"api_call_count"`
+}
+
+type CompactTranscriptResponse struct {
+	Transcript string                       `json:"transcript"`
+	Assets     []CompactTranscriptAssetJSON `json:"assets,omitempty"`
+}
+
+type CompactTranscriptAssetJSON struct {
+	Name      string `json:"name"`
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
+}
+
+type AgentSessionJSON struct {
+	SessionID     string   `json:"session_id"`
+	AgentName     string   `json:"agent_name"`
+	RepoPath      string   `json:"repo_path"`
+	SessionRef    string   `json:"session_ref"`
+	StartTime     string   `json:"start_time"`
+	NativeData    []byte   `json:"native_data"`
+	ModifiedFiles []string `json:"modified_files"`
+	NewFiles      []string `json:"new_files"`
+	DeletedFiles  []string `json:"deleted_files"`
+}
+
+type HookInputJSON struct {
+	HookType   string                 `json:"hook_type"`
+	SessionID  string                 `json:"session_id"`
+	SessionRef string                 `json:"session_ref"`
+	Timestamp  string                 `json:"timestamp"`
+	UserPrompt string                 `json:"user_prompt,omitempty"`
+	ToolName   string                 `json:"tool_name,omitempty"`
+	ToolUseID  string                 `json:"tool_use_id,omitempty"`
+	ToolInput  json.RawMessage        `json:"tool_input,omitempty"`
+	RawData    map[string]interface{} `json:"raw_data,omitempty"`
+}
+
+type EventJSON struct {
+	Type              int               `json:"type"`
+	SessionID         string            `json:"session_id"`
+	PreviousSessionID string            `json:"previous_session_id,omitempty"`
+	SessionRef        string            `json:"session_ref,omitempty"`
+	Prompt            string            `json:"prompt,omitempty"`
+	Model             string            `json:"model,omitempty"`
+	Timestamp         string            `json:"timestamp,omitempty"`
+	ToolUseID         string            `json:"tool_use_id,omitempty"`
+	SubagentID        string            `json:"subagent_id,omitempty"`
+	ToolInput         json.RawMessage   `json:"tool_input,omitempty"`
+	SubagentType      string            `json:"subagent_type,omitempty"`
+	TaskDescription   string            `json:"task_description,omitempty"`
+	ResponseMessage   string            `json:"response_message,omitempty"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+}

--- a/agents/entire-agent-zcode/internal/zcode/agent.go
+++ b/agents/entire-agent-zcode/internal/zcode/agent.go
@@ -1,0 +1,94 @@
+package zcode
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/entireio/external-agents/agents/entire-agent-zcode/internal/protocol"
+)
+
+// Agent implements the Entire external agent protocol for ZCode.
+//
+// ZCode is an Electron desktop app with no headless CLI, so every operation
+// either reads its on-disk state (SQLite session DB at ~/.zcode/cli/db) or its
+// user-level hook config (~/.zcode/cli/config.json — the only hook config
+// source ZCode executes).
+type Agent struct {
+	DBQuerier DBQuerier
+}
+
+func New() *Agent {
+	return &Agent{DBQuerier: &SQLiteQuerier{}}
+}
+
+func (a *Agent) Info() protocol.InfoResponse {
+	return protocol.InfoResponse{
+		ProtocolVersion: protocol.ProtocolVersion,
+		Name:            "zcode",
+		Type:            "ZCode",
+		Description:     "ZCode agentic development environment integration for Entire (desktop app; sessions are read from ZCode's local SQLite store)",
+		IsPreview:       true,
+		ProtectedDirs:   []string{".zcode"},
+		HookNames: []string{
+			HookNameSessionStart,
+			HookNameTurnStart,
+			HookNameTurnEnd,
+			HookNameCompaction,
+		},
+		Capabilities: protocol.DeclaredCapabilities{
+			Hooks:              true,
+			TranscriptAnalyzer: true,
+			TranscriptPreparer: true,
+			TokenCalculator:    true,
+			UsesTerminal:       false,
+		},
+	}
+}
+
+func (a *Agent) Detect() protocol.DetectResponse {
+	if _, err := exec.LookPath("zcode"); err == nil {
+		return protocol.DetectResponse{Present: true}
+	}
+	// The binary may not be on PATH (desktop install); the local state
+	// directory is equally strong evidence ZCode is in use.
+	if info, err := os.Stat(zcodeHome()); err == nil && info.IsDir() {
+		return protocol.DetectResponse{Present: true}
+	}
+	return protocol.DetectResponse{Present: false}
+}
+
+func (a *Agent) GetSessionID(input *protocol.HookInputJSON) string {
+	if input != nil && input.SessionID != "" {
+		return input.SessionID
+	}
+	return ""
+}
+
+// FormatResumeCommand cannot resume a specific session: ZCode is a GUI app
+// with no headless resume. Launching the app opens the session list where the
+// user picks the session.
+func (a *Agent) FormatResumeCommand(_ string) string {
+	return "zcode"
+}
+
+// zcodeHome returns ZCode's state root. ZCODE_HOME overrides it so tests (and
+// sandboxed environments) can point at a fixture directory.
+func zcodeHome() string {
+	if home := os.Getenv("ZCODE_HOME"); home != "" {
+		return home
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ".zcode"
+	}
+	return filepath.Join(home, ".zcode")
+}
+
+func configPath() string {
+	return filepath.Join(zcodeHome(), "cli", "config.json")
+}
+
+func dbPath() string {
+	return filepath.Join(zcodeHome(), "cli", "db", "db.sqlite")
+}

--- a/agents/entire-agent-zcode/internal/zcode/db.go
+++ b/agents/entire-agent-zcode/internal/zcode/db.go
@@ -1,0 +1,40 @@
+package zcode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// DBQuerier runs read-only queries against ZCode's SQLite store. The default
+// implementation shells out to the `sqlite3` CLI (opened read-only so the
+// app's WAL is never touched); tests substitute their own querier.
+type DBQuerier interface {
+	Query(ctx context.Context, dbPath, query string) ([]byte, error)
+}
+
+type SQLiteQuerier struct{}
+
+func (q *SQLiteQuerier) Query(ctx context.Context, dbPath, query string) ([]byte, error) {
+	if strings.TrimSpace(query) == "" {
+		return nil, errors.New("empty query")
+	}
+	cmd := exec.CommandContext(ctx, "sqlite3", "-readonly", "-json", dbPath, query)
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil, fmt.Errorf("sqlite3 query: %w: %s", err, strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return nil, fmt.Errorf("sqlite3 query: %w", err)
+	}
+	return out, nil
+}
+
+// sqlLiteral single-quotes a value for embedding in a query. sqlite3 has no
+// bind parameters on the CLI, so session ids must be escaped in-band.
+func sqlLiteral(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}

--- a/agents/entire-agent-zcode/internal/zcode/export.go
+++ b/agents/entire-agent-zcode/internal/zcode/export.go
@@ -1,0 +1,257 @@
+package zcode
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const maxTranscriptLine = 10 * 1024 * 1024
+
+// dbJoinedRow is one row of the message⨝part export query. Messages without
+// parts produce one row with a NULL pdata.
+type dbJoinedRow struct {
+	MessageID string          `json:"message_id"`
+	MSequence *int64          `json:"mseq"`
+	MData     json.RawMessage `json:"mdata"`
+	PSequence *int64          `json:"pseq"`
+	PData     json.RawMessage `json:"pdata"`
+}
+
+// querySessionRow loads the session row for id, or (nil, nil) when absent.
+func (a *Agent) querySessionRow(ctx context.Context, sessionID string) (*dbSessionRow, error) {
+	querier := a.querier()
+	if querier == nil {
+		return nil, nil
+	}
+	query := "select id, coalesce(parent_id,'') as parent_id, title, coalesce(directory,'') as directory, time_created, time_updated from session where id = " + sqlLiteral(sessionID)
+	out, err := querier.Query(ctx, dbPath(), query)
+	if err != nil {
+		return nil, fmt.Errorf("query session: %w", err)
+	}
+	trimmed := bytes.TrimSpace(out)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	var rows []dbSessionRow
+	if err := json.Unmarshal(trimmed, &rows); err != nil {
+		return nil, fmt.Errorf("parse session rows: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	return &rows[0], nil
+}
+
+// exportSession reads a session's messages+parts from ZCode's SQLite store
+// and projects them into the export format. Hidden/synthetic content is
+// dropped at this boundary; the JSONL on disk only holds visible content.
+func (a *Agent) exportSession(ctx context.Context, sessionID string) ([]ExportMessage, error) {
+	querier := a.querier()
+	if querier == nil {
+		return nil, nil
+	}
+	query := "select m.id as message_id, m.sequence as mseq, m.data as mdata, p.sequence as pseq, p.data as pdata " +
+		"from message m left join part p on p.message_id = m.id " +
+		"where m.session_id = " + sqlLiteral(sessionID) + " " +
+		"order by coalesce(m.sequence, 0), m.time_created, m.id, coalesce(p.sequence, 0), p.id"
+	out, err := querier.Query(ctx, dbPath(), query)
+	if err != nil {
+		return nil, fmt.Errorf("query messages: %w", err)
+	}
+	trimmed := bytes.TrimSpace(out)
+	var rows []dbJoinedRow
+	if len(trimmed) > 0 {
+		if err := json.Unmarshal(trimmed, &rows); err != nil {
+			return nil, fmt.Errorf("parse message rows: %w", err)
+		}
+	}
+
+	var messages []ExportMessage
+	byID := map[string]int{}
+	for _, row := range rows {
+		var msgData dbMessageData
+		if !decodeJSONColumn(row.MData, &msgData) {
+			continue
+		}
+		if !isVisibleMessage(&msgData) {
+			continue
+		}
+		idx, ok := byID[row.MessageID]
+		if !ok {
+			messages = append(messages, ExportMessage{
+				ID:    row.MessageID,
+				Role:  msgData.Role,
+				Kind:  semanticsKind(&msgData),
+				Time:  msgData.Time.Created,
+				Model: messageModel(&msgData),
+			})
+			idx = len(messages) - 1
+			byID[row.MessageID] = idx
+		}
+		applyTokens(&messages[idx], &msgData)
+		var partData dbPartData
+		if decodeJSONColumn(row.PData, &partData) {
+			applyPart(&messages[idx], partData)
+		}
+	}
+	return messages, nil
+}
+
+// decodeJSONColumn decodes a TEXT column from `sqlite3 -json` output. Such
+// columns arrive as JSON strings containing the row text, so a struct payload
+// is double-encoded; both the direct and string-wrapped forms are accepted.
+func decodeJSONColumn(raw json.RawMessage, dst any) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return false
+	}
+	if err := json.Unmarshal(trimmed, dst); err == nil {
+		return true
+	}
+	var wrapped string
+	if err := json.Unmarshal(trimmed, &wrapped); err != nil {
+		return false
+	}
+	inner := bytes.TrimSpace([]byte(wrapped))
+	if len(inner) == 0 || string(inner) == "null" {
+		return false
+	}
+	return json.Unmarshal(inner, dst) == nil
+}
+
+func (a *Agent) querier() DBQuerier {
+	if a.DBQuerier == nil {
+		return nil
+	}
+	return a.DBQuerier
+}
+
+func isVisibleMessage(msg *dbMessageData) bool {
+	// ZCode tags hidden/synthetic messages (system reminders, internal
+	// continuations); anything explicitly hidden stays out of the export.
+	if msg.Semantics != nil && msg.Semantics.TranscriptVisibility == "hidden" {
+		return false
+	}
+	return msg.Role == "user" || msg.Role == "assistant"
+}
+
+func semanticsKind(msg *dbMessageData) string {
+	if msg.Semantics == nil {
+		return ""
+	}
+	return msg.Semantics.Kind
+}
+
+func messageModel(msg *dbMessageData) string {
+	if msg.ModelID != "" {
+		return msg.ModelID
+	}
+	return msg.Model.ModelID
+}
+
+func applyTokens(msg *ExportMessage, data *dbMessageData) {
+	if data.Tokens == nil {
+		return
+	}
+	tokens := &ExportTokens{
+		Input:  data.Tokens.Input,
+		Output: data.Tokens.Output,
+	}
+	if data.Tokens.Cache != nil {
+		tokens.CacheRead = data.Tokens.Cache.Read
+		tokens.CacheWrite = data.Tokens.Cache.Write
+	}
+	msg.Tokens = tokens
+}
+
+func applyPart(msg *ExportMessage, part dbPartData) {
+	switch part.Type {
+	case "text":
+		if part.Text != "" && !part.Synthetic {
+			if msg.Text == "" {
+				msg.Text = part.Text
+			} else {
+				msg.Text += "\n" + part.Text
+			}
+		}
+	case "tool":
+		if part.Tool == "" {
+			return
+		}
+		tool := ExportTool{Tool: part.Tool}
+		if part.State != nil {
+			tool.Status = part.State.Status
+			tool.Input = part.State.Input
+			tool.Output = part.State.Output
+		}
+		msg.Tools = append(msg.Tools, tool)
+	}
+}
+
+// encodeMessagesJSONL serializes messages as one JSON object per line so
+// Entire's line-based scoping lands on message boundaries.
+func encodeMessagesJSONL(messages []ExportMessage) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	for i := range messages {
+		if err := enc.Encode(&messages[i]); err != nil {
+			return nil, fmt.Errorf("encode message: %w", err)
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// decodeTranscript reads the on-disk JSONL export. Blank/unparseable lines
+// are skipped so header-less scoped slices decode cleanly.
+func decodeTranscript(data []byte) ([]ExportMessage, error) {
+	messages := make([]ExportMessage, 0)
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 64*1024), maxTranscriptLine)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var msg ExportMessage
+		if json.Unmarshal(line, &msg) != nil {
+			continue
+		}
+		if msg.ID == "" && msg.Role == "" {
+			continue
+		}
+		messages = append(messages, msg)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan zcode transcript: %w", err)
+	}
+	return messages, nil
+}
+
+// atomicWriteFile writes data to path via a temp file + rename so a crash
+// mid-write cannot leave a partially-written transcript behind.
+func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".zcode-write-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(mode); err != nil {
+		return errors.Join(err, tmp.Close())
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return errors.Join(err, tmp.Close())
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/agents/entire-agent-zcode/internal/zcode/export_test.go
+++ b/agents/entire-agent-zcode/internal/zcode/export_test.go
@@ -1,0 +1,199 @@
+package zcode
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeQuerier serves canned `sqlite3 -json` output per query substring.
+type fakeQuerier struct {
+	responses map[string]string
+	queries   []string
+}
+
+func (q *fakeQuerier) Query(_ context.Context, dbPath, query string) ([]byte, error) {
+	q.queries = append(q.queries, query)
+	for needle, response := range q.responses {
+		if strings.Contains(query, needle) {
+			return []byte(response), nil
+		}
+	}
+	return nil, nil
+}
+
+// jsonColumn mimics `sqlite3 -json`: TEXT columns are rendered as JSON strings
+// (double-encoded), which the export path must tolerate.
+func jsonColumn(v any) string {
+	raw, _ := json.Marshal(v)
+	return fmt.Sprintf("%q", string(raw))
+}
+
+func TestExportSessionProjectsVisibleContent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("ZCODE_HOME", home)
+	db := filepath.Join(home, "cli", "db", "db.sqlite")
+	if err := os.MkdirAll(filepath.Dir(db), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(db, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	userMsg := map[string]any{
+		"role": "user",
+		"time": map[string]any{"created": 1788277204342},
+		"semantics": map[string]any{
+			"kind": "user_prompt", "origin": "real_user", "transcriptVisibility": "visible",
+		},
+	}
+	assistantMsg := map[string]any{
+		"role":    "assistant",
+		"time":    map[string]any{"created": 1788277209312},
+		"modelID": "GLM-5.3",
+		"tokens":  map[string]any{"input": 100, "output": 20, "cache": map[string]any{"read": 5, "write": 7}},
+	}
+	hiddenMsg := map[string]any{
+		"role": "user",
+		"semantics": map[string]any{
+			"kind": "system_reminder", "transcriptVisibility": "hidden",
+		},
+	}
+	writeToolPart := map[string]any{
+		"type": "tool", "tool": "Write",
+		"state": map[string]any{
+			"status": "completed",
+			"input":  map[string]any{"file_path": "/repo/main.go"},
+			"output": "ok",
+		},
+	}
+	_ = writeToolPart
+	syntheticPart := map[string]any{"type": "text", "text": "<system-reminder>", "synthetic": true}
+	_ = syntheticPart
+	textPart := map[string]any{"type": "text", "text": "Created the file."}
+	_ = textPart
+
+	querier := &fakeQuerier{responses: map[string]string{
+		"from message m left join part p": fmt.Sprintf(`[
+ {"message_id":"m1","mseq":0,"mdata":%s,"pseq":0,"pdata":%s},
+ {"message_id":"m1","mseq":0,"mdata":%s,"pseq":1,"pdata":%s},
+ {"message_id":"m2","mseq":1,"mdata":%s,"pseq":0,"pdata":%s},
+ {"message_id":"m2","mseq":1,"mdata":%s,"pseq":1,"pdata":%s},
+ {"message_id":"m2","mseq":1,"mdata":%s,"pseq":2,"pdata":%s},
+ {"message_id":"m3","mseq":2,"mdata":%s,"pseq":0,"pdata":null}
+]`,
+			jsonColumn(userMsg), jsonColumn(map[string]any{"type": "text", "text": "make a file"}),
+			jsonColumn(userMsg), jsonColumn(map[string]any{"type": "text", "text": "line2"}),
+			jsonColumn(assistantMsg), jsonColumn(syntheticPart),
+			jsonColumn(assistantMsg), jsonColumn(textPart),
+			jsonColumn(assistantMsg), jsonColumn(writeToolPart),
+			jsonColumn(hiddenMsg)),
+		"from session where id": `[{"id":"sess_1","parent_id":"","title":"t","directory":"","time_created":1788277204342,"time_updated":1}]`,
+	}}
+	agent := &Agent{DBQuerier: querier}
+
+	messages, err := agent.exportSession(context.Background(), "sess_1")
+	if err != nil {
+		t.Fatalf("exportSession: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("got %d messages, want 2 (hidden dropped): %+v", len(messages), messages)
+	}
+
+	first := messages[0]
+	if first.Role != "user" || first.Kind != "user_prompt" {
+		t.Fatalf("first message: %+v", first)
+	}
+	if first.Text != "make a file\nline2" {
+		t.Fatalf("text parts not joined: %q", first.Text)
+	}
+
+	second := messages[1]
+	if second.Model != "GLM-5.3" || second.Tokens == nil {
+		t.Fatalf("assistant message: %+v", second)
+	}
+	if second.Text != "Created the file." {
+		t.Fatalf("synthetic part leaked / text lost: %q", second.Text)
+	}
+	if second.Tokens.Input != 100 || second.Tokens.Output != 20 ||
+		second.Tokens.CacheRead != 5 || second.Tokens.CacheWrite != 7 {
+		t.Fatalf("tokens: %+v", second.Tokens)
+	}
+	if len(second.Tools) != 1 || second.Tools[0].Tool != "Write" {
+		t.Fatalf("tools: %+v", second.Tools)
+	}
+
+	// Synthetic text and hidden messages must not appear in the encoded output.
+	encoded, err := encodeMessagesJSONL(messages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "system-reminder") {
+		t.Fatalf("synthetic content leaked: %s", encoded)
+	}
+}
+
+func TestExportSessionEmptyDBOutput(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("ZCODE_HOME", home)
+	agent := &Agent{DBQuerier: &fakeQuerier{}} // no responses → empty output
+	messages, err := agent.exportSession(context.Background(), "sess_x")
+	if err != nil {
+		t.Fatalf("exportSession: %v", err)
+	}
+	if len(messages) != 0 {
+		t.Fatalf("want 0 messages, got %d", len(messages))
+	}
+}
+
+func TestDecodeJSONColumnBothShapes(t *testing.T) {
+	var direct struct{ A string }
+	if !decodeJSONColumn(json.RawMessage(`{"A":"x"}`), &direct) || direct.A != "x" {
+		t.Fatalf("direct object failed: %+v", direct)
+	}
+	var wrapped struct{ A string }
+	if !decodeJSONColumn(json.RawMessage(`"{\"A\":\"y\"}"`), &wrapped) || wrapped.A != "y" {
+		t.Fatalf("string-wrapped failed: %+v", wrapped)
+	}
+	if decodeJSONColumn(json.RawMessage(`null`), &wrapped) {
+		t.Fatal("null should not decode")
+	}
+	if decodeJSONColumn(json.RawMessage(`"not json"`), &wrapped) {
+		t.Fatal("invalid inner JSON should not decode")
+	}
+}
+
+func TestEncodeDecodeTranscriptRoundTrip(t *testing.T) {
+	messages := []ExportMessage{
+		{ID: "m1", Role: "user", Kind: "user_prompt", Time: 1, Text: "hi"},
+		{ID: "m2", Role: "assistant", Time: 2, Model: "GLM-5.3", Text: "hello",
+			Tokens: &ExportTokens{Input: 1, Output: 2},
+			Tools:  []ExportTool{{Tool: "Bash", Status: "completed", Input: json.RawMessage(`{"command":"ls"}`)}}},
+	}
+	encoded, err := encodeMessagesJSONL(messages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(encoded), "\n") != 2 {
+		t.Fatalf("want one line per message: %q", encoded)
+	}
+	decoded, err := decodeTranscript(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded) != 2 || decoded[1].Tools[0].Tool != "Bash" {
+		t.Fatalf("round trip: %+v", decoded)
+	}
+}
+
+func TestSQLLiteralEscaping(t *testing.T) {
+	got := sqlLiteral("sess'a'; drop table session; --")
+	want := "'sess''a''; drop table session; --'"
+	if got != want {
+		t.Fatalf("sqlLiteral = %s, want %s", got, want)
+	}
+}

--- a/agents/entire-agent-zcode/internal/zcode/hooks.go
+++ b/agents/entire-agent-zcode/internal/zcode/hooks.go
@@ -1,0 +1,351 @@
+package zcode
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/entireio/external-agents/agents/entire-agent-zcode/internal/protocol"
+)
+
+// Hook names follow Entire's kebab-case external-agent convention. They map
+// to ZCode's native hook events:
+//
+//	session-start ← SessionStart (source: startup/resume/clear)
+//	compaction    ← SessionStart (source: compact) — installed as a separate
+//	                matcher so ZCode routes it to its own hook name
+//	turn-start    ← UserPromptSubmit
+//	turn-end      ← Stop
+const (
+	HookNameSessionStart = "session-start"
+	HookNameTurnStart    = "turn-start"
+	HookNameTurnEnd      = "turn-end"
+	HookNameCompaction   = "compaction"
+)
+
+// hookStatusMarker identifies our hook entries inside ZCode's user config.
+// ZCode drops unknown keys on its own rewrites of config.json, so entries are
+// recognized structurally (args referencing `hooks zcode <name>`) as well.
+const hookStatusMarker = "entire-agent-zcode"
+
+// hookSpec describes one hook entry to install.
+type hookSpec struct {
+	event   string // ZCode native event name
+	hook    string // Entire hook name passed to `entire hooks zcode <hook>`
+	matcher string // regex matched against the event's match value ("" = all)
+}
+
+var hookSpecs = []hookSpec{
+	{event: "SessionStart", hook: HookNameSessionStart, matcher: ""},
+	// "compact" alone would also match on the matcher for session-start
+	// installed above firing with source=compact; an anchored regex keeps the
+	// two routes disjoint.
+	{event: "SessionStart", hook: HookNameCompaction, matcher: "^compact$"},
+	{event: "UserPromptSubmit", hook: HookNameTurnStart},
+	{event: "Stop", hook: HookNameTurnEnd},
+}
+
+// zcodeHookPayload is the stdin JSON ZCode sends to hooks. Common fields
+// plus per-event extras (source, prompt, last_assistant_message).
+type zcodeHookPayload struct {
+	SessionID            string          `json:"session_id"`
+	TranscriptPath       string          `json:"transcript_path"`
+	Cwd                  string          `json:"cwd"`
+	HookEventName        string          `json:"hook_event_name"`
+	Source               string          `json:"source"`
+	Model                string          `json:"model"`
+	Prompt               string          `json:"prompt"`
+	LastAssistantMessage string          `json:"last_assistant_message"`
+	ToolName             string          `json:"tool_name"`
+	ToolUseID            string          `json:"tool_use_id"`
+	ToolInput            json.RawMessage `json:"tool_input"`
+}
+
+func (a *Agent) ParseHook(hookName string, input []byte) (*protocol.EventJSON, error) {
+	if len(input) == 0 {
+		return nil, nil
+	}
+	var raw zcodeHookPayload
+	if err := json.Unmarshal(input, &raw); err != nil {
+		return nil, fmt.Errorf("parse %s payload: %w", hookName, err)
+	}
+	if raw.SessionID == "" {
+		return nil, nil
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	switch hookName {
+	case HookNameSessionStart:
+		// source=compact means compaction; ZCode also fires SessionStart on
+		// resume/clear which are still session starts for Entire's purposes.
+		eventType := 1
+		if raw.Source == "compact" {
+			eventType = 4
+		}
+		return &protocol.EventJSON{
+			Type:       eventType,
+			SessionID:  raw.SessionID,
+			SessionRef: transcriptPath(raw.SessionID),
+			Model:      raw.Model,
+			Timestamp:  now,
+		}, nil
+
+	case HookNameCompaction:
+		return &protocol.EventJSON{
+			Type:       4,
+			SessionID:  raw.SessionID,
+			SessionRef: transcriptPath(raw.SessionID),
+			Timestamp:  now,
+		}, nil
+
+	case HookNameTurnStart:
+		return &protocol.EventJSON{
+			Type:       2,
+			SessionID:  raw.SessionID,
+			SessionRef: transcriptPath(raw.SessionID),
+			Prompt:     raw.Prompt,
+			Timestamp:  now,
+		}, nil
+
+	case HookNameTurnEnd:
+		return &protocol.EventJSON{
+			Type:            3,
+			SessionID:       raw.SessionID,
+			SessionRef:      transcriptPath(raw.SessionID),
+			ResponseMessage: raw.LastAssistantMessage,
+			Timestamp:       now,
+		}, nil
+
+	default:
+		return nil, nil
+	}
+}
+
+// loadConfig reads ZCode's user config.json into a generic map so every
+// unrelated key survives the round-trip. Missing file → empty config.
+func loadConfig(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]any{}, nil
+		}
+		return nil, err
+	}
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return map[string]any{}, nil
+	}
+	config := map[string]any{}
+	if err := json.Unmarshal([]byte(trimmed), &config); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return config, nil
+}
+
+func saveConfig(path string, config map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+	return atomicWriteFile(path, append(data, '\n'), 0o600)
+}
+
+func asObject(v any) map[string]any {
+	obj, _ := v.(map[string]any)
+	return obj
+}
+
+func asArray(v any) []any {
+	arr, _ := v.([]any)
+	return arr
+}
+
+// entireHookCommand builds the `type: "process"` hook that invokes Entire.
+// localDev reroutes through `go run` on the Entire checkout.
+func entireHookCommand(localDev bool, hook string) map[string]any {
+	if localDev {
+		return map[string]any{
+			"type":          "command",
+			"command":       `go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go hooks zcode ` + hook,
+			"statusMessage": hookStatusMarker + ": " + hook,
+		}
+	}
+	return map[string]any{
+		"type":          "process",
+		"command":       "entire",
+		"args":          []any{"hooks", "zcode", hook},
+		"statusMessage": hookStatusMarker + ": " + hook,
+	}
+}
+
+// isOurGroup reports whether a matcher group from config.json was installed
+// by us. The structural check (args `hooks zcode <hook>`) survives ZCode
+// dropping the statusMessage key.
+func isOurGroup(group any, hook string) bool {
+	obj := asObject(group)
+	if obj == nil {
+		return false
+	}
+	for _, h := range asArray(obj["hooks"]) {
+		hookObj := asObject(h)
+		if hookObj == nil {
+			continue
+		}
+		args := asArray(hookObj["args"])
+		if len(args) == 3 && args[0] == "hooks" && args[1] == "zcode" && args[2] == hook {
+			return true
+		}
+		// statusMessage fallback for shell-style (local-dev) entries: match on
+		// both the marker and the specific hook name so sibling hooks installed
+		// under the same marker are not confused for each other.
+		if status, ok := hookObj["statusMessage"].(string); ok &&
+			strings.Contains(status, hookStatusMarker) && strings.Contains(status, hook) {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *Agent) InstallHooks(localDev bool, force bool) (int, error) {
+	path := configPath()
+	config, err := loadConfig(path)
+	if err != nil {
+		return 0, err
+	}
+
+	hooks := asObject(config["hooks"])
+	if hooks == nil {
+		hooks = map[string]any{}
+		config["hooks"] = hooks
+	}
+	// Configuration-file hooks are disabled unless enabled=true.
+	hooks["enabled"] = true
+	events := asObject(hooks["events"])
+	if events == nil {
+		events = map[string]any{}
+		hooks["events"] = events
+	}
+
+	installed := 0
+	for _, spec := range hookSpecs {
+		groups := asArray(events[spec.event])
+		present := false
+		for _, group := range groups {
+			if isOurGroup(group, spec.hook) {
+				present = true
+				break
+			}
+		}
+		if present && !force {
+			continue
+		}
+		entry := map[string]any{
+			"hooks": []any{entireHookCommand(localDev, spec.hook)},
+		}
+		if spec.matcher != "" {
+			entry["matcher"] = spec.matcher
+		}
+		// With --force, replace our stale entry instead of stacking duplicates.
+		if force && present {
+			replaced := groups[:0]
+			for _, group := range groups {
+				if !isOurGroup(group, spec.hook) {
+					replaced = append(replaced, group)
+				}
+			}
+			groups = replaced
+		}
+		events[spec.event] = append(groups, entry)
+		installed++
+	}
+
+	if installed == 0 {
+		return 0, nil
+	}
+	if err := saveConfig(path, config); err != nil {
+		return 0, fmt.Errorf("write config: %w", err)
+	}
+	return installed, nil
+}
+
+func (a *Agent) UninstallHooks() error {
+	path := configPath()
+	config, err := loadConfig(path)
+	if err != nil {
+		return err
+	}
+	hooks := asObject(config["hooks"])
+	if hooks == nil {
+		return nil
+	}
+	events := asObject(hooks["events"])
+	if events == nil {
+		return nil
+	}
+
+	changed := false
+	for _, spec := range hookSpecs {
+		groups, ok := events[spec.event].([]any)
+		if !ok {
+			continue
+		}
+		kept := groups[:0]
+		for _, group := range groups {
+			if isOurGroup(group, spec.hook) {
+				changed = true
+				continue
+			}
+			kept = append(kept, group)
+		}
+		if len(kept) == 0 {
+			delete(events, spec.event)
+		} else {
+			events[spec.event] = kept
+		}
+	}
+	if !changed {
+		return nil
+	}
+	if len(events) == 0 {
+		delete(hooks, "events")
+		if enabled, ok := hooks["enabled"].(bool); ok && enabled {
+			hooks["enabled"] = false
+		}
+	}
+	return saveConfig(path, config)
+}
+
+func (a *Agent) AreHooksInstalled() bool {
+	config, err := loadConfig(configPath())
+	if err != nil {
+		return false
+	}
+	hooks := asObject(config["hooks"])
+	if hooks == nil {
+		return false
+	}
+	events := asObject(hooks["events"])
+	if events == nil {
+		return false
+	}
+	for _, spec := range hookSpecs {
+		found := false
+		for _, group := range asArray(events[spec.event]) {
+			if isOurGroup(group, spec.hook) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/agents/entire-agent-zcode/internal/zcode/hooks_test.go
+++ b/agents/entire-agent-zcode/internal/zcode/hooks_test.go
@@ -1,0 +1,233 @@
+package zcode
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/external-agents/agents/entire-agent-zcode/internal/protocol"
+)
+
+func withTempZCodeHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("ZCODE_HOME", home)
+	return home
+}
+
+func TestParseHookEventMappings(t *testing.T) {
+	agent := &Agent{}
+	tests := []struct {
+		name     string
+		hook     string
+		payload  string
+		wantType int
+		wantNil  bool
+	}{
+		{name: "session start", hook: HookNameSessionStart,
+			payload: `{"session_id":"sess_1","source":"startup"}`, wantType: 1},
+		{name: "resume is still session start", hook: HookNameSessionStart,
+			payload: `{"session_id":"sess_1","source":"resume"}`, wantType: 1},
+		{name: "compact source becomes compaction", hook: HookNameSessionStart,
+			payload: `{"session_id":"sess_1","source":"compact"}`, wantType: 4},
+		{name: "dedicated compaction hook", hook: HookNameCompaction,
+			payload: `{"session_id":"sess_1","source":"compact"}`, wantType: 4},
+		{name: "turn start carries prompt", hook: HookNameTurnStart,
+			payload: `{"session_id":"sess_1","prompt":"fix the bug"}`, wantType: 2},
+		{name: "turn end carries response", hook: HookNameTurnEnd,
+			payload: `{"session_id":"sess_1","last_assistant_message":"done"}`, wantType: 3},
+		{name: "empty session id is ignored", hook: HookNameTurnStart,
+			payload: `{"prompt":"no session"}`, wantNil: true},
+		{name: "unknown hook is ignored", hook: "pre-tool-use",
+			payload: `{"session_id":"sess_1"}`, wantNil: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event, err := agent.ParseHook(tt.hook, []byte(tt.payload))
+			if err != nil {
+				t.Fatalf("ParseHook: %v", err)
+			}
+			if tt.wantNil {
+				if event != nil {
+					t.Fatalf("want nil event, got %+v", event)
+				}
+				return
+			}
+			if event == nil {
+				t.Fatal("want event, got nil")
+			}
+			if event.Type != tt.wantType {
+				t.Fatalf("type = %d, want %d", event.Type, tt.wantType)
+			}
+			if event.SessionID != "sess_1" {
+				t.Fatalf("session id = %q", event.SessionID)
+			}
+			if event.SessionRef == "" {
+				t.Fatal("session ref must point at the export path")
+			}
+		})
+	}
+}
+
+func TestParseHookTurnFields(t *testing.T) {
+	agent := &Agent{}
+	start, err := agent.ParseHook(HookNameTurnStart, []byte(`{"session_id":"s","prompt":"hello"}`))
+	if err != nil || start == nil {
+		t.Fatalf("turn-start: %v %v", start, err)
+	}
+	if start.Prompt != "hello" {
+		t.Fatalf("prompt = %q", start.Prompt)
+	}
+	end, err := agent.ParseHook(HookNameTurnEnd, []byte(`{"session_id":"s","last_assistant_message":"all done"}`))
+	if err != nil || end == nil {
+		t.Fatalf("turn-end: %v %v", end, err)
+	}
+	if end.ResponseMessage != "all done" {
+		t.Fatalf("response = %q", end.ResponseMessage)
+	}
+}
+
+func TestParseHookEmptyInput(t *testing.T) {
+	agent := &Agent{}
+	event, err := agent.ParseHook(HookNameSessionStart, nil)
+	if err != nil || event != nil {
+		t.Fatalf("want (nil, nil), got (%v, %v)", event, err)
+	}
+}
+
+func TestInstallAreUninstallHooks(t *testing.T) {
+	withTempZCodeHome(t)
+	agent := &Agent{}
+
+	if agent.AreHooksInstalled() {
+		t.Fatal("nothing installed yet")
+	}
+	n, err := agent.InstallHooks(false, false)
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if n != len(hookSpecs) {
+		t.Fatalf("installed %d hooks, want %d", n, len(hookSpecs))
+	}
+	if !agent.AreHooksInstalled() {
+		t.Fatal("hooks should be installed")
+	}
+
+	// Idempotent reinstall.
+	n, err = agent.InstallHooks(false, false)
+	if err != nil {
+		t.Fatalf("reinstall: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("reinstall added %d hooks, want 0", n)
+	}
+
+	if err := agent.UninstallHooks(); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if agent.AreHooksInstalled() {
+		t.Fatal("hooks should be uninstalled")
+	}
+}
+
+func TestInstallHooksPreservesForeignConfig(t *testing.T) {
+	home := withTempZCodeHome(t)
+	path := filepath.Join(home, "cli", "config.json")
+	foreign := map[string]any{
+		"theme": "dark",
+		"hooks": map[string]any{
+			"events": map[string]any{
+				"Stop": []any{map[string]any{
+					"hooks": []any{map[string]any{"type": "command", "command": "echo user-hook"}},
+				}},
+			},
+		},
+	}
+	raw, _ := json.Marshal(foreign)
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	agent := &Agent{}
+	if _, err := agent.InstallHooks(false, false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	var got map[string]any
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("config not valid JSON after install: %v", err)
+	}
+	if got["theme"] != "dark" {
+		t.Fatalf("foreign key lost: %v", got)
+	}
+
+	if err := agent.UninstallHooks(); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	got = map[string]any{}
+	data, _ = os.ReadFile(path)
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["theme"] != "dark" {
+		t.Fatalf("foreign key lost on uninstall: %v", got)
+	}
+	hooks2, ok := got["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("hooks lost: %v", got)
+	}
+	events, ok := hooks2["events"].(map[string]any)
+	if !ok {
+		t.Fatalf("events lost: %v", got)
+	}
+	stopList, ok := events["Stop"].([]any)
+	if !ok || len(stopList) != 1 {
+		t.Fatalf("user Stop hook removed: %v", events["Stop"])
+	}
+	hook, ok := stopList[0].(map[string]any)["hooks"].([]any)[0].(map[string]any)
+	if !ok || hook["command"] != "echo user-hook" {
+		t.Fatalf("wrong survivor: %v", stopList)
+	}
+}
+
+func TestInstallHooksForceReplacesStaleEntries(t *testing.T) {
+	withTempZCodeHome(t)
+	agent := &Agent{}
+	if _, err := agent.InstallHooks(false, false); err != nil {
+		t.Fatal(err)
+	}
+	n, err := agent.InstallHooks(false, true)
+	if err != nil {
+		t.Fatalf("force install: %v", err)
+	}
+	if n != len(hookSpecs) {
+		t.Fatalf("force install replaced %d, want %d", n, len(hookSpecs))
+	}
+	if !agent.AreHooksInstalled() {
+		t.Fatal("hooks missing after force install")
+	}
+}
+
+func TestInfoDeclaresImplementedCapabilities(t *testing.T) {
+	info := (&Agent{}).Info()
+	if info.Name != "zcode" || info.ProtocolVersion != protocol.ProtocolVersion {
+		t.Fatalf("info: %+v", info)
+	}
+	caps := info.Capabilities
+	if !caps.Hooks || !caps.TranscriptAnalyzer || !caps.TranscriptPreparer || !caps.TokenCalculator {
+		t.Fatalf("missing declared capabilities: %+v", caps)
+	}
+	for _, forbidden := range []bool{caps.TextGenerator, caps.SubagentAwareExtractor, caps.CompactTranscript} {
+		if forbidden {
+			t.Fatalf("undeclared capability must be false: %+v", caps)
+		}
+	}
+}

--- a/agents/entire-agent-zcode/internal/zcode/paths.go
+++ b/agents/entire-agent-zcode/internal/zcode/paths.go
@@ -7,26 +7,40 @@ import (
 	"github.com/entireio/external-agents/agents/entire-agent-zcode/internal/protocol"
 )
 
-const transcriptSubdir = "zcode"
-
-func (a *Agent) GetSessionDir(repoPath string) (string, error) {
-	return protocol.DefaultSessionDir(repoPath), nil
+// GetSessionDir returns the directory where Entire stores zcode session
+// snapshots and exported transcripts. It deliberately lives OUTSIDE the repo:
+// Entire attributes a session to the agent whose session dir contains its
+// transcript path, and repo-local scratch dirs like .entire/tmp nest inside
+// other external agents' session dirs (kilo, amp, ... use .entire/tmp), which
+// misattributes zcode sessions to whichever such agent sorts first.
+//
+// ZCode keys sessions by ID globally (its SQLite store is not per-repo), so
+// repoPath does not change the location; the dir hangs off ZCode's own home
+// and follows the ZCODE_HOME override used by tests.
+func (a *Agent) GetSessionDir(_ string) (string, error) {
+	return entireSessionDir(), nil
 }
 
 func (a *Agent) ResolveSessionFile(sessionDir, sessionID string) string {
 	return protocol.ResolveSessionFile(sessionDir, sessionID)
 }
 
+// entireSessionDir is where write-session snapshots (<id>.json) and exported
+// transcripts (<id>.jsonl) live.
+func entireSessionDir() string {
+	return filepath.Join(zcodeHome(), "entire", "sessions")
+}
+
 // transcriptPath is the JSONL transcript this agent exports from ZCode's
 // SQLite store. One message per line so line index == message index, which is
 // the unit Entire records via get-transcript-position.
 func transcriptPath(sessionID string) string {
-	return filepath.Join(protocol.DefaultSessionDir(protocol.RepoRoot()), transcriptSubdir, safeSessionID(sessionID)+".jsonl")
+	return filepath.Join(entireSessionDir(), safeSessionID(sessionID)+".jsonl")
 }
 
 // sessionIDFromTranscriptRef recovers the ZCode session id from an exported
-// transcript path (<session_dir>/zcode/<safe-id>.jsonl). Message ids do not
-// encode the session id, so the filename is the source of truth.
+// transcript path (<session-dir>/<safe-id>.jsonl). Message ids do not encode
+// the session id, so the filename is the source of truth.
 func sessionIDFromTranscriptRef(sessionRef string) string {
 	base := filepath.Base(sessionRef)
 	ext := filepath.Ext(base)

--- a/agents/entire-agent-zcode/internal/zcode/paths.go
+++ b/agents/entire-agent-zcode/internal/zcode/paths.go
@@ -1,0 +1,46 @@
+package zcode
+
+import (
+	"path/filepath"
+	"regexp"
+
+	"github.com/entireio/external-agents/agents/entire-agent-zcode/internal/protocol"
+)
+
+const transcriptSubdir = "zcode"
+
+func (a *Agent) GetSessionDir(repoPath string) (string, error) {
+	return protocol.DefaultSessionDir(repoPath), nil
+}
+
+func (a *Agent) ResolveSessionFile(sessionDir, sessionID string) string {
+	return protocol.ResolveSessionFile(sessionDir, sessionID)
+}
+
+// transcriptPath is the JSONL transcript this agent exports from ZCode's
+// SQLite store. One message per line so line index == message index, which is
+// the unit Entire records via get-transcript-position.
+func transcriptPath(sessionID string) string {
+	return filepath.Join(protocol.DefaultSessionDir(protocol.RepoRoot()), transcriptSubdir, safeSessionID(sessionID)+".jsonl")
+}
+
+// sessionIDFromTranscriptRef recovers the ZCode session id from an exported
+// transcript path (<session_dir>/zcode/<safe-id>.jsonl). Message ids do not
+// encode the session id, so the filename is the source of truth.
+func sessionIDFromTranscriptRef(sessionRef string) string {
+	base := filepath.Base(sessionRef)
+	ext := filepath.Ext(base)
+	if ext == "" {
+		return base
+	}
+	return base[:len(base)-len(ext)]
+}
+
+var unsafeSessionIDChars = regexp.MustCompile(`[^A-Za-z0-9_.-]+`)
+
+func safeSessionID(sessionID string) string {
+	if sessionID == "" {
+		return "unknown"
+	}
+	return unsafeSessionIDChars.ReplaceAllString(sessionID, "_")
+}

--- a/agents/entire-agent-zcode/internal/zcode/transcript.go
+++ b/agents/entire-agent-zcode/internal/zcode/transcript.go
@@ -175,7 +175,7 @@ func (a *Agent) loadMessages(ctx context.Context, sessionID, sessionRef string) 
 }
 
 // PrepareTranscript materializes the JSONL export for a session. sessionRef
-// is the transcript path (<session_dir>/zcode/<id>.jsonl). Never clobbers an
+// is the transcript path (<session_dir>/<id>.jsonl). Never clobbers an
 // existing transcript with an empty export — a store that is momentarily
 // unreadable must not destroy the last good transcript.
 func (a *Agent) PrepareTranscript(sessionRef string) error {

--- a/agents/entire-agent-zcode/internal/zcode/transcript.go
+++ b/agents/entire-agent-zcode/internal/zcode/transcript.go
@@ -1,0 +1,424 @@
+package zcode
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/entireio/external-agents/agents/entire-agent-zcode/internal/protocol"
+)
+
+func (a *Agent) ReadSession(input *protocol.HookInputJSON) (protocol.AgentSessionJSON, error) {
+	var sessionID string
+	var sessionRef string
+	if input != nil {
+		sessionID = input.SessionID
+		sessionRef = input.SessionRef
+		if sessionRef == "" && sessionID != "" {
+			sessionRef = transcriptPath(sessionID)
+		}
+	}
+	if sessionRef == "" {
+		return protocol.AgentSessionJSON{}, errors.New("session_ref or session_id is required")
+	}
+
+	// A session_ref that exists on disk but is not a transcript export is a
+	// write-session snapshot (Entire stores raw native_data there); echo the
+	// bytes back. Transcript refs (.jsonl under the zcode export dir) and
+	// missing files fall through to the live transcript paths.
+	if input != nil && input.SessionRef != "" && !isTranscriptExportRef(input.SessionRef) {
+		if session, ok, err := readStoredSession(input.SessionRef, sessionID); err == nil && ok {
+			return session, nil
+		}
+	}
+
+	// Prefer a fresh export from ZCode's store; fall back to the last
+	// prepared transcript file when the store is unavailable (app closed,
+	// fixture-only environments).
+	messages, startMS, err := a.loadMessages(context.Background(), sessionID, sessionRef)
+	if err != nil {
+		return protocol.AgentSessionJSON{}, err
+	}
+	if sessionID == "" {
+		sessionID = sessionIDFromTranscriptRef(sessionRef)
+	}
+
+	encoded, err := encodeMessagesJSONL(messages)
+	if err != nil {
+		return protocol.AgentSessionJSON{}, err
+	}
+
+	startTime := time.Now().UTC()
+	if startMS > 0 {
+		startTime = time.UnixMilli(startMS)
+	} else if len(messages) > 0 && messages[0].Time > 0 {
+		startTime = time.UnixMilli(messages[0].Time)
+	}
+
+	return protocol.AgentSessionJSON{
+		SessionID:     sessionID,
+		AgentName:     "zcode",
+		RepoPath:      protocol.RepoRoot(),
+		SessionRef:    sessionRef,
+		StartTime:     startTime.Format(time.RFC3339),
+		NativeData:    encoded,
+		ModifiedFiles: modifiedFilesFromMessages(messages),
+		NewFiles:      []string{},
+		DeletedFiles:  []string{},
+	}, nil
+}
+
+// isTranscriptExportRef reports whether a session_ref points at a JSONL
+// transcript exported by prepare-transcript rather than a session snapshot.
+func isTranscriptExportRef(sessionRef string) bool {
+	return filepath.Ext(sessionRef) == ".jsonl"
+}
+
+// readStoredSession builds an AgentSession from a write-session snapshot at
+// path: an AgentSession envelope is echoed with its own fields, any other
+// non-empty file is returned with its raw bytes as native_data.
+func readStoredSession(path, sessionID string) (protocol.AgentSessionJSON, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return protocol.AgentSessionJSON{}, false, nil
+		}
+		return protocol.AgentSessionJSON{}, false, err
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return protocol.AgentSessionJSON{}, false, nil
+	}
+
+	var stored protocol.AgentSessionJSON
+	if err := json.Unmarshal(data, &stored); err == nil &&
+		(stored.SessionID != "" || stored.AgentName != "") {
+		if stored.SessionRef == "" {
+			stored.SessionRef = path
+		}
+		return stored, true, nil
+	}
+
+	// Raw native_data bytes: derive what we can from the content and file.
+	messages, decodeErr := decodeTranscript(data)
+	session := protocol.AgentSessionJSON{
+		SessionID:  sessionID,
+		AgentName:  "zcode",
+		RepoPath:   protocol.RepoRoot(),
+		SessionRef: path,
+		NativeData: data,
+	}
+	if decodeErr == nil && len(messages) > 0 {
+		if sessionID == "" {
+			session.SessionID = sessionIDFromTranscriptRef(path)
+		}
+		if messages[0].Time > 0 {
+			session.StartTime = time.UnixMilli(messages[0].Time).UTC().Format(time.RFC3339)
+		}
+		session.ModifiedFiles = modifiedFilesFromMessages(messages)
+	}
+	if session.StartTime == "" {
+		if info, statErr := os.Stat(path); statErr == nil {
+			session.StartTime = info.ModTime().UTC().Format(time.RFC3339)
+		} else {
+			session.StartTime = time.Now().UTC().Format(time.RFC3339)
+		}
+	}
+	if session.ModifiedFiles == nil {
+		session.ModifiedFiles = []string{}
+	}
+	session.NewFiles = []string{}
+	session.DeletedFiles = []string{}
+	return session, true, nil
+}
+
+// loadMessages exports from the SQLite store when possible, otherwise reads
+// the prepared transcript file.
+func (a *Agent) loadMessages(ctx context.Context, sessionID, sessionRef string) ([]ExportMessage, int64, error) {
+	if sessionID != "" && a.querier() != nil {
+		if _, statErr := os.Stat(dbPath()); statErr == nil {
+			session, err := a.querySessionRow(ctx, sessionID)
+			if err != nil {
+				return nil, 0, err
+			}
+			messages, err := a.exportSession(ctx, sessionID)
+			if err != nil {
+				return nil, 0, err
+			}
+			if len(messages) > 0 {
+				var startMS int64
+				if session != nil {
+					startMS = session.TimeCreated
+				}
+				return messages, startMS, nil
+			}
+		}
+	}
+	data, err := os.ReadFile(sessionRef)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, 0, nil
+		}
+		return nil, 0, err
+	}
+	messages, err := decodeTranscript(data)
+	if err != nil {
+		return nil, 0, err
+	}
+	return messages, 0, nil
+}
+
+// PrepareTranscript materializes the JSONL export for a session. sessionRef
+// is the transcript path (<session_dir>/zcode/<id>.jsonl). Never clobbers an
+// existing transcript with an empty export — a store that is momentarily
+// unreadable must not destroy the last good transcript.
+func (a *Agent) PrepareTranscript(sessionRef string) error {
+	if strings.TrimSpace(sessionRef) == "" {
+		return errors.New("session_ref is required")
+	}
+	if a.querier() == nil {
+		return nil
+	}
+	sessionID := sessionIDFromTranscriptRef(sessionRef)
+	if _, statErr := os.Stat(dbPath()); statErr == nil {
+		return a.exportTo(sessionID, sessionRef)
+	}
+	return nil
+}
+
+func (a *Agent) exportTo(sessionID, sessionRef string) error {
+	messages, err := a.exportSession(context.Background(), sessionID)
+	if err != nil {
+		return fmt.Errorf("export session %s: %w", sessionID, err)
+	}
+	if len(messages) == 0 {
+		return nil
+	}
+	encoded, err := encodeMessagesJSONL(messages)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(sessionRef), 0o750); err != nil {
+		return err
+	}
+	return atomicWriteFile(sessionRef, encoded, 0o600)
+}
+
+// WriteSession persists Entire's session snapshot next to the transcript.
+// ZCode's own store is never written to — restoring a live session happens
+// through ZCode's UI; this snapshot exists for Entire's bookkeeping.
+func (a *Agent) WriteSession(session protocol.AgentSessionJSON) error {
+	if session.SessionRef == "" {
+		return errors.New("session_ref is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(session.SessionRef), 0o700); err != nil {
+		return err
+	}
+	return atomicWriteFile(session.SessionRef, session.NativeData, 0o600)
+}
+
+func (a *Agent) ReadTranscript(sessionRef string) ([]byte, error) {
+	data, err := os.ReadFile(sessionRef)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := decodeTranscript(data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (a *Agent) ChunkTranscript(content []byte, maxSize int) ([][]byte, error) {
+	if maxSize <= 0 {
+		return nil, fmt.Errorf("max-size must be positive, got %d", maxSize)
+	}
+	var chunks [][]byte
+	for len(content) > 0 {
+		end := min(maxSize, len(content))
+		chunks = append(chunks, content[:end])
+		content = content[end:]
+	}
+	return chunks, nil
+}
+
+func (a *Agent) ReassembleTranscript(chunks [][]byte) ([]byte, error) {
+	var data []byte
+	for _, chunk := range chunks {
+		data = append(data, chunk...)
+	}
+	return data, nil
+}
+
+// readMessages loads and decodes a transcript file, tolerating a missing
+// file as empty (Entire records position 0 for new sessions).
+func readMessages(path string) ([]ExportMessage, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return decodeTranscript(data)
+}
+
+func (a *Agent) GetTranscriptPosition(path string) (int, error) {
+	messages, err := readMessages(path)
+	if err != nil {
+		return 0, err
+	}
+	return len(messages), nil
+}
+
+func (a *Agent) ExtractModifiedFiles(path string, offset int) ([]string, int, error) {
+	messages, err := readMessages(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	return modifiedFilesFromMessages(messagesFromOffset(messages, offset)), len(messages), nil
+}
+
+func (a *Agent) ExtractPrompts(sessionRef string, offset int) ([]string, error) {
+	messages, err := readMessages(sessionRef)
+	if err != nil {
+		return nil, err
+	}
+	var prompts []string
+	for _, msg := range messagesFromOffset(messages, offset) {
+		if msg.Role != "user" || !isUserPrompt(msg) || msg.Text == "" {
+			continue
+		}
+		prompts = append(prompts, msg.Text)
+	}
+	return prompts, nil
+}
+
+func (a *Agent) ExtractSummary(sessionRef string) (string, bool, error) {
+	messages, err := readMessages(sessionRef)
+	if err != nil {
+		return "", false, err
+	}
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		if msg.Role != "assistant" || msg.Text == "" {
+			continue
+		}
+		return msg.Text, true, nil
+	}
+	return "", false, nil
+}
+
+func (a *Agent) CalculateTokens(data []byte, offset int) (protocol.TokenUsageResponse, error) {
+	messages, err := decodeTranscript(data)
+	if err != nil {
+		return protocol.TokenUsageResponse{}, err
+	}
+	var usage protocol.TokenUsageResponse
+	for _, msg := range messagesFromOffset(messages, offset) {
+		if msg.Role != "assistant" || msg.Tokens == nil {
+			continue
+		}
+		usage.InputTokens += msg.Tokens.Input
+		usage.OutputTokens += msg.Tokens.Output
+		usage.CacheReadTokens += msg.Tokens.CacheRead
+		usage.CacheCreationTokens += msg.Tokens.CacheWrite
+		usage.APICallCount++
+	}
+	return usage, nil
+}
+
+// isUserPrompt distinguishes real user prompts from synthetic user-role
+// messages (system reminders, goal continuations). Anything without a
+// semantics kind recorded falls back to role alone.
+func isUserPrompt(msg ExportMessage) bool {
+	if msg.Kind == "" || msg.Kind == "user_prompt" {
+		return true
+	}
+	return false
+}
+
+// messagesFromOffset returns the messages at index >= offset; the on-disk
+// transcript is one message per line, so the line offset Entire records via
+// get-transcript-position is also a message index.
+func messagesFromOffset(messages []ExportMessage, offset int) []ExportMessage {
+	if len(messages) == 0 {
+		return nil
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(messages) {
+		return nil
+	}
+	return messages[offset:]
+}
+
+// toolInputFileKeys lists the JSON object keys to scan on a tool call's
+// input for file paths (single- and multi-path forms).
+var toolInputFileKeys = []string{"file_path", "filePath", "filepath", "path", "absolutePath", "paths", "files"}
+
+func modifiedFilesFromMessages(messages []ExportMessage) []string {
+	seen := map[string]bool{}
+	for _, msg := range messages {
+		for _, tool := range msg.Tools {
+			if !isMutatingToolName(tool.Tool) {
+				continue
+			}
+			for _, file := range filePathsFromJSON(tool.Input, toolInputFileKeys) {
+				if file != "" {
+					seen[file] = true
+				}
+			}
+		}
+	}
+	files := make([]string, 0, len(seen))
+	for file := range seen {
+		files = append(files, file)
+	}
+	sort.Strings(files)
+	return files
+}
+
+func filePathsFromJSON(raw []byte, keys []string) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil
+	}
+	var files []string
+	for _, key := range keys {
+		switch value := obj[key].(type) {
+		case string:
+			if strings.TrimSpace(value) != "" {
+				files = append(files, value)
+			}
+		case []any:
+			for _, item := range value {
+				if s, ok := item.(string); ok && strings.TrimSpace(s) != "" {
+					files = append(files, s)
+				}
+			}
+		}
+	}
+	return files
+}
+
+// isMutatingToolName covers ZCode's write-capable tool names (Write, Edit,
+// ApplyPatch alias) plus generic fallbacks.
+func isMutatingToolName(name string) bool {
+	switch strings.ReplaceAll(strings.ToLower(strings.TrimSpace(name)), "-", "_") {
+	case "write", "edit", "multiedit", "multi_edit", "apply_patch", "patch",
+		"create", "create_file", "delete", "delete_file", "move", "move_file",
+		"rename", "rename_file":
+		return true
+	}
+	return false
+}

--- a/agents/entire-agent-zcode/internal/zcode/transcript_test.go
+++ b/agents/entire-agent-zcode/internal/zcode/transcript_test.go
@@ -1,0 +1,285 @@
+package zcode
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/external-agents/agents/entire-agent-zcode/internal/protocol"
+)
+
+func writeTranscript(t *testing.T, dir string, messages []ExportMessage) string {
+	t.Helper()
+	encoded, err := encodeMessagesJSONL(messages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "sess_1.jsonl")
+	if err := os.WriteFile(path, encoded, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func sampleMessages() []ExportMessage {
+	return []ExportMessage{
+		{ID: "m1", Role: "user", Kind: "user_prompt", Time: 1000, Text: "first prompt"},
+		{ID: "m2", Role: "assistant", Time: 2000, Model: "GLM-5.3", Text: "working",
+			Tokens: &ExportTokens{Input: 10, Output: 5, CacheRead: 1, CacheWrite: 2},
+			Tools:  []ExportTool{{Tool: "Write", Status: "completed", Input: json.RawMessage(`{"file_path":"/repo/a.go"}`)}}},
+		{ID: "m3", Role: "user", Kind: "user_prompt", Time: 3000, Text: "second prompt"},
+		{ID: "m4", Role: "assistant", Time: 4000, Text: "final answer",
+			Tokens: &ExportTokens{Input: 20, Output: 8},
+			Tools: []ExportTool{
+				{Tool: "Edit", Status: "completed", Input: json.RawMessage(`{"file_path":"/repo/b.go"}`)},
+				{Tool: "Edit", Status: "completed", Input: json.RawMessage(`{"file_path":"/repo/a.go"}`)}, // duplicate
+				{Tool: "Read", Status: "completed", Input: json.RawMessage(`{"file_path":"/repo/c.go"}`)}, // not mutating
+			}},
+	}
+}
+
+func TestGetTranscriptPosition(t *testing.T) {
+	path := writeTranscript(t, t.TempDir(), sampleMessages())
+	pos, err := (&Agent{}).GetTranscriptPosition(path)
+	if err != nil || pos != 4 {
+		t.Fatalf("position = %d, %v; want 4", pos, err)
+	}
+	pos, err = (&Agent{}).GetTranscriptPosition(filepath.Join(t.TempDir(), "missing.jsonl"))
+	if err != nil || pos != 0 {
+		t.Fatalf("missing file: position = %d, %v; want 0", pos, err)
+	}
+}
+
+func TestExtractModifiedFiles(t *testing.T) {
+	path := writeTranscript(t, t.TempDir(), sampleMessages())
+	files, current, err := (&Agent{}).ExtractModifiedFiles(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"/repo/a.go", "/repo/b.go"} // sorted, deduped, read excluded
+	if len(files) != 2 || files[0] != want[0] || files[1] != want[1] {
+		t.Fatalf("files = %v, want %v", files, want)
+	}
+	if current != 4 {
+		t.Fatalf("current position = %d, want 4", current)
+	}
+
+	// Offset scopes to messages after the first write.
+	files, _, err = (&Agent{}).ExtractModifiedFiles(path, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 2 { // m4 edits both a.go and b.go
+		t.Fatalf("offset files = %v", files)
+	}
+}
+
+func TestExtractPromptsRespectsOffsetAndKind(t *testing.T) {
+	msgs := sampleMessages()
+	msgs = append(msgs, ExportMessage{ID: "m5", Role: "user", Kind: "system_reminder", Time: 5000, Text: "hidden"})
+	path := writeTranscript(t, t.TempDir(), msgs)
+
+	prompts, err := (&Agent{}).ExtractPrompts(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prompts) != 2 || prompts[0] != "first prompt" || prompts[1] != "second prompt" {
+		t.Fatalf("prompts = %v", prompts)
+	}
+	prompts, err = (&Agent{}).ExtractPrompts(path, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prompts) != 1 || prompts[0] != "second prompt" {
+		t.Fatalf("offset prompts = %v", prompts)
+	}
+}
+
+func TestExtractSummary(t *testing.T) {
+	path := writeTranscript(t, t.TempDir(), sampleMessages())
+	summary, ok, err := (&Agent{}).ExtractSummary(path)
+	if err != nil || !ok || summary != "final answer" {
+		t.Fatalf("summary = %q ok=%v err=%v", summary, ok, err)
+	}
+}
+
+func TestCalculateTokens(t *testing.T) {
+	data, err := encodeMessagesJSONL(sampleMessages())
+	if err != nil {
+		t.Fatal(err)
+	}
+	usage, err := (&Agent{}).CalculateTokens(data, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage.InputTokens != 30 || usage.OutputTokens != 13 ||
+		usage.CacheReadTokens != 1 || usage.CacheCreationTokens != 2 || usage.APICallCount != 2 {
+		t.Fatalf("usage = %+v", usage)
+	}
+
+	// Offset skips m2's tokens.
+	usage, err = (&Agent{}).CalculateTokens(data, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage.InputTokens != 20 || usage.APICallCount != 1 {
+		t.Fatalf("offset usage = %+v", usage)
+	}
+}
+
+func TestChunkReassembleRoundTrip(t *testing.T) {
+	agent := &Agent{}
+	content := []byte("abcdefghijklmnopqrstuvwxyz")
+	chunks, err := agent.ChunkTranscript(content, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(chunks) != 3 {
+		t.Fatalf("chunks = %d, want 3", len(chunks))
+	}
+	back, err := agent.ReassembleTranscript(chunks)
+	if err != nil || string(back) != string(content) {
+		t.Fatalf("round trip mismatch: %q %v", back, err)
+	}
+	if _, err := agent.ChunkTranscript(content, 0); err == nil {
+		t.Fatal("max-size 0 must be rejected")
+	}
+}
+
+func TestReadSessionFallsBackToTranscriptFile(t *testing.T) {
+	t.Setenv("ZCODE_HOME", t.TempDir()) // no db → file fallback
+	path := writeTranscript(t, t.TempDir(), sampleMessages())
+
+	session, err := (&Agent{DBQuerier: &SQLiteQuerier{}}).ReadSession(&protocol.HookInputJSON{
+		HookType:   "session_start",
+		SessionID:  "sess_1",
+		SessionRef: path,
+	})
+	if err != nil {
+		t.Fatalf("ReadSession: %v", err)
+	}
+	if session.AgentName != "zcode" || session.SessionID != "sess_1" {
+		t.Fatalf("session = %+v", session)
+	}
+	if session.SessionRef == "" || len(session.NativeData) == 0 {
+		t.Fatalf("session ref/native data: %+v", session)
+	}
+	if len(session.ModifiedFiles) != 2 {
+		t.Fatalf("modified files = %v", session.ModifiedFiles)
+	}
+	if _, err := (&Agent{}).ReadSession(&protocol.HookInputJSON{}); err == nil {
+		t.Fatal("missing session_ref/session_id must error")
+	}
+}
+
+func TestReadSessionEchoesStoredSnapshot(t *testing.T) {
+	t.Setenv("ZCODE_HOME", t.TempDir()) // no db interference
+	dir := t.TempDir()
+	ref := filepath.Join(dir, "sess_snap.json")
+	stored := protocol.AgentSessionJSON{
+		SessionID:     "sess_snap",
+		AgentName:     "zcode",
+		RepoPath:      "/repo",
+		SessionRef:    ref,
+		StartTime:     "2026-09-01T00:00:00Z",
+		NativeData:    []byte(`{"test": true}`),
+		ModifiedFiles: []string{"file1.go"},
+		NewFiles:      []string{"file3.go"},
+		DeletedFiles:  []string{},
+	}
+	raw, err := json.Marshal(stored)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ref, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	readBack, err := (&Agent{}).ReadSession(&protocol.HookInputJSON{
+		HookType:   "session_start",
+		SessionID:  "sess_snap",
+		SessionRef: ref,
+	})
+	if err != nil {
+		t.Fatalf("ReadSession: %v", err)
+	}
+	if string(readBack.NativeData) != `{"test": true}` || readBack.SessionRef != ref {
+		t.Fatalf("snapshot not echoed: %+v", readBack)
+	}
+}
+
+func TestPrepareTranscriptNeverClobbersWithEmpty(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ZCODE_HOME", t.TempDir()) // no db
+	ref := filepath.Join(dir, "sess_keep.jsonl")
+	existing, err := encodeMessagesJSONL(sampleMessages())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ref, existing, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&Agent{DBQuerier: &SQLiteQuerier{}}).PrepareTranscript(ref); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(ref)
+	if len(data) != len(existing) {
+		t.Fatal("empty export must not clobber the existing transcript")
+	}
+}
+
+func TestPrepareTranscriptExportsFromStore(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("ZCODE_HOME", home)
+	db := filepath.Join(home, "cli", "db", "db.sqlite")
+	if err := os.MkdirAll(filepath.Dir(db), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(db, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	msg := map[string]any{"role": "assistant", "time": map[string]any{"created": 1}, "modelID": "GLM-5.3"}
+	querier := &fakeQuerier{responses: map[string]string{
+		"from message m left join part p": fmt.Sprintf(`[{"message_id":"m1","mseq":0,"mdata":%s,"pseq":0,"pdata":null}]`, jsonColumn(msg)),
+		"from session where id":           `[{"id":"sess_1","parent_id":"","title":"t","directory":"","time_created":1,"time_updated":1}]`,
+	}}
+	agent := &Agent{DBQuerier: querier}
+	ref := filepath.Join(t.TempDir(), "sess_1.jsonl")
+	if err := agent.PrepareTranscript(ref); err != nil {
+		t.Fatalf("PrepareTranscript: %v", err)
+	}
+	messages, err := readMessages(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 || messages[0].Model != "GLM-5.3" {
+		t.Fatalf("exported = %+v", messages)
+	}
+}
+
+func TestWriteAndReadTranscriptRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	ref := filepath.Join(dir, "sess_w.jsonl")
+	agent := &Agent{}
+	messages := sampleMessages()
+	encoded, err := encodeMessagesJSONL(messages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.WriteSession(protocol.AgentSessionJSON{
+		SessionRef: ref,
+		NativeData: encoded,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := agent.ReadTranscript(ref)
+	if err != nil {
+		t.Fatalf("ReadTranscript: %v", err)
+	}
+	decoded, err := decodeTranscript(data)
+	if err != nil || len(decoded) != len(messages) {
+		t.Fatalf("round trip: %d messages, err %v", len(decoded), err)
+	}
+}

--- a/agents/entire-agent-zcode/internal/zcode/types.go
+++ b/agents/entire-agent-zcode/internal/zcode/types.go
@@ -1,0 +1,78 @@
+package zcode
+
+import "encoding/json"
+
+// ExportMessage is one line of the JSONL transcript this agent writes. It is
+// a lossy, protocol-friendly projection of ZCode's native message+part rows:
+// hidden/synthetic content is dropped, and tool parts are flattened.
+type ExportMessage struct {
+	ID     string        `json:"id"`
+	Role   string        `json:"role"`
+	Kind   string        `json:"kind,omitempty"` // semantics.kind, e.g. user_prompt
+	Time   int64         `json:"time"`           // unix milliseconds
+	Model  string        `json:"model,omitempty"`
+	Text   string        `json:"text,omitempty"` // visible text parts joined by newline
+	Tokens *ExportTokens `json:"tokens,omitempty"`
+	Tools  []ExportTool  `json:"tools,omitempty"`
+}
+
+type ExportTokens struct {
+	Input      int `json:"input"`
+	Output     int `json:"output"`
+	CacheRead  int `json:"cache_read"`
+	CacheWrite int `json:"cache_write"`
+}
+
+type ExportTool struct {
+	Tool   string          `json:"tool"`
+	Status string          `json:"status,omitempty"`
+	Input  json.RawMessage `json:"input,omitempty"`
+	Output string          `json:"output,omitempty"`
+}
+
+// Native row shapes from ZCode's SQLite store (message.data / part.data).
+
+type dbMessageData struct {
+	Role string `json:"role"`
+	Time struct {
+		Created int64 `json:"created"` // unix milliseconds
+	} `json:"time"`
+	ModelID string `json:"modelID"`
+	Model   struct {
+		ModelID string `json:"modelID"`
+	} `json:"model"`
+	Tokens *struct {
+		Input  int `json:"input"`
+		Output int `json:"output"`
+		Cache  *struct {
+			Read  int `json:"read"`
+			Write int `json:"write"`
+		} `json:"cache"`
+	} `json:"tokens"`
+	Semantics *struct {
+		Origin               string `json:"origin"`
+		Kind                 string `json:"kind"`
+		TranscriptVisibility string `json:"transcriptVisibility"`
+	} `json:"semantics"`
+}
+
+type dbPartData struct {
+	Type      string `json:"type"`
+	Text      string `json:"text"`
+	Synthetic bool   `json:"synthetic"`
+	Tool      string `json:"tool"`
+	State     *struct {
+		Status string          `json:"status"`
+		Input  json.RawMessage `json:"input"`
+		Output string          `json:"output"`
+	} `json:"state"`
+}
+
+type dbSessionRow struct {
+	ID          string `json:"id"`
+	ParentID    string `json:"parent_id"`
+	Title       string `json:"title"`
+	Directory   string `json:"directory"`
+	TimeCreated int64  `json:"time_created"`
+	TimeUpdated int64  `json:"time_updated"`
+}

--- a/agents/entire-agent-zcode/mise.toml
+++ b/agents/entire-agent-zcode/mise.toml
@@ -1,0 +1,10 @@
+[tools]
+go = "1.26.0"
+
+[tasks.build]
+description = "Build the entire-agent-zcode binary"
+run = "go build -o entire-agent-zcode ./cmd/entire-agent-zcode"
+
+[tasks.test]
+description = "Run unit tests"
+run = "go test ./..."

--- a/agents/entire-agent-zcode/scripts/verify-zcode.sh
+++ b/agents/entire-agent-zcode/scripts/verify-zcode.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# verify-zcode.sh — capture real ZCode hook payloads and verify session storage.
+#
+# ZCode is an Electron desktop app, so this script cannot launch a session
+# itself. Use --manual-live: it wires hook captures into the USER config
+# (~/.zcode/cli/config.json — the only executed config source; workspace
+# configs are ignored), then you interact with ZCode normally, press Enter
+# here, and it pretty-prints every captured payload and restores the config.
+set -euo pipefail
+
+AGENT_NAME="ZCode"
+AGENT_SLUG="zcode"
+CONFIG="$HOME/.zcode/cli/config.json"
+PROBE_DIR="$(cd "$(dirname "$0")" && pwd)/.probe-${AGENT_SLUG}-$(date +%s)"
+CAPTURES="$PROBE_DIR/captures"
+MARKER="entire-agent-zcode-probe"
+ENTIRE_BIN="${E2E_ENTIRE_BIN:-$(command -v entire || true)}"
+
+mkdir -p "$CAPTURES"
+
+on_exit() { restore_config; }
+trap on_exit EXIT
+
+backup_config() {
+  if [[ -f "$CONFIG" ]]; then
+    cp "$CONFIG" "$PROBE_DIR/config.json.bak"
+  fi
+}
+
+restore_config() {
+  if [[ -f "$PROBE_DIR/config.json.bak" ]]; then
+    cp "$PROBE_DIR/config.json.bak" "$CONFIG"
+    echo "[cleanup] restored original config"
+  fi
+}
+
+write_hook() { # <EventName>
+  cat > "$CAPTURES/hook-$1.json.dump.sh" <<EOF
+#!/usr/bin/env bash
+cat > "$CAPTURES/$1-\$(date +%s%N).json"
+EOF
+  chmod +x "$CAPTURES/hook-$1.json.dump.sh"
+}
+
+install_hooks() {
+  backup_config
+  mkdir -p "$(dirname "$CONFIG")"
+  for ev in SessionStart UserPromptSubmit PreToolUse PostToolUse Stop; do
+    write_hook "$ev"
+  done
+  python3 - "$CONFIG" "$CAPTURES" <<'EOF'
+import json, os, sys
+config_path, captures = sys.argv[1], sys.argv[2]
+config = {}
+if os.path.exists(config_path):
+    with open(config_path) as f:
+        config = json.load(f)
+hooks = config.setdefault("hooks", {})
+hooks["enabled"] = True
+events = hooks.setdefault("events", {})
+for ev in ("SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop"):
+    groups = events.setdefault(ev, [])
+    if not any("entire-agent-zcode-probe" in json.dumps(g) for g in groups):
+        groups.append({
+            "hooks": [{
+                "type": "process",
+                "command": "/usr/bin/env",
+                "args": ["bash", os.path.join(captures, f"hook-{ev}.json.dump.sh")],
+                "statusMessage": "entire-agent-zcode probe: " + ev,
+                "entire-agent-zcode-probe": True,
+            }]
+        })
+with open(config_path, "w") as f:
+    json.dump(config, f, indent=2)
+print("[hooks] capture hooks installed (marker: entire-agent-zcode-probe)")
+EOF
+}
+
+static_checks() {
+  echo "== Static checks =="
+  if command -v "$AGENT_SLUG" >/dev/null 2>&1; then
+    echo "PASS binary present: $(command -v $AGENT_SLUG)"
+  else
+    echo "FAIL binary not on PATH"
+  fi
+  if [[ -d "$HOME/.zcode/cli/db" ]]; then
+    echo "PASS db dir: $HOME/.zcode/cli/db"
+    if command -v sqlite3 >/dev/null 2>&1; then
+      sqlite3 "$HOME/.zcode/cli/db/db.sqlite" \
+        "select id, title, datetime(time_created/1000,'unixepoch') from session order by time_created desc limit 5;"
+    fi
+  else
+    echo "WARN no ~/.zcode/cli/db — has a session ever run?"
+  fi
+  if compgen -G "$HOME/.zcode/cli/rollout/model-io-sess_*.jsonl" >/dev/null; then
+    echo "PASS rollout logs present"
+  else
+    echo "WARN no rollout/model-io logs"
+  fi
+}
+
+collect() {
+  echo "== Captured payloads =="
+  local found=0
+  for f in "$CAPTURES"/*.json; do
+    [[ -e "$f" ]] || continue
+    found=1
+    echo "--- $f"
+    python3 -m json.tool "$f" 2>/dev/null || cat "$f"
+  done
+  if [[ $found -eq 0 ]]; then
+    echo "WARN no payloads captured"
+  fi
+}
+
+verdict() {
+  echo "== Verdict =="
+  for ev in SessionStart UserPromptSubmit PreToolUse PostToolUse Stop; do
+    if compgen -G "$CAPTURES/$ev-"*.json >/dev/null; then
+      echo "PASS $ev payload captured"
+    else
+      echo "WARN $ev: no payload"
+    fi
+  done
+}
+
+case "${1:-}" in
+  --manual-live)
+    static_checks
+    install_hooks
+    echo
+    echo "[live] Now open ZCode, start a NEW session, submit a prompt that"
+    echo "       reads a file, and wait for the response to finish."
+    read -r -p "Press Enter when done (config will be restored)... "
+    collect
+    verdict
+    ;;
+  *)
+    static_checks
+    echo
+    echo "Run with --manual-live to capture hook payloads from a real ZCode session."
+    ;;
+esac

--- a/e2e/agents/zcode.go
+++ b/e2e/agents/zcode.go
@@ -1,0 +1,52 @@
+package agents
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+)
+
+// ZCode is an Electron desktop app with no headless CLI, so prompt-driven
+// lifecycle automation is not possible. The adapter is registered only when
+// explicitly opted in (ZCODE_E2E=1 and E2E_AGENT=zcode) and every prompt
+// attempt reports the limitation instead of failing obscurely.
+func init() {
+	if os.Getenv("ZCODE_E2E") != "1" || os.Getenv("E2E_AGENT") != "zcode" {
+		return
+	}
+	Register(&ZCode{})
+	RegisterGate("zcode", 1)
+}
+
+var errHeadlessUnsupported = errors.New(
+	"zcode is a desktop app with no headless mode; drive a ZCode session manually " +
+		"and use agents/entire-agent-zcode/scripts/verify-zcode.sh to capture hook payloads")
+
+type ZCode struct{}
+
+func (z *ZCode) Name() string               { return "zcode" }
+func (z *ZCode) Binary() string             { return "zcode" }
+func (z *ZCode) EntireAgent() string        { return "zcode" }
+func (z *ZCode) PromptPattern() string      { return `>` }
+func (z *ZCode) TimeoutMultiplier() float64 { return 2.0 }
+func (z *ZCode) IsExternalAgent() bool      { return true }
+func (z *ZCode) Bootstrap() error           { return nil }
+
+func (z *ZCode) IsTransientError(out Output, _ error) bool {
+	combined := strings.ToLower(out.Stdout + out.Stderr)
+	for _, pattern := range []string{"429", "rate limit", "overloaded", "503", "timeout", "econnreset"} {
+		if strings.Contains(combined, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func (z *ZCode) RunPrompt(_ context.Context, _ string, _ string, _ ...Option) (Output, error) {
+	return Output{Command: "zcode", ExitCode: 1, Stderr: errHeadlessUnsupported.Error()}, errHeadlessUnsupported
+}
+
+func (z *ZCode) StartSession(_ context.Context, _ string) (Session, error) {
+	return nil, errHeadlessUnsupported
+}


### PR DESCRIPTION
## Summary

Adds \`entire-agent-zcode\`, a standalone external agent binary integrating [ZCode](https://zcode.z.ai) (Z.ai's agentic development environment) with the Entire CLI, following the repo's research → write-tests → implement pipeline.

ZCode is an Electron desktop app with no headless CLI, so the integration is read-oriented:

- **Sessions/transcripts** are read from ZCode's local SQLite store (`~/.zcode/cli/db/db.sqlite`) via the `sqlite3` CLI (read-only) and exported as one-message-per-line JSONL under `<repo>/.entire/tmp/zcode/<id>.jsonl` (`transcript_preparer`). Hidden/synthetic messages are filtered at the export boundary.
- **Hooks** use ZCode's documented config-file hook system: `install-hooks` merges four entries (`session-start`, `turn-start`, `turn-end`, plus `compaction` via a `^compact$` matcher on `SessionStart`'s `source`) into the user-level `~/.zcode/cli/config.json` — the only hook config ZCode executes — preserving all foreign keys, with marker-scoped uninstall.
- **Capabilities declared**: `hooks`, `transcript_analyzer`, `transcript_preparer`, `token_calculator`. Not declared: `text_generator` (no headless model invocation), `hook_response_writer`, `subagent_aware_extractor` (documented as gaps in AGENT.md).

## Changes

- \`agents/entire-agent-zcode/\` — new agent module (Go, zero deps): AGENT.md research one-pager, verify script, binary, unit tests, README
- \`e2e/agents/zcode.go\` — opt-in lifecycle adapter (\`ZCODE_E2E=1 && E2E_AGENT=zcode\`); ZCode has no headless mode, so prompt automation is not possible and the adapter reports that explicitly
- \`README.md\` — agent table, layout tree, env var rows

## Testing

- ✅ Protocol compliance: \`external-agents-tests verify\` — all suites pass (mandatory, hooks, optional, transcript, subagent)
- ✅ Unit tests (\`go test ./...\`) and golangci-lint clean
- ✅ Verified against a live ZCode install (v3.10.2): session export, extract-prompts/summary/modified-files, token calculation, and hook install/uninstall round-trip all validated with ground-truth data
- ✅ e2e harness builds and passes with the new agent registered

## Notes

- \`ZCODE_HOME\` env override is supported as a test seam for the config path and session DB.
- Hook config changes are snapshotted per session by ZCode — a new ZCode session is needed after \`entire enable --agent zcode\`.