### PR TITLE
Ignore local redactor configuration

### DIFF
--- a/.entire/.gitignore
+++ b/.entire/.gitignore
@@ -2,3 +2,4 @@ tmp/
 settings.local.json
 metadata/
 logs/
+redactors/local/


### PR DESCRIPTION
Adds redactors/local/ to .entire/.gitignore so local redactor configuration stays out of version control.

Validation: git diff --check passed; git check-ignore confirmed files under .entire/redactors/local/ are ignored.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Gitignore-only change with no runtime or security impact.
> 
> **Overview**
> Adds **`redactors/local/`** to **`.entire/.gitignore`** so machine-specific redactor configuration under that path is not committed.
> 
> This matches the existing pattern of ignoring other local Entire tooling paths (e.g. `settings.local.json`, `tmp/`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4ac11f4f33d864d5f1b1a943735391ec904b741. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->