### PR TITLE
Restrict license-check workflow token permissions

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check-licenses:
     uses: entireio/shared/.github/workflows/license-check-reusable.yml@6e5ecde24c20a17b4146250287307718987b7317 # main


### PR DESCRIPTION
The license-check workflow inherited repository token permissions, triggering CodeQL alert #1. Set `contents: read` explicitly, which is sufficient for the reusable workflow's checkout and license checks and remains restrictive if repository defaults change.

Validation: whitespace checks and the hosted license-check workflow pass with the restricted token.

Addresses https://github.com/entireio/external-agents/security/code-scanning/1.
